### PR TITLE
chore: polish docs and remove an unused port helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,5 +147,3 @@ Project resources: [Eclipse project page](https://projects.eclipse.org/projects/
 [contributing guide](CONTRIBUTING.md), [security policy](SECURITY.md),
 [code of conduct](CODE_OF_CONDUCT.md), [license](LICENSE.md), and
 [notices](NOTICE.md).
-
-Network policy changes can be pushed to running gateways with `enclave network apply`. Persisted unrestricted mode still requires a session restart.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -103,7 +103,7 @@ cross-session coordination).
 Provider credentials follow the same layered resolution as other secrets (see
 below). Use `--no-api-key` to suppress provider credential secrets that are API
 keys. Provider credential secrets default to API keys; profiles can set
-`api_key: false` on OAuth/provider token secrets so those tokens continue to
+`apiKey: false` on OAuth/provider token secrets so those tokens continue to
 resolve normally. Feature-declared secrets that are not provider credentials also
 continue to resolve normally. In `--ephemeral` mode, `--pass-api-key` controls
 only API key secrets.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -38,7 +38,7 @@ enclave network apply                      # Apply policy to running gateways
 
 Network mutations are currently global-only. `--project` scope is planned but not yet supported.
 
-Mutating commands (`add-domain`, `remove-domain`, `set-mode`) apply the updated policy to running gateways automatically. Pass `--no-apply` to persist the change without applying it, or `--all-running` to target every running gateway on the host instead of just the current project/tool. Run `enclave network apply` (optionally with `--all-running`) to push the persisted policy to running gateways on demand.
+Mutating commands (`add-domain`, `remove-domain`, `set-mode`) apply the updated policy to running gateways automatically. Pass `--no-apply` to persist the change without applying it, or `--all-running` to target every running gateway on the host instead of just the current project/tool. Run `enclave network apply` (optionally with `--all-running`) to push the persisted policy to running gateways on demand. Persisted unrestricted mode still requires a session restart.
 
 ## Adding Custom Domains
 

--- a/docs/runtime/stores.md
+++ b/docs/runtime/stores.md
@@ -134,7 +134,7 @@ This means the tool writes to its normal config location, but the symlink
 redirects writes to the shared auth store.
 
 For Claude the primary path is different. enclave only redirects Claude's
-secure-storage directory: the `securestorage_dir_env`
+secure-storage directory: the `securestorageDirEnv`
 (`CLAUDE_SECURESTORAGE_CONFIG_DIR`) points at the shared auth store. Claude
 itself writes `.credentials.json` and `.oauth_refresh.lock` there and performs
 its native token-refresh coordination across concurrent sessions. The

--- a/extensions/tools/theia-next/README.md
+++ b/extensions/tools/theia-next/README.md
@@ -11,7 +11,7 @@ enclave gateway, so the same secret-injection and allowlist rules apply.
 
 - **Command**: `sleep infinity`
 - **Config directory**: `~/.theia`
-- **post_start.open_ide**: `theia-next`. Triggers the host launcher once the
+- **postStart.openIDE**: `theia-next`. Triggers the host launcher once the
   container is running.
 
 ## API Keys

--- a/extensions/tools/theia/README.md
+++ b/extensions/tools/theia/README.md
@@ -11,7 +11,7 @@ gateway, so the same secret-injection and allowlist rules apply.
 
 - **Command**: `sleep infinity`
 - **Config directory**: `~/.theia`
-- **post_start.open_ide**: `theia`. Triggers the host launcher once the
+- **postStart.openIDE**: `theia`. Triggers the host launcher once the
   container is running.
 
 ## API Keys

--- a/internal/util/portspec.go
+++ b/internal/util/portspec.go
@@ -7,10 +7,7 @@
 
 package util
 
-import (
-	"net"
-	"strings"
-)
+import "strings"
 
 // ParsePortSpec parses a Docker-style publish spec into its parts. The optional
 // "/proto" suffix is not handled here (callers assume tcp). Accepted forms:
@@ -94,28 +91,6 @@ func SplitPortHostIP(value string) (string, string, bool) {
 		return candidate, value[first+1:], true
 	}
 	return "", value, false
-}
-
-// IsUnspecifiedHostIP reports whether ip is a wildcard / "bind to all
-// interfaces" host IP. Accepts the bracketed IPv6 form ("[::]", "[::0]",
-// "[0:0:0:0:0:0:0:0]"), the IPv4 form ("0.0.0.0"), and Docker's "*" alias.
-// All non-zero IPv6 forms (e.g. "[::ffff:0.0.0.0]") that net.ParseIP reports
-// as unspecified are also rejected so that an attacker cannot smuggle a
-// non-loopback binding past the loopback clamp by using an alternate
-// canonicalization of "::".
-func IsUnspecifiedHostIP(ip string) bool {
-	if ip == "*" {
-		return true
-	}
-	candidate := ip
-	if strings.HasPrefix(candidate, "[") && strings.HasSuffix(candidate, "]") {
-		candidate = candidate[1 : len(candidate)-1]
-	}
-	parsed := net.ParseIP(candidate)
-	if parsed == nil {
-		return false
-	}
-	return parsed.IsUnspecified()
 }
 
 // looksLikeIPv4 reports whether s is a dotted-quad IPv4 literal. We don't need

--- a/internal/util/portspec_test.go
+++ b/internal/util/portspec_test.go
@@ -59,28 +59,6 @@ func TestSplitPortHostIP(t *testing.T) {
 	}
 }
 
-func TestIsUnspecifiedHostIP(t *testing.T) {
-	cases := []struct {
-		ip   string
-		want bool
-	}{
-		{"0.0.0.0", true},
-		{"*", true},
-		{"[::]", true},
-		{"[::0]", true},
-		{"[::ffff:0.0.0.0]", true},
-		{"127.0.0.1", false},
-		{"192.168.1.10", false},
-		{"[::1]", false},
-		{"", false},
-	}
-	for _, c := range cases {
-		if got := IsUnspecifiedHostIP(c.ip); got != c.want {
-			t.Errorf("IsUnspecifiedHostIP(%q) = %v, want %v", c.ip, got, c.want)
-		}
-	}
-}
-
 func TestSplitPortMapping(t *testing.T) {
 	cases := []struct {
 		in         string

--- a/website/docs/docusaurus.config.js
+++ b/website/docs/docusaurus.config.js
@@ -21,7 +21,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 // so this is the ONE place to adjust the base path. Nothing else hardcodes it.
 //
 // If the whole site is served under a project subpath (e.g.
-// eclipsesource.github.io/enclave/), set DOCS_BASE_URL to
+// eclipse-enclave.github.io/enclave/), set DOCS_BASE_URL to
 // '/<project>/docs/' at build time (e.g. via env in a future deploy step).
 // Default assumes a root deployment (custom domain / eclipse.dev forward).
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Use the camelCase spec.yaml field names (apiKey, securestorageDirEnv, postStart.openIDE) in extension-facing docs. The snake_case forms are internal model names, not what extension authors write.

Move the network apply note from the README footer into the networking guide and fix a stale example URL in the docusaurus config comment.

Remove the unused IsUnspecifiedHostIP helper. The loopback clamp it guarded no longer exists, so the helper and its stale attacker-scenario comment are dead code.