### PR TITLE
feat: add --theia-api-port and --theia-api-token flags

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -132,6 +132,8 @@ Mutation commands (`add-domain`, `remove-domain`, `set-mode`) apply the new poli
 | `--background` | Detached background session |
 | `-p <port>` | Publish a container port to the host (container → host, e.g. `-p 3002`). A host port of `0` (e.g. `-p 0:3000`) lets the daemon pick a free host port (Docker only); read it back with `enclave ps --json`. |
 | `--bridge-port <port>` | Forward a host port into the container (host → container, repeatable, comma-separated) |
+| `--theia-api-port <port>` | Theia only: publish a port on host loopback and enable Theia's separate-port external API on it. Ignored (with a warning) for non-Theia tools, which have nothing serving the port. See [Theia](../extensions/tools/theia/README.md). |
+| `--theia-api-token <token>` | Theia only: token for the external API; only takes effect with `--theia-api-port`. If omitted, no token preference is set. The token is passed to the IDE process as an argument, so it is visible via `ps` to other users on the host (it is redacted from the launch log); intended for the loopback dev flow. |
 | `--add-dir <path>` | Mount an additional host directory |
 | `--add-readonly-dir <path>` | Mount an additional host directory read-only |
 | `--project-mount <writable\|readonly>` | Mount the project/worktree read-write (default) or read-only |

--- a/extensions/tools/theia-next/README.md
+++ b/extensions/tools/theia-next/README.md
@@ -45,6 +45,40 @@ Preference overrides passed to Theia via `--session-preference` are merged from
 Note: the preference config is shared with the `theia` tool; both variants
 read from the same files.
 
+## External API Port
+
+`--theia-api-port <port>` couples two steps that otherwise had to be done by
+hand:
+
+1. Publishes `<port>` on the host **loopback** (equivalent to `-p <port>`,
+   resolving to `127.0.0.1:<port>-><port>`), so it is reachable from the host
+   only (not the LAN).
+2. Hands these preferences to Theia at launch so it serves its external API on
+   the same port:
+
+   ```json
+   "externalApi.delivery": "separatePort",
+   "externalApi.port":     <port>,
+   "externalApi.hostname": "0.0.0.0"
+   ```
+
+`externalApi.hostname` is `0.0.0.0` (the in-container bind) so the service is
+reachable across the gateway network namespace via the published loopback port.
+Pass `--theia-api-token <token>` to also set `externalApi.token`; when omitted,
+no token preference is set. The token reaches the IDE process as a launch
+argument, so it is visible via `ps` to other users on the host (it is redacted
+from the launch log); see the [Theia README](../theia/README.md) for details.
+
+```bash
+enclave --tool theia-next --theia-api-port 3333
+```
+
+The flag also applies when reattaching the IDE to a running container
+(`enclave theia-next <container> --theia-api-port 3333`) — the preferences are
+re-injected, though the host port is only published at the initial container
+start. The preferences are injected regardless of yolo mode (they enable an API
+surface rather than relaxing tool confirmation).
+
 ## Files
 
 | File | Purpose |

--- a/extensions/tools/theia/README.md
+++ b/extensions/tools/theia/README.md
@@ -42,6 +42,41 @@ Preference overrides passed to Theia via `--session-preference` are merged from
 2. Global:  `~/.config/enclave/tools/theia/preferences.json` (flat map, honors `$XDG_CONFIG_HOME`)
 3. Built-in default: `ai-features.chat.defaultToolConfirmation=always_allow`
 
+## External API Port
+
+`--theia-api-port <port>` couples two steps that otherwise had to be done by
+hand:
+
+1. Publishes `<port>` on the host **loopback** (equivalent to `-p <port>`,
+   resolving to `127.0.0.1:<port>-><port>`), so it is reachable from the host
+   only (not the LAN).
+2. Hands these preferences to Theia at launch so it serves its external API on
+   the same port:
+
+   ```json
+   "externalApi.delivery": "separatePort",
+   "externalApi.port":     <port>,
+   "externalApi.hostname": "0.0.0.0"
+   ```
+
+`externalApi.hostname` is `0.0.0.0` (the in-container bind) so the service is
+reachable across the gateway network namespace via the published loopback port.
+Pass `--theia-api-token <token>` to also set `externalApi.token`; when omitted,
+no token preference is set. The token reaches the IDE process as a launch
+argument, so it is visible via `ps` to other users on the host (it is redacted
+from the launch log). This is acceptable for the loopback-only dev flow this
+targets; do not rely on it as a secret on a shared multi-user host.
+
+```bash
+enclave --tool theia --theia-api-port 3333
+```
+
+The flag also applies when reattaching the IDE to a running container
+(`enclave theia <container> --theia-api-port 3333`) — the preferences are
+re-injected, though the host port is only published at the initial container
+start. The preferences are injected regardless of yolo mode (they enable an API
+surface rather than relaxing tool confirmation).
+
 ## Files
 
 | File | Purpose |

--- a/internal/app/command_run.go
+++ b/internal/app/command_run.go
@@ -157,8 +157,7 @@ func runExecutionCommand(input *CommandInput) int {
 // user wants the container shell, not the IDE. A session the user already
 // requested as background needs no adjustment.
 func autoBackgroundForIDE(action string, opts model.Options, profile model.Profile) bool {
-	return action == "run" && !opts.Shell && !opts.Background &&
-		profile.PostStart != nil && theia.Variant(profile.PostStart.OpenIDE).Valid()
+	return action == "run" && !opts.Shell && !opts.Background && theia.OpensIDE(profile.PostStart)
 }
 
 func executionRequiresDocker(action string, opts model.Options) bool {

--- a/internal/app/command_theia.go
+++ b/internal/app/command_theia.go
@@ -64,6 +64,7 @@ func runTheia(variant theia.Variant, projectDir string, opts model.Options) int 
 		logx.Errorf("%v", err)
 		return 1
 	}
+	prefs = theia.MergeExternalAPI(prefs, opts.TheiaAPIPort, opts.TheiaAPIToken)
 
 	logPath := theia.LogPath(home, containerName)
 	if err := theia.Launch(variant, containerName, prefs, logPath); err != nil {

--- a/internal/app/testdata/config_rows.golden
+++ b/internal/app/testdata/config_rows.golden
@@ -45,3 +45,5 @@ worktree_metadata | default=""/false global=""/false project=""/false toolOverri
 allow_domains | default=""/false global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective=""
 playwright_mcp | default="false"/true global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective="false"
 bridge_ports | default=""/false global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective=""
+theia_api_port | default=""/false global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective=""
+theia_api_token | default=""/false global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective=""

--- a/internal/config/options_cli.go
+++ b/internal/config/options_cli.go
@@ -348,6 +348,15 @@ func applyBridgePort(opts *model.Options, value string) error {
 	return nil
 }
 
+func applyTheiaAPIPort(opts *model.Options, value string) error {
+	value = strings.TrimSpace(value)
+	if !util.IsPortNumber(value) {
+		return fmt.Errorf("invalid --theia-api-port value: %s (must be 1-65535)", value)
+	}
+	opts.TheiaAPIPort = value
+	return nil
+}
+
 func isValidEnvKey(value string) bool {
 	if value == "" {
 		return false

--- a/internal/config/options_cli_gen.go
+++ b/internal/config/options_cli_gen.go
@@ -341,5 +341,21 @@ func optionCLIFlags() map[string][]CLIFlag {
 				return nil
 			}),
 		},
+		"theia_api_port": {
+			valueFlag("--theia-api-port", "Publish a Theia external-API port on host loopback and enable Theia's separate-port external API", "--theia-api-port requires a port number", func(opts *model.Options, sources *model.OptionSources, value string) error {
+				if err := applyTheiaAPIPort(opts, value); err != nil {
+					return err
+				}
+				sources.TheiaAPIPort = model.SourceCLI
+				return nil
+			}),
+		},
+		"theia_api_token": {
+			valueFlag("--theia-api-token", "Token for the Theia external API (see --theia-api-port); no token preference is set if omitted", "--theia-api-token requires a value", func(opts *model.Options, sources *model.OptionSources, value string) error {
+				opts.TheiaAPIToken = value
+				sources.TheiaAPIToken = model.SourceCLI
+				return nil
+			}),
+		},
 	}
 }

--- a/internal/config/options_cli_test.go
+++ b/internal/config/options_cli_test.go
@@ -10,11 +10,45 @@ package config
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"enclave/internal/model"
 	"enclave/internal/util"
 )
+
+func TestApplyTheiaAPIPort(t *testing.T) {
+	cases := []struct {
+		value   string
+		wantErr bool
+	}{
+		{"8080", false},
+		{"1", false},
+		{"65535", false},
+		{" 3333 ", false},
+		{"0", true},
+		{"70000", true},
+		{"abc", true},
+		{"", true},
+	}
+	for _, tc := range cases {
+		var opts model.Options
+		err := applyTheiaAPIPort(&opts, tc.value)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("applyTheiaAPIPort(%q): expected error, got nil", tc.value)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("applyTheiaAPIPort(%q): unexpected error: %v", tc.value, err)
+			continue
+		}
+		if opts.TheiaAPIPort != strings.TrimSpace(tc.value) {
+			t.Errorf("applyTheiaAPIPort(%q): TheiaAPIPort = %q", tc.value, opts.TheiaAPIPort)
+		}
+	}
+}
 
 func TestAppendCSVUnique(t *testing.T) {
 	// Dedup against the existing slice and within the input; blanks skipped.

--- a/internal/config/options_def.go
+++ b/internal/config/options_def.go
@@ -1110,5 +1110,47 @@ func OptionDefs() []OptionDef {
 				},
 			},
 		},
+		{
+			Name:        "theia_api_port",
+			Group:       OptionGroupRun,
+			Kind:        OptionKindString,
+			OptionField: "TheiaAPIPort",
+			SourceField: "TheiaAPIPort",
+			Apply:       ApplyNone,
+			CLIFlags: []CLIFlagDef{
+				{
+					Name:                "--theia-api-port",
+					Usage:               "Publish a Theia external-API port on host loopback and enable Theia's separate-port external API",
+					ValueKind:           CLIValueRequired,
+					MissingValueMessage: "--theia-api-port requires a port number",
+					Action: CLIAction{
+						Kind:        CLIActionCall,
+						Call:        "applyTheiaAPIPort",
+						SourceField: "TheiaAPIPort",
+					},
+				},
+			},
+		},
+		{
+			Name:        "theia_api_token",
+			Group:       OptionGroupRun,
+			Kind:        OptionKindString,
+			OptionField: "TheiaAPIToken",
+			SourceField: "TheiaAPIToken",
+			Apply:       ApplyNone,
+			CLIFlags: []CLIFlagDef{
+				{
+					Name:                "--theia-api-token",
+					Usage:               "Token for the Theia external API (see --theia-api-port); no token preference is set if omitted",
+					ValueKind:           CLIValueRequired,
+					MissingValueMessage: "--theia-api-token requires a value",
+					Action: CLIAction{
+						Kind:        CLIActionSetString,
+						OptionField: "TheiaAPIToken",
+						SourceField: "TheiaAPIToken",
+					},
+				},
+			},
+		},
 	}
 }

--- a/internal/config/options_registry_gen.go
+++ b/internal/config/options_registry_gen.go
@@ -428,6 +428,14 @@ func OptionSpecs() []OptionSpec {
 				}
 			},
 		},
+		{
+			Name:  "theia_api_port",
+			Group: OptionGroupRun,
+		},
+		{
+			Name:  "theia_api_token",
+			Group: OptionGroupRun,
+		},
 	}
 	attachCLIFlags(specs)
 	return specs

--- a/internal/model/option_sources_gen.go
+++ b/internal/model/option_sources_gen.go
@@ -41,6 +41,8 @@ type RunOptionSources struct {
 	ProjectMount     OptionSource
 	SessionMonitor   OptionSource
 	SessionName      OptionSource
+	TheiaAPIPort     OptionSource
+	TheiaAPIToken    OptionSource
 	Tool             OptionSource
 	WorktreeMetadata OptionSource
 	Yolo             OptionSource
@@ -103,6 +105,8 @@ func DefaultOptionSources() OptionSources {
 			ProjectMount:     SourceDefault,
 			SessionMonitor:   SourceDefault,
 			SessionName:      SourceDefault,
+			TheiaAPIPort:     SourceDefault,
+			TheiaAPIToken:    SourceDefault,
 			Tool:             SourceDefault,
 			WorktreeMetadata: SourceDefault,
 			Yolo:             SourceDefault,
@@ -264,6 +268,12 @@ func MergeOptionSources(base OptionSources, override OptionSources) OptionSource
 	}
 	if override.Slim != SourceUnset {
 		base.Slim = override.Slim
+	}
+	if override.TheiaAPIPort != SourceUnset {
+		base.TheiaAPIPort = override.TheiaAPIPort
+	}
+	if override.TheiaAPIToken != SourceUnset {
+		base.TheiaAPIToken = override.TheiaAPIToken
 	}
 	if override.Tool != SourceUnset {
 		base.Tool = override.Tool

--- a/internal/model/option_sources_test.go
+++ b/internal/model/option_sources_test.go
@@ -43,6 +43,8 @@ func TestMergeOptionSourcesCoversAllFields(t *testing.T) {
 			AllowDomains:     SourceCLI,
 			BridgePorts:      SourceCLI,
 			SessionName:      SourceCLI,
+			TheiaAPIPort:     SourceCLI,
+			TheiaAPIToken:    SourceCLI,
 			PlaywrightMCP:    SourceCLI,
 		},
 		AuthOptionSources: AuthOptionSources{

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -38,6 +38,8 @@ type RunOptions struct {
 	Verbose           bool
 	Background        bool
 	SessionName       string
+	TheiaAPIPort      string
+	TheiaAPIToken     string
 	PlaywrightMCP     bool
 	AllRunning        bool
 	NoApply           bool

--- a/internal/runtime/background.go
+++ b/internal/runtime/background.go
@@ -89,6 +89,7 @@ func (r *Runtime) runPostStart(containerName string) {
 		logx.Warnf("load %s preferences: %v", variant, err)
 		return
 	}
+	prefs = theia.MergeExternalAPI(prefs, r.run.TheiaAPIPort, r.run.TheiaAPIToken)
 	logPath := theia.LogPath(r.host.Home, containerName)
 	if err := theia.Launch(variant, containerName, prefs, logPath); err != nil {
 		logx.Warnf("launch %s: %v (you can retry via `enclave %s %s`)", variant, err, variant, containerName)

--- a/internal/runtime/ports_test.go
+++ b/internal/runtime/ports_test.go
@@ -87,6 +87,44 @@ func TestApplyProfilePortsSkipsUserMappedPort(t *testing.T) {
 	}
 }
 
+// theiaProfile is a minimal profile whose post_start launches Theia, matching
+// the gating in applyTheiaAPIPort.
+func theiaProfile() model.Profile {
+	return model.Profile{Name: "theia", PostStart: &model.PostStartActions{OpenIDE: "theia"}}
+}
+
+func TestApplyTheiaAPIPortInjectsBarePort(t *testing.T) {
+	r := &Runtime{run: model.RunOptions{TheiaAPIPort: "3333"}, profile: theiaProfile()}
+	r.applyTheiaAPIPort()
+	if !portListHas(r.run.Ports, "3333") {
+		t.Errorf("expected 3333 injected, got %v", r.run.Ports)
+	}
+}
+
+func TestApplyTheiaAPIPortNoopWhenUnset(t *testing.T) {
+	r := &Runtime{run: model.RunOptions{}, profile: theiaProfile()}
+	r.applyTheiaAPIPort()
+	if len(r.run.Ports) != 0 {
+		t.Errorf("expected no ports when unset, got %v", r.run.Ports)
+	}
+}
+
+func TestApplyTheiaAPIPortSkipsUserMappedPort(t *testing.T) {
+	r := &Runtime{run: model.RunOptions{Ports: []string{"0.0.0.0:3333:3333"}, TheiaAPIPort: "3333"}, profile: theiaProfile()}
+	r.applyTheiaAPIPort()
+	if len(r.run.Ports) != 1 {
+		t.Errorf("expected no duplicate for user-mapped 3333, got %v", r.run.Ports)
+	}
+}
+
+func TestApplyTheiaAPIPortSkipsNonTheiaTool(t *testing.T) {
+	r := &Runtime{run: model.RunOptions{TheiaAPIPort: "3333"}, profile: model.Profile{Name: "claude"}}
+	r.applyTheiaAPIPort()
+	if len(r.run.Ports) != 0 {
+		t.Errorf("expected no port published for non-Theia tool, got %v", r.run.Ports)
+	}
+}
+
 func TestApplyProfilePortsSkipsHostIPMappedPort(t *testing.T) {
 	r := &Runtime{
 		run: model.RunOptions{Ports: []string{"0.0.0.0:3000:3000"}},

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -27,6 +27,7 @@ import (
 	"enclave/internal/mounts"
 	"enclave/internal/network"
 	"enclave/internal/policy"
+	"enclave/internal/theia"
 	"enclave/internal/util"
 )
 
@@ -230,6 +231,7 @@ func (r *Runtime) prepareExecution() (*ExecutionContext, error) {
 	r.applyDevcontainerPorts()
 	r.applyProfilePorts()
 	r.applyFeaturePorts()
+	r.applyTheiaAPIPort()
 	runCtx.Run = r.run
 	if err := r.handler.ValidateRun(runCtx); err != nil {
 		return nil, err
@@ -599,6 +601,26 @@ func (r *Runtime) applyProfilePorts() {
 		}
 		r.addDeclaredPort(p)
 	}
+}
+
+// applyTheiaAPIPort publishes the port requested via --theia-api-port. The bare
+// port flows through the same resolution as applyProfilePorts (loopback-by-default
+// on the host, gateway-vs-tool-container isolation seam), and addUniquePort skips
+// it when the user already mapped the port explicitly with -p.
+//
+// The external API is served by the in-container Theia backend, so publishing the
+// port only makes sense for a Theia profile. For any other tool nothing would
+// listen on it, so we skip the publish and warn instead of leaving a dangling
+// host binding.
+func (r *Runtime) applyTheiaAPIPort() {
+	if r.run.TheiaAPIPort == "" {
+		return
+	}
+	if !theia.OpensIDE(r.profile.PostStart) {
+		logx.Warnf("ignoring --theia-api-port %s: tool %q does not serve the Theia external API", r.run.TheiaAPIPort, r.profile.Name)
+		return
+	}
+	r.addUniquePort(r.run.TheiaAPIPort, "Publishing Theia external API port %s (host loopback)", r.run.TheiaAPIPort)
 }
 
 // announcePublishedPorts reports port information once the session is

--- a/internal/theia/launcher.go
+++ b/internal/theia/launcher.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"enclave/internal/config"
+	"enclave/internal/model"
 )
 
 // Variant identifies which Theia binary to launch.
@@ -36,6 +37,13 @@ func (v Variant) Valid() bool {
 }
 
 func (v Variant) Binary() string { return string(v) }
+
+// OpensIDE reports whether post declares a host IDE launch this package can
+// perform, i.e. a post_start.open_ide naming a valid Variant. Both the
+// auto-detach of a bare run and the Theia-only run flags key off this signal.
+func OpensIDE(post *model.PostStartActions) bool {
+	return post != nil && Variant(post.OpenIDE).Valid()
+}
 
 // containerNamePattern restricts attach-container values to Docker-legal
 // container names. This guards against argv injection if a container name
@@ -115,7 +123,12 @@ func Launch(variant Variant, containerName string, preferences map[string]any, l
 	// #nosec G204 -- variant is a fixed enum and BuildArgs validates the container name.
 	cmd := exec.Command(bin, args...)
 	if logFile != nil {
-		_, _ = fmt.Fprintf(logFile, "%s %s\n\n", bin, formatArgs(args))
+		// Redact secret-bearing preferences (e.g. externalApi.token) before
+		// writing the argv: the log is 0600 but need not carry the token
+		// verbatim. Note the process still receives the real value as an argv
+		// element, so it remains visible via `ps` to other users on the host —
+		// acceptable for the loopback dev flow this targets.
+		_, _ = fmt.Fprintf(logFile, "%s %s\n\n", bin, formatArgs(redactArgs(args)))
 		cmd.Stdout = logFile
 		cmd.Stderr = logFile
 	}
@@ -135,6 +148,29 @@ func openLogFile(logPath string) (*os.File, error) {
 		return nil, fmt.Errorf("open log file %s: %w", logPath, err)
 	}
 	return f, nil
+}
+
+// sensitivePrefKeys are preference keys whose values must be masked in the
+// launch log. They still reach the IDE process unmodified via argv.
+var sensitivePrefKeys = map[string]bool{
+	"externalApi.token": true,
+}
+
+// redactArgs returns a copy of args with the values of any sensitive
+// `--session-preference key=value` pairs masked, leaving the input untouched.
+func redactArgs(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := 0; i+1 < len(out); i++ {
+		if out[i] != "--session-preference" {
+			continue
+		}
+		key, _, found := strings.Cut(out[i+1], "=")
+		if found && sensitivePrefKeys[key] {
+			out[i+1] = key + "=<redacted>"
+		}
+	}
+	return out
 }
 
 func formatArgs(args []string) string {

--- a/internal/theia/launcher_test.go
+++ b/internal/theia/launcher_test.go
@@ -116,3 +116,23 @@ func TestLaunch_UnsupportedVariant(t *testing.T) {
 		t.Fatalf("Launch: got %v, want unsupported variant error", err)
 	}
 }
+
+func TestRedactArgs_MasksTokenLeavesInputUntouched(t *testing.T) {
+	in := []string{
+		"--attach-container", "enclave-theia-abc",
+		"--session-preference", "externalApi.port=3333",
+		"--session-preference", `externalApi.token="s3cret"`,
+	}
+	got := redactArgs(in)
+	want := []string{
+		"--attach-container", "enclave-theia-abc",
+		"--session-preference", "externalApi.port=3333",
+		"--session-preference", "externalApi.token=<redacted>",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("redactArgs: got %v, want %v", got, want)
+	}
+	if in[5] != `externalApi.token="s3cret"` {
+		t.Fatalf("redactArgs mutated its input: %v", in)
+	}
+}

--- a/internal/theia/preferences.go
+++ b/internal/theia/preferences.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 
 	"enclave/internal/config"
 )
@@ -36,6 +38,37 @@ var DefaultPreferences = map[string]any{
 			},
 		},
 	},
+}
+
+// MergeExternalAPI overlays Theia's separate-port external-API preferences for
+// apiPort onto prefs (allocating prefs if nil) and returns it. An empty or
+// non-numeric apiPort is a no-op. The externalApi.token preference is only set
+// when apiToken is non-empty; otherwise it is left unset. These are functional
+// preferences (they enable an API surface), not the yolo "always allow" trust
+// preferences, so they are injected regardless of yolo mode when the caller
+// passes a port — the matching host port must be published separately (see
+// --theia-api-port). externalApi.hostname stays 0.0.0.0 so the service binds
+// all in-container interfaces and is reachable through the published (loopback)
+// host port.
+func MergeExternalAPI(prefs map[string]any, apiPort, apiToken string) map[string]any {
+	apiPort = strings.TrimSpace(apiPort)
+	if apiPort == "" {
+		return prefs
+	}
+	port, err := strconv.Atoi(apiPort)
+	if err != nil {
+		return prefs // defensive; CLI validation prevents this
+	}
+	if prefs == nil {
+		prefs = make(map[string]any)
+	}
+	prefs["externalApi.delivery"] = "separatePort"
+	prefs["externalApi.port"] = port
+	prefs["externalApi.hostname"] = "0.0.0.0"
+	if apiToken != "" {
+		prefs["externalApi.token"] = apiToken
+	}
+	return prefs
 }
 
 // LoadPreferences returns the preferences to pass on launch. When yoloEnabled

--- a/internal/theia/preferences_test.go
+++ b/internal/theia/preferences_test.go
@@ -16,6 +16,52 @@ import (
 	"enclave/internal/config"
 )
 
+func TestMergeExternalAPI_InjectsKeys(t *testing.T) {
+	got := MergeExternalAPI(nil, "3333", "")
+	if got == nil {
+		t.Fatal("expected non-nil map for a valid port")
+	}
+	if got["externalApi.delivery"] != "separatePort" {
+		t.Errorf("delivery = %v", got["externalApi.delivery"])
+	}
+	if got["externalApi.port"] != 3333 {
+		t.Errorf("port = %v (want int 3333)", got["externalApi.port"])
+	}
+	if got["externalApi.hostname"] != "0.0.0.0" {
+		t.Errorf("hostname = %v", got["externalApi.hostname"])
+	}
+	if _, ok := got["externalApi.token"]; ok {
+		t.Errorf("expected no token preference when none provided, got %v", got["externalApi.token"])
+	}
+}
+
+func TestMergeExternalAPI_CustomToken(t *testing.T) {
+	got := MergeExternalAPI(nil, "3333", "s3cr3t")
+	if got["externalApi.token"] != "s3cr3t" {
+		t.Errorf("token = %v (want s3cr3t)", got["externalApi.token"])
+	}
+}
+
+func TestMergeExternalAPI_EmptyIsNoop(t *testing.T) {
+	if got := MergeExternalAPI(nil, "", "s3cr3t"); got != nil {
+		t.Errorf("expected nil passthrough for empty port, got %v", got)
+	}
+	if got := MergeExternalAPI(nil, "  ", ""); got != nil {
+		t.Errorf("expected nil passthrough for blank port, got %v", got)
+	}
+}
+
+func TestMergeExternalAPI_PreservesExistingKeys(t *testing.T) {
+	prefs := map[string]any{"ai-features.chat.defaultToolConfirmation": "always_allow"}
+	got := MergeExternalAPI(prefs, "8080", "")
+	if got["ai-features.chat.defaultToolConfirmation"] != "always_allow" {
+		t.Errorf("dropped existing key: %v", got)
+	}
+	if got["externalApi.port"] != 8080 {
+		t.Errorf("port = %v", got["externalApi.port"])
+	}
+}
+
 func TestLoadPreferences_DefaultsOnly(t *testing.T) {
 	got, err := LoadPreferences(t.TempDir(), t.TempDir(), true)
 	if err != nil {


### PR DESCRIPTION
--theia-api-port publishes a container port on host loopback and enables Theia's separate-port external API on it by injecting the externalApi.* preferences. This applies to the --background auto-launch and to the theia/theia-next re-attach verbs. --theia-api-token sets the external API token. Without it no token preference is set.

The port is only published for tools that launch a Theia IDE, using the same post_start.open_ide signal as the auto-launch. For other tools nothing would listen on the port, so the flag is ignored with a warning.

The token reaches the IDE process via argv and stays visible in ps, which is acceptable for the loopback dev flow this targets. It is redacted from the launch log.