### PR TITLE
feat(ports): accept Docker's "0" sentinel for auto-assigned host ports

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -125,7 +125,7 @@ Mutation commands (`add-domain`, `remove-domain`, `set-mode`) apply the new poli
 | `--backend <backend>` | Isolation backend: `docker` (default) or experimental `qemu` |
 | `--name <name>` | Named persistent session |
 | `--background` | Detached background session |
-| `-p <port>` | Publish a container port to the host (container → host, e.g. `-p 3002`) |
+| `-p <port>` | Publish a container port to the host (container → host, e.g. `-p 3002`). A host port of `0` (e.g. `-p 0:3000`) lets the daemon pick a free host port (Docker only); read it back with `enclave ps --json`. |
 | `--bridge-port <port>` | Forward a host port into the container (host → container, repeatable, comma-separated) |
 | `--add-dir <path>` | Mount an additional host directory |
 | `--add-readonly-dir <path>` | Mount an additional host directory read-only |

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -74,6 +74,8 @@ These two flags handle opposite directions of port forwarding:
 
 - **`-p <port>`** — Publishes a **container** port to the **host** (container → host). Use this when the agent starts a service inside the container (e.g. a dev server on port 3000) and you want to access it from your host browser.
 
+  Accepts Docker's publish forms: `3000` (host `3000` → container `3000`), `8080:80` (host:container), and `127.0.0.1:8080:80` (explicit host-IP). A host port of `0` — e.g. `-p 0:3000` or `-p 127.0.0.1:0:3000` — asks the daemon to assign a free host port at runtime, which avoids collisions when many sessions publish the same container port. The assigned port is printed once the session starts and is discoverable with `enclave ps --json` (each session lists its `ports` bindings). Auto-assigned host ports are Docker-only; the experimental QEMU backend rejects a host port of `0`.
+
 - **`--bridge-port <port>`** — Forwards a **host** port into the **container** (host → container). Use this when you have a service running on your host (e.g. an MCP server on port 9800) and the agent needs to reach it at `localhost:9800` from inside the container.
 
 ## Bridging Host Ports

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tidwall/jsonc v0.3.2
 	golang.org/x/crypto v0.47.0
+	golang.org/x/sys v0.40.0
 	golang.org/x/term v0.39.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -27,6 +28,5 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/internal/backend/docker/docker_test.go
+++ b/internal/backend/docker/docker_test.go
@@ -371,6 +371,24 @@ func TestSessionPortMappingsSortsAndDropsUnbound(t *testing.T) {
 	}
 }
 
+// A host port of "0" is Docker's request for an OS-assigned port and must be
+// preserved as a binding (so `--publish` lets the daemon pick a free port),
+// while a genuinely empty host port stays dropped.
+func TestPortMapKeepsAutoAssignedHostPort(t *testing.T) {
+	bindings := portMap([]backend.PortMapping{
+		{HostIP: "127.0.0.1", HostPort: "0", ContainerPort: "5391", Protocol: "tcp"},
+		{HostIP: "127.0.0.1", HostPort: "", ContainerPort: "9229", Protocol: "tcp"},
+	})
+
+	auto := bindings["5391/tcp"]
+	if len(auto) != 1 || auto[0].HostIP != "127.0.0.1" || auto[0].HostPort != "0" {
+		t.Fatalf("auto-assigned binding = %+v, want one 127.0.0.1:0 binding", auto)
+	}
+	if _, ok := bindings["9229/tcp"]; ok {
+		t.Fatalf("empty host port should be dropped, got %+v", bindings["9229/tcp"])
+	}
+}
+
 func TestFillGatewayPortsReadsBindingFromGatewayContainer(t *testing.T) {
 	var inspected []string
 	containerInspectMany = func(_ context.Context, ids []string) ([]dockercmd.InspectResponse, error) {

--- a/internal/config/options_cli_gen.go
+++ b/internal/config/options_cli_gen.go
@@ -274,7 +274,7 @@ func optionCLIFlags() map[string][]CLIFlag {
 			}),
 		},
 		"ports": {
-			valueFlag("-p", "Forward port to container", "-p requires a value", func(opts *model.Options, sources *model.OptionSources, value string) error {
+			valueFlag("-p", "Publish a container port to the host (e.g. 5391, 8080:80, or 0:5391 for an auto-assigned host port, Docker only)", "-p requires a value", func(opts *model.Options, sources *model.OptionSources, value string) error {
 				opts.Ports = append(opts.Ports, value)
 				sources.Ports = model.SourceCLI
 				return nil

--- a/internal/config/options_def.go
+++ b/internal/config/options_def.go
@@ -922,7 +922,7 @@ func OptionDefs() []OptionDef {
 			CLIFlags: []CLIFlagDef{
 				{
 					Name:                "-p",
-					Usage:               "Forward port to container",
+					Usage:               "Publish a container port to the host (e.g. 5391, 8080:80, or 0:5391 for an auto-assigned host port, Docker only)",
 					ValueKind:           CLIValueRequired,
 					MissingValueMessage: "-p requires a value",
 					Action: CLIAction{

--- a/internal/logx/logx.go
+++ b/internal/logx/logx.go
@@ -38,8 +38,15 @@ func SetLevel(value string) {
 	}
 }
 
+// isRawTTY is a variable so tests can stub the terminal state.
+var isRawTTY = writerIsRawTTY
+
 func logf(w io.Writer, label string, color Color, format string, args ...any) {
-	_, _ = fmt.Fprintf(w, "%s"+format+"\n", append([]any{colorPrefix(label, color)}, args...)...)
+	prefix, ending := "", "\n"
+	if isRawTTY(w) {
+		prefix, ending = "\r", "\r\n"
+	}
+	_, _ = fmt.Fprintf(w, prefix+"%s"+format+ending, append([]any{colorPrefix(label, color)}, args...)...)
 }
 
 func Infof(format string, args ...any) {

--- a/internal/logx/logx_test.go
+++ b/internal/logx/logx_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package logx
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	os.Stdout = writer
+
+	defer func() {
+		os.Stdout = original
+	}()
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return string(data)
+}
+
+func TestInfofDefaultLineEnding(t *testing.T) {
+	output := captureStdout(t, func() { Infof("hello %s", "world") })
+	if !strings.HasSuffix(output, "hello world\n") || strings.Contains(output, "\r") {
+		t.Fatalf("Infof output = %q, want plain newline ending without carriage returns", output)
+	}
+}
+
+func TestInfofRawTTYLineEnding(t *testing.T) {
+	original := isRawTTY
+	isRawTTY = func(io.Writer) bool { return true }
+	defer func() { isRawTTY = original }()
+
+	output := captureStdout(t, func() { Infof("hello") })
+	if !strings.HasPrefix(output, "\r") || !strings.HasSuffix(output, "hello\r\n") {
+		t.Fatalf("Infof output = %q, want carriage-return prefix and CRLF ending on a raw terminal", output)
+	}
+}

--- a/internal/logx/rawtty.go
+++ b/internal/logx/rawtty.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package logx
+
+import (
+	"io"
+	"os"
+)
+
+// writerIsRawTTY reports whether w is a terminal currently in raw mode, i.e.
+// with output post-processing disabled. A raw terminal no longer translates
+// "\n" into "\r\n", so a log line written while an interactive attach (e.g.
+// `docker run -it`) holds the terminal raw needs explicit carriage returns to
+// keep following output column-aligned.
+func writerIsRawTTY(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return terminalIsRaw(file.Fd())
+}

--- a/internal/logx/rawtty_darwin.go
+++ b/internal/logx/rawtty_darwin.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build darwin
+
+package logx
+
+import "golang.org/x/sys/unix"
+
+func terminalIsRaw(fd uintptr) bool {
+	termios, err := unix.IoctlGetTermios(int(fd), unix.TIOCGETA) // #nosec G115 -- file descriptor from Fd() fits in int on all supported platforms.
+	if err != nil {
+		return false
+	}
+	return termios.Oflag&unix.OPOST == 0
+}

--- a/internal/logx/rawtty_linux.go
+++ b/internal/logx/rawtty_linux.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build linux
+
+package logx
+
+import "golang.org/x/sys/unix"
+
+func terminalIsRaw(fd uintptr) bool {
+	termios, err := unix.IoctlGetTermios(int(fd), unix.TCGETS) // #nosec G115 -- file descriptor from Fd() fits in int on all supported platforms.
+	if err != nil {
+		return false
+	}
+	return termios.Oflag&unix.OPOST == 0
+}

--- a/internal/logx/rawtty_other.go
+++ b/internal/logx/rawtty_other.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build !linux && !darwin
+
+package logx
+
+func terminalIsRaw(uintptr) bool {
+	return false
+}

--- a/internal/mounts/mounts.go
+++ b/internal/mounts/mounts.go
@@ -357,14 +357,15 @@ func validateWorktreeMountPath(path string, validatedDirs *[]string, projectReal
 // ResolvePorts converts Docker-style publish specs into neutral port
 // mappings. Bindings that omit an explicit host-IP default to loopback
 // (127.0.0.1); binding to another interface is an explicit opt-in via the
-// "ip:host:container" form (e.g. "0.0.0.0:3000:3000").
+// "ip:host:container" form (e.g. "0.0.0.0:3000:3000"). A host port of "0"
+// (e.g. "0:3000") requests an OS-assigned host port at runtime.
 func ResolvePorts(ports []string) []backend.PortMapping {
 	var mappings []backend.PortMapping
 	for _, port := range ports {
 		hostIP, hostPort, containerPort, ok := util.ParsePortSpec(port)
 		if !ok {
 			if strings.TrimSpace(port) != "" {
-				logx.Warnf("Invalid port format: %s (use '3000', '3000:8080', or '127.0.0.1:3000:8080')", port)
+				logx.Warnf("Invalid port format: %s (use '3000', '3000:8080', '0:3000' for an auto-assigned host port, or '127.0.0.1:3000:8080')", port)
 			}
 			continue
 		}
@@ -372,7 +373,6 @@ func ResolvePorts(ports []string) []backend.PortMapping {
 			hostIP = "127.0.0.1"
 		}
 		mappings = append(mappings, backend.PortMapping{HostIP: hostIP, HostPort: hostPort, ContainerPort: containerPort, Protocol: "tcp"})
-		logx.Infof("Port forwarding: %s:%s -> %s", hostIP, hostPort, containerPort)
 	}
 	return mappings
 }

--- a/internal/mounts/ports_test.go
+++ b/internal/mounts/ports_test.go
@@ -52,6 +52,23 @@ func TestResolvePortsThreePartSpec(t *testing.T) {
 	}
 }
 
+// A host port of "0" requests an OS-assigned port; it must survive parsing
+// with the sentinel intact (and its host-IP default applied) so the backend
+// emits a Docker "--publish" that lets the daemon pick a free host port.
+func TestResolvePortsAutoAssignedHostPort(t *testing.T) {
+	cases := map[string]string{
+		"0:5391":           "127.0.0.1", // host-IP defaults to loopback
+		"127.0.0.1:0:5391": "127.0.0.1",
+		"0.0.0.0:0:5391":   "0.0.0.0", // explicit non-loopback opt-in
+	}
+	for spec, wantIP := range cases {
+		got := singleMapping(t, spec)
+		if got.HostIP != wantIP || got.HostPort != "0" || got.ContainerPort != "5391" {
+			t.Fatalf("ResolvePorts([%s]) = %+v, want %s:0->5391", spec, got, wantIP)
+		}
+	}
+}
+
 func TestResolvePortsIgnoresInvalidAndEmpty(t *testing.T) {
 	mappings := ResolvePorts([]string{"", "  ", "bogus", "1:2:3"})
 	if len(mappings) != 0 {

--- a/internal/runtime/backend_fake_test.go
+++ b/internal/runtime/backend_fake_test.go
@@ -18,9 +18,10 @@ import (
 // filtered the way the real Docker backend would, i.e. gateway sidecars
 // excluded); other methods are no-ops.
 type fakeBackend struct {
-	sessions []backend.Session
-	listErr  error
-	listFn   func(backend.SessionFilter) ([]backend.Session, error)
+	sessions  []backend.Session
+	listErr   error
+	listFn    func(backend.SessionFilter) ([]backend.Session, error)
+	inspectFn func(backend.SessionRef) (*backend.Session, error)
 
 	storage        backend.StoreManager
 	prepared       []backend.StorePrep
@@ -50,7 +51,10 @@ func (f *fakeBackend) List(_ context.Context, filter backend.SessionFilter) ([]b
 	}
 	return f.sessions, f.listErr
 }
-func (f *fakeBackend) Inspect(context.Context, backend.SessionRef) (*backend.Session, error) {
+func (f *fakeBackend) Inspect(_ context.Context, ref backend.SessionRef) (*backend.Session, error) {
+	if f.inspectFn != nil {
+		return f.inspectFn(ref)
+	}
 	return nil, nil
 }
 func (f *fakeBackend) Attach(context.Context, backend.SessionRef, backend.AttachIO) error { return nil }

--- a/internal/runtime/background.go
+++ b/internal/runtime/background.go
@@ -38,9 +38,10 @@ func (r *Runtime) ExecuteBackground() (string, error) {
 		return "", err
 	}
 
-	// Announce only after the container is confirmed started, so a failed bind
-	// (e.g. a host-port conflict) never prints a URL that was never reachable.
-	r.logPublishedPortURLs()
+	// Announce only after the container is confirmed started: auto-assigned
+	// host ports do not exist until then, and a failed bind (e.g. a host-port
+	// conflict) never prints a forwarding or URL that did not happen.
+	r.announcePublishedPorts(ctx.ContainerName)
 
 	r.runPostStart(ctx.ContainerName)
 

--- a/internal/runtime/ports_test.go
+++ b/internal/runtime/ports_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"enclave/internal/backend"
 	"enclave/internal/model"
 )
 
@@ -99,7 +100,7 @@ func TestApplyProfilePortsSkipsHostIPMappedPort(t *testing.T) {
 	}
 }
 
-func TestLogPublishedPortURLsUsesExplicitHostPort(t *testing.T) {
+func TestLogDeclaredPortAvailabilityUsesExplicitHostPort(t *testing.T) {
 	r := &Runtime{
 		run: model.RunOptions{Ports: []string{"8080:3000"}},
 		profile: model.Profile{
@@ -114,12 +115,109 @@ func TestLogPublishedPortURLsUsesExplicitHostPort(t *testing.T) {
 	r.applyProfilePorts()
 
 	output := captureStdout(t, func() {
-		r.logPublishedPortURLs()
+		r.logDeclaredPortAvailability(nil)
 	})
 	if !strings.Contains(output, "http://localhost:8080") {
 		t.Fatalf("expected URL to use host port 8080, got %q", output)
 	}
 	if strings.Contains(output, "http://localhost:3000") {
 		t.Fatalf("expected URL not to use container port 3000, got %q", output)
+	}
+}
+
+func TestAnnouncePublishedPortsPrintsExplicitForwarding(t *testing.T) {
+	r := &Runtime{
+		run:     model.RunOptions{Ports: []string{"8080:3000", "0.0.0.0:9000:9000"}},
+		profile: model.Profile{Name: "claude"},
+	}
+
+	output := captureStdout(t, func() {
+		r.announcePublishedPorts("enclave-test")
+	})
+	if !strings.Contains(output, "Port forwarding: 127.0.0.1:8080 -> 3000") {
+		t.Fatalf("expected loopback-defaulted forwarding line, got %q", output)
+	}
+	if !strings.Contains(output, "Port forwarding: 0.0.0.0:9000 -> 9000") {
+		t.Fatalf("expected explicit host-IP forwarding line, got %q", output)
+	}
+}
+
+func TestAnnouncePublishedPortsResolvesAutoAssignedHostPort(t *testing.T) {
+	r := &Runtime{
+		run: model.RunOptions{Ports: []string{"127.0.0.1:0:3000"}},
+		profile: model.Profile{
+			Ports: []model.PortConfig{{
+				Container: 3000,
+				Publish:   true,
+				Label:     "Theia IDE",
+				OpenURL:   "http://localhost:{host_port}",
+			}},
+		},
+		backend: &fakeBackend{inspectFn: func(ref backend.SessionRef) (*backend.Session, error) {
+			if ref.Name != "enclave-test" {
+				t.Errorf("expected inspect of enclave-test, got %q", ref.Name)
+			}
+			return &backend.Session{Ports: []backend.PortMapping{
+				{HostIP: "127.0.0.1", HostPort: "49321", ContainerPort: "3000", Protocol: "tcp"},
+			}}, nil
+		}},
+	}
+	r.applyProfilePorts()
+
+	output := captureStdout(t, func() {
+		r.announcePublishedPorts("enclave-test")
+	})
+	if !strings.Contains(output, "Port forwarding: 127.0.0.1:49321 -> 3000") {
+		t.Fatalf("expected completed forwarding line, got %q", output)
+	}
+	if !strings.Contains(output, "http://localhost:49321") {
+		t.Fatalf("expected URL with the live host port, got %q", output)
+	}
+}
+
+func TestAnnouncePublishedPortsCompletesForwardingWithoutOpenURL(t *testing.T) {
+	r := &Runtime{
+		run:     model.RunOptions{Ports: []string{"127.0.0.1:0:2000"}},
+		profile: model.Profile{Name: "claude"},
+		backend: &fakeBackend{inspectFn: func(backend.SessionRef) (*backend.Session, error) {
+			return &backend.Session{Ports: []backend.PortMapping{
+				{HostIP: "127.0.0.1", HostPort: "49500", ContainerPort: "2000", Protocol: "tcp"},
+			}}, nil
+		}},
+	}
+
+	output := captureStdout(t, func() {
+		r.announcePublishedPorts("enclave-test")
+	})
+	if !strings.Contains(output, "Port forwarding: 127.0.0.1:49500 -> 2000") {
+		t.Fatalf("expected completed forwarding line, got %q", output)
+	}
+}
+
+func TestAnnouncePublishedPortsAutoPortWithoutBindingFallsBack(t *testing.T) {
+	r := &Runtime{
+		run: model.RunOptions{Ports: []string{"127.0.0.1:0:3000"}},
+		profile: model.Profile{
+			Ports: []model.PortConfig{{
+				Container: 3000,
+				Publish:   true,
+				Label:     "Theia IDE",
+				OpenURL:   "http://localhost:{host_port}",
+			}},
+		},
+	}
+	r.applyProfilePorts()
+
+	output := captureStdout(t, func() {
+		r.announcePublishedPorts("enclave-test")
+	})
+	if strings.Contains(output, "http://localhost:0") {
+		t.Fatalf("expected no URL with the 0 sentinel, got %q", output)
+	}
+	if !strings.Contains(output, "Port forwarding: 127.0.0.1:<auto> -> 3000") {
+		t.Fatalf("expected <auto> placeholder forwarding line, got %q", output)
+	}
+	if !strings.Contains(output, "enclave ps") {
+		t.Fatalf("expected hint at enclave ps, got %q", output)
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -588,10 +588,59 @@ func (r *Runtime) applyProfilePorts() {
 	}
 }
 
-// logPublishedPortURLs prints the resolved localhost URL for each declared,
-// published port so the user can open it. The {host_port} placeholder is
-// resolved from the actual host binding when the user supplied one.
-func (r *Runtime) logPublishedPortURLs() {
+// announcePublishedPorts reports port information once the session is
+// started: one forwarding line per published port — with auto-assigned host
+// ports resolved from the live bindings — and the resolved URL for each
+// declared, published port. Announcing only after start keeps the lines
+// truthful: a failed bind never prints a forwarding that did not happen.
+func (r *Runtime) announcePublishedPorts(containerName string) {
+	var bindings []backend.PortMapping
+	if hasAutoAssignedPort(r.run.Ports) {
+		bindings = r.sessionPortBindings(containerName)
+	}
+	r.logPortForwardings(bindings)
+	r.logDeclaredPortAvailability(bindings)
+}
+
+func hasAutoAssignedPort(ports []string) bool {
+	for _, spec := range ports {
+		if hostPort, _, ok := util.SplitPortMapping(spec); ok && hostPort == "0" {
+			return true
+		}
+	}
+	return false
+}
+
+// logPortForwardings prints one forwarding line per published port. The
+// loopback default mirrors ResolvePorts, so the printed host-IP matches the
+// actual binding. Auto-assigned host ports show the daemon-picked value from
+// the live bindings, or "<auto>" when the binding cannot be read back.
+func (r *Runtime) logPortForwardings(bindings []backend.PortMapping) {
+	for _, spec := range r.run.Ports {
+		hostIP, hostPort, containerPort, ok := util.ParsePortSpec(spec)
+		if !ok {
+			continue
+		}
+		if hostIP == "" {
+			hostIP = "127.0.0.1"
+		}
+		if hostPort == "0" {
+			if binding := boundPortMapping(bindings, containerPort); binding != nil {
+				hostIP, hostPort = binding.HostIP, binding.HostPort
+			} else {
+				hostPort = "<auto>"
+			}
+		}
+		logx.Infof("Port forwarding: %s:%s -> %s", hostIP, hostPort, containerPort)
+	}
+}
+
+// logDeclaredPortAvailability tells the user where each declared, published
+// port with an openUrl is reachable. The {host_port} placeholder resolves
+// from the mapped host binding; auto-assigned host ports use the live
+// bindings of the started session, falling back to a hint at enclave ps when
+// the binding cannot be read back.
+func (r *Runtime) logDeclaredPortAvailability(bindings []backend.PortMapping) {
 	for _, p := range r.profile.Ports {
 		if !p.Publish || p.OpenURL == "" {
 			continue
@@ -601,9 +650,46 @@ func (r *Runtime) logPublishedPortURLs() {
 		if !ok {
 			continue
 		}
+		if hostPort == "0" {
+			hostPort = boundHostPort(bindings, containerPort)
+			if hostPort == "" {
+				logx.Infof("%s port %s has an auto-assigned host port; run '%s ps' to see it", p.Label, containerPort, model.AppName)
+				continue
+			}
+		}
 		url := strings.ReplaceAll(p.OpenURL, model.PortHostPlaceholder, hostPort)
 		logx.Successf("%s available at %s", p.Label, url)
 	}
+}
+
+// sessionPortBindings reads the live port bindings of a started session so
+// auto-assigned host ports can be reported with their real value.
+func (r *Runtime) sessionPortBindings(containerName string) []backend.PortMapping {
+	if r.backend == nil {
+		return nil
+	}
+	session, err := r.backend.Inspect(context.Background(), backend.SessionRef{Name: containerName})
+	if err != nil || session == nil {
+		return nil
+	}
+	return session.Ports
+}
+
+func boundPortMapping(bindings []backend.PortMapping, containerPort string) *backend.PortMapping {
+	for i := range bindings {
+		b := &bindings[i]
+		if b.ContainerPort == containerPort && b.HostPort != "" && b.HostPort != "0" {
+			return b
+		}
+	}
+	return nil
+}
+
+func boundHostPort(bindings []backend.PortMapping, containerPort string) string {
+	if b := boundPortMapping(bindings, containerPort); b != nil {
+		return b.HostPort
+	}
+	return ""
 }
 
 func (r *Runtime) runContainer(ctx *ExecutionContext) error {
@@ -611,7 +697,7 @@ func (r *Runtime) runContainer(ctx *ExecutionContext) error {
 	if be == nil {
 		return fmt.Errorf("runtime backend is not configured")
 	}
-	_, err := be.Run(context.Background(), r.backendRequest(ctx, false, true), backend.AttachIO{TTY: true, OnStarted: r.logPublishedPortURLs})
+	_, err := be.Run(context.Background(), r.backendRequest(ctx, false, true), backend.AttachIO{TTY: true, OnStarted: func() { r.announcePublishedPorts(ctx.ContainerName) }})
 	return err
 }
 

--- a/internal/util/portspec.go
+++ b/internal/util/portspec.go
@@ -17,9 +17,16 @@ import (
 //
 //	"3000"                -> ("", "3000", "3000", true)
 //	"8080:80"             -> ("", "8080", "80",  true)
+//	"0:80"                -> ("", "0", "80", true)          // OS-assigned host port
 //	"127.0.0.1:8080:80"   -> ("127.0.0.1", "8080", "80", true)
+//	"127.0.0.1:0:80"      -> ("127.0.0.1", "0", "80", true) // OS-assigned host port
 //	"0.0.0.0:8080:80"     -> ("0.0.0.0", "8080", "80", true)
 //	"[::1]:8080:80"       -> ("[::1]", "8080", "80", true)
+//
+// A host port of "0" is Docker's sentinel for "assign a free host port at
+// runtime"; the actual port is discoverable afterwards via the container's
+// published-port bindings. "0" is only accepted in the host-port position: a
+// bare "0" or a "0" container port stays invalid.
 //
 // hostIP is empty when the spec omits it; callers decide the default (the run
 // path defaults to loopback). ok is false for malformed specs.
@@ -36,10 +43,17 @@ func ParsePortSpec(value string) (hostIP, hostPort, containerPort string, ok boo
 		return ip, rest, rest, true
 	}
 	parts := strings.Split(rest, ":")
-	if len(parts) != 2 || !IsPortNumber(parts[0]) || !IsPortNumber(parts[1]) {
+	if len(parts) != 2 || !isHostPort(parts[0]) || !IsPortNumber(parts[1]) {
 		return "", "", "", false
 	}
 	return ip, parts[0], parts[1], true
+}
+
+// isHostPort reports whether s is valid in the host-port position of a publish
+// spec. This is a real port number or Docker's "0" sentinel requesting an
+// OS-assigned host port.
+func isHostPort(s string) bool {
+	return s == "0" || IsPortNumber(s)
 }
 
 // SplitPortMapping returns the host and container ports of a publish spec,

--- a/internal/util/portspec_test.go
+++ b/internal/util/portspec_test.go
@@ -23,11 +23,18 @@ func TestParsePortSpec(t *testing.T) {
 		{"*:3000:3000", "*", "3000", "3000", true},
 		{"[::1]:8080:80", "[::1]", "8080", "80", true},
 		{"127.0.0.1:3000", "127.0.0.1", "3000", "3000", true},
+		// "0" host port -> Docker assigns a free host port at runtime.
+		{"0:80", "", "0", "80", true},
+		{"127.0.0.1:0:80", "127.0.0.1", "0", "80", true},
+		{"[::1]:0:80", "[::1]", "0", "80", true},
 		{"", "", "", "", false},
 		{"abc", "", "", "", false},
 		{"1:2:3", "", "", "", false},
 		{"3000:", "", "", "", false},
 		{"8080:notaport", "", "", "", false},
+		// "0" is only valid as a host port, never bare or as a container port.
+		{"0", "", "", "", false},
+		{"8080:0", "", "", "", false},
 	}
 	for _, c := range cases {
 		ip, host, cont, ok := ParsePortSpec(c.in)


### PR DESCRIPTION
-p rejected a host port of "0", so the standard Docker form 127.0.0.1:0:5391 for letting the daemon pick a free host port was reported as an invalid port format. Publishing the same container port across many concurrent sessions required hand-assigning a unique host port to each one.

ParsePortSpec now accepts "0" in the host-port position. A bare "0" and a "0" container port stay invalid. The sentinel reaches Docker unchanged and the assigned port is discoverable via enclave ps --json. ResolvePorts logs auto-assigned bindings as "<auto>" and the invalid format hint mentions the new form. Docs and tests updated.