### PR TITLE
chore: add GitHub issue, discussion, and PR templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,10 @@
+labels: []
+body:
+  - type: textarea
+    id: content
+    attributes:
+      label: Discussion
+      description: Share what's on your mind about Eclipse Enclave.
+      placeholder: Start your discussion here...
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,10 @@
+labels: []
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: Idea Description
+      description: Describe your idea for Eclipse Enclave.
+      placeholder: Share your idea here...
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/improvements.yml
+++ b/.github/DISCUSSION_TEMPLATE/improvements.yml
@@ -1,0 +1,10 @@
+labels: []
+body:
+  - type: textarea
+    id: improvement
+    attributes:
+      label: Improvement Description
+      description: Describe the improvement you'd like to see in Eclipse Enclave.
+      placeholder: Describe the improvement here...
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,10 @@
+labels: []
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know about Eclipse Enclave?
+      placeholder: Ask your question here...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report (except security vulnerabilities)
+about: Create a report to help us improve
+---
+
+<!-- Please provide a detailed description of the bug. -->
+<!-- Note: This template is not meant for security vulnerabilities disclosure -->
+<!-- Any such issue, created in this repo, will be deleted on sight -->
+<!-- Instead please report vulnerabilities to the Eclipse Foundation's security team -->
+<!-- For more details, please read SECURITY.md in the repository root -->
+### Bug Description:
+
+<!-- Please provide clear steps to reproduce the bug. -->
+### Steps to Reproduce:
+
+1.
+2.
+3.
+
+<!-- Please provide any additional information available. -->
+<!-- Additional information can be in the form of logs, screenshots, screencasts. -->
+
+### Additional Information
+
+- Operating System:
+- Enclave Version:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url:  https://github.com/eclipse-enclave/enclave/discussions
+    about: Please ask questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Propose an idea for the project
+---
+
+<!-- Please fill out the following content for a feature request. -->
+
+<!-- Please provide a clear description of the feature and any relevant information. -->
+### Feature Description:
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Thank you for your Pull Request. Please provide a description and review
+the requirements below.
+
+Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md
+
+Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
+other means. See SECURITY.md at the root of this repository, to learn how to report
+vulnerabilities.
+-->
+
+#### What it does
+
+<!-- Include relevant issues and describe how they are addressed. -->
+
+#### How to test
+
+<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
+
+#### Follow-ups
+
+<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
+
+#### Breaking changes
+
+- [ ] This PR introduces breaking changes and has been coordinated with maintainers.
+
+#### Review checklist
+
+- [ ] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,3 @@
-# Copyright (C) 2026 EclipseSource GmbH and others.
-#
-# This program and the accompanying materials are made available under the
-# terms of the MIT License, which is available in the project root.
-#
-# SPDX-License-Identifier: MIT
-
 name: CI
 
 on:

--- a/.github/workflows/deb-smoke.yml
+++ b/.github/workflows/deb-smoke.yml
@@ -1,10 +1,3 @@
-# Copyright (C) 2026 EclipseSource GmbH and others.
-#
-# This program and the accompanying materials are made available under the
-# terms of the MIT License, which is available in the project root.
-#
-# SPDX-License-Identifier: MIT
-
 name: Debian Package Smoke Test
 
 on:

--- a/.github/workflows/reusable-deb-build.yml
+++ b/.github/workflows/reusable-deb-build.yml
@@ -1,10 +1,3 @@
-# Copyright (C) 2026 EclipseSource GmbH and others.
-#
-# This program and the accompanying materials are made available under the
-# terms of the MIT License, which is available in the project root.
-#
-# SPDX-License-Identifier: MIT
-
 name: Reusable Debian Package Build
 
 on:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -1,10 +1,3 @@
-# Copyright (C) 2026 EclipseSource GmbH and others.
-#
-# This program and the accompanying materials are made available under the
-# terms of the MIT License, which is available in the project root.
-#
-# SPDX-License-Identifier: MIT
-
 name: Rolling Release
 
 # Manual-only until the public repository's release policy, permissions, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Read `README.md` before making user-facing changes.
   ```
 - Preserve existing copyright years and owners. New files use their initial creation year and the actual legal copyright holder; do not guess ownership.
 - Files created by splitting, refactoring, or generating existing content inherit the source header. Update generators so regenerated files retain the header.
+- YAML files under `.github/` do not require headers.
 - Headers are not required for Markdown, JSON, lock/sum files, test fixtures, rendered SVGs, images, PDFs, binaries, or imported third-party content.
 - Run `make check-license-headers` after adding or moving files.
 

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -12,6 +12,9 @@ is_candidate() {
     local path="$1"
 
     case "$path" in
+        .github/*.yaml | .github/*.yml)
+            return 1
+            ;;
         LICENSE | LICENSE.md | NOTICE | NOTICE.md)
             return 1
             ;;


### PR DESCRIPTION
#### What it does

Adds GitHub templates for issues, discussions, and pull requests:

- Issue templates: bug report, feature request, and issue config (routes questions to Discussions).
- Discussion templates: general, ideas, improvements, and q-a.
- Pull request template with What/How-to-test/Follow-ups/Breaking-changes sections and a review checklist.

Links point to Enclave's `CONTRIBUTING.md` and `SECURITY.md`.

#### How to test

Proofread the new templates

#### Follow-ups

<!-- none -->

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
