### PR TITLE
feat: launch Theia in one command and allow Open VSX marketplace access

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -52,9 +52,14 @@ With no command, starts a new agent session (`run` is implicit).
 
 These are host-side attach commands, not tool selections: they launch the
 host-installed IDE against an already-running container of any tool. With
-exactly one running container, the name may be omitted. To start a new
-session container that auto-launches the IDE on top, use the corresponding
-tool profile instead (`enclave --tool theia`); see [Tools](tools.md).
+exactly one running container, the name may be omitted.
+
+To start a new session container that auto-launches the IDE on top, use the
+corresponding tool profile instead (`enclave --tool theia`); see
+[Tools](tools.md). The IDE tool profiles run detached automatically: a bare
+`enclave --tool theia` starts the container in the background and opens the IDE
+in one step, printing the container name so you can reattach later with
+`enclave theia <container>`.
 
 ### Network
 

--- a/extensions/tools/theia-next/README.md
+++ b/extensions/tools/theia-next/README.md
@@ -7,6 +7,19 @@ The IDE process lives on the host; the container provides the dev environment
 that Theia Next connects into. Theia's AI features call out through the
 enclave gateway, so the same secret-injection and allowlist rules apply.
 
+## Usage
+
+```bash
+enclave --tool theia-next        # start the container and open the IDE (one step)
+enclave theia-next <container>   # reattach the IDE to an already-running container
+```
+
+Because the container's entrypoint is `sleep infinity` and the IDE launches on
+the host, this profile has no interactive foreground mode: `enclave --tool
+theia-next` runs detached automatically, prints the container name, and opens
+the IDE. Use `enclave theia-next <container>` to reattach later (the name may be
+omitted when exactly one enclave container is running).
+
 ## Configuration
 
 - **Command**: `sleep infinity`

--- a/extensions/tools/theia-next/gateway-allowlist.conf
+++ b/extensions/tools/theia-next/gateway-allowlist.conf
@@ -26,5 +26,8 @@ conf-file=/etc/dnsmasq.allowlists/fragments/github.conf
 # npm (Node.js)
 conf-file=/etc/dnsmasq.allowlists/fragments/npm.conf
 
+# Open VSX (extension marketplace)
+conf-file=/etc/dnsmasq.allowlists/fragments/openvsx.conf
+
 # SSL/TLS certificate validation
 conf-file=/etc/dnsmasq.allowlists/fragments/tls.conf

--- a/extensions/tools/theia/README.md
+++ b/extensions/tools/theia/README.md
@@ -7,6 +7,19 @@ The IDE process lives on the host; the container provides the dev environment
 that Theia connects into. Theia's AI features call out through the enclave
 gateway, so the same secret-injection and allowlist rules apply.
 
+## Usage
+
+```bash
+enclave --tool theia        # start the container and open the IDE (one step)
+enclave theia <container>   # reattach the IDE to an already-running container
+```
+
+Because the container's entrypoint is `sleep infinity` and the IDE launches on
+the host, this profile has no interactive foreground mode: `enclave --tool
+theia` runs detached automatically, prints the container name, and opens the
+IDE. Use `enclave theia <container>` to reattach later (the name may be omitted
+when exactly one enclave container is running).
+
 ## Configuration
 
 - **Command**: `sleep infinity`

--- a/extensions/tools/theia/gateway-allowlist.conf
+++ b/extensions/tools/theia/gateway-allowlist.conf
@@ -26,5 +26,8 @@ conf-file=/etc/dnsmasq.allowlists/fragments/github.conf
 # npm (Node.js)
 conf-file=/etc/dnsmasq.allowlists/fragments/npm.conf
 
+# Open VSX (extension marketplace)
+conf-file=/etc/dnsmasq.allowlists/fragments/openvsx.conf
+
 # SSL/TLS certificate validation
 conf-file=/etc/dnsmasq.allowlists/fragments/tls.conf

--- a/internal/app/command_run.go
+++ b/internal/app/command_run.go
@@ -20,6 +20,7 @@ import (
 	"enclave/internal/model"
 	"enclave/internal/mounts"
 	"enclave/internal/runtime"
+	"enclave/internal/theia"
 	"enclave/internal/tools"
 )
 
@@ -63,6 +64,13 @@ func runExecutionCommand(input *CommandInput) int {
 	}
 	if len(sessionArgs) > 0 {
 		opts.CmdArgs = append(sessionArgs, opts.CmdArgs...)
+	}
+
+	if autoBackgroundForIDE(input.Action, opts, profile) {
+		logx.Infof("%s auto-launches the %s IDE; starting detached (reattach later with `%s %s <container>`)",
+			profile.Name, profile.PostStart.OpenIDE, model.AppName, profile.PostStart.OpenIDE)
+		opts.Background = true
+		input.Options.Background = true
 	}
 
 	yoloEnabled := resolveYoloEnabled(profile, opts)
@@ -138,6 +146,19 @@ func runExecutionCommand(input *CommandInput) int {
 		return 1
 	}
 	return dispatchRunner(input, runner)
+}
+
+// autoBackgroundForIDE reports whether a run should be forced detached because
+// the profile auto-launches a host IDE on start. Such profiles
+// (post_start.open_ide) run `sleep infinity` and only fire the IDE hook on the
+// detached path, so a foreground run would hang with no IDE ever opening.
+// Running detached lets a bare `enclave --tool theia` start the container and
+// open the IDE in one command. An explicit `shell` session is exempt: there the
+// user wants the container shell, not the IDE. A session the user already
+// requested as background needs no adjustment.
+func autoBackgroundForIDE(action string, opts model.Options, profile model.Profile) bool {
+	return action == "run" && !opts.Shell && !opts.Background &&
+		profile.PostStart != nil && theia.Variant(profile.PostStart.OpenIDE).Valid()
 }
 
 func executionRequiresDocker(action string, opts model.Options) bool {

--- a/internal/app/command_run_test.go
+++ b/internal/app/command_run_test.go
@@ -51,6 +51,32 @@ func TestExecutionRequiresDocker(t *testing.T) {
 	}
 }
 
+func TestAutoBackgroundForIDE(t *testing.T) {
+	ideProfile := model.Profile{Name: "theia", PostStart: &model.PostStartActions{OpenIDE: "theia"}}
+
+	cases := []struct {
+		name    string
+		action  string
+		opts    model.Options
+		profile model.Profile
+		want    bool
+	}{
+		{"bare run of IDE profile is forced detached", "run", model.Options{}, ideProfile, true},
+		{"already background is left alone", "run", model.Options{RunOptions: model.RunOptions{Background: true}}, ideProfile, false},
+		{"explicit shell keeps the container shell", "shell", model.Options{RunOptions: model.RunOptions{Shell: true}}, ideProfile, false},
+		{"exec is never auto-backgrounded", "exec", model.Options{}, ideProfile, false},
+		{"non-IDE profile is untouched", "run", model.Options{}, model.Profile{Name: "claude"}, false},
+		{"unsupported open_ide value is untouched", "run", model.Options{}, model.Profile{Name: "x", PostStart: &model.PostStartActions{OpenIDE: "vscode"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autoBackgroundForIDE(tc.action, tc.opts, tc.profile); got != tc.want {
+				t.Fatalf("autoBackgroundForIDE = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEnsureExistingRuntimeImageWith(t *testing.T) {
 	t.Run("returns nil when image exists", func(t *testing.T) {
 		err := ensureExistingRuntimeImageWith("enclave:latest", func(context.Context, string) (bool, error) {

--- a/internal/runtime/background.go
+++ b/internal/runtime/background.go
@@ -47,9 +47,11 @@ func (r *Runtime) ExecuteBackground() (string, error) {
 	return ctx.ContainerName, nil
 }
 
-// warnPostStartInteractive warns when a profile with a post_start IDE hook is
-// launched in the foreground (where the IDE hook is intentionally skipped
-// because the container's TTY is held by `sleep infinity`).
+// warnPostStartInteractive warns when a profile with a post_start IDE hook runs
+// a foreground session (e.g. an explicit `shell` or `exec`), where the IDE hook
+// is skipped. A plain `run` never reaches here: it is auto-backgrounded so the
+// IDE launches. The warning only points at the reattach command; suggesting
+// --background would be wrong for an interactive shell the user asked for.
 func (r *Runtime) warnPostStartInteractive() {
 	if r.run.Background {
 		return
@@ -57,14 +59,14 @@ func (r *Runtime) warnPostStartInteractive() {
 	if r.profile.PostStart == nil || r.profile.PostStart.OpenIDE == "" {
 		return
 	}
-	logx.Warnf("tool %q opens %q on start, but you're running in the foreground; pass --background, or attach the IDE later with `enclave %s <container>`",
+	logx.Warnf("tool %q normally opens the %q IDE on start; this foreground session skips it, so attach the IDE to the container with `enclave %s <container>`",
 		r.profile.Name, r.profile.PostStart.OpenIDE, r.profile.PostStart.OpenIDE)
 }
 
 // runPostStart performs profile-declared side effects after the container is
 // running. Failures here are logged but do not fail the session start: the
 // container is up either way and the user can retry the side effect manually
-// (e.g. via the GUI button or `enclave theia <name>`).
+// (e.g. via `enclave theia <name>`).
 func (r *Runtime) runPostStart(containerName string) {
 	if r.profile.PostStart == nil {
 		return

--- a/runtime-assets/gateway-allowlists/fragments/openvsx.conf
+++ b/runtime-assets/gateway-allowlists/fragments/openvsx.conf
@@ -1,0 +1,12 @@
+# Copyright (C) 2026 EclipseSource GmbH and others.
+#
+# This program and the accompanying materials are made available under the
+# terms of the MIT License, which is available in the project root.
+#
+# SPDX-License-Identifier: MIT
+
+# Open VSX Registry (VS Code extension marketplace used by Theia)
+# Registry/API (also covers subdomains such as ai.open-vsx.org)
+server=/open-vsx.org/8.8.8.8
+# Extension file (.vsix) downloads are served from the Eclipse content CDN
+server=/openvsx.eclipsecontent.org/8.8.8.8


### PR DESCRIPTION
#### What it does

Makes IDE tool profiles (`theia`, `theia-next`) usable in one command. These profiles run `sleep infinity` and only launch the IDE on the detached path, so a foreground `enclave --tool theia` hung with no IDE, and the useful flow required remembering `--background`.

- Force the detached path for the `run` action of profiles that declare `post_start.open_ide`, so a bare `enclave --tool theia` starts the container and opens the IDE in one step.
- Leave `shell`/`exec` sessions and explicit `--background` runs untouched.
- Reword the foreground IDE-hook warning and update docs (`cli-reference` + both tool READMEs).

It also fixes Open VSX marketplace access behind the network gateway. The Theia and Theia Next allowlists blocked all DNS by default and never allowlisted Open VSX, so the Extensions view failed with `Error fetching extensions. fetch failed`.

- Add an `openvsx.conf` allowlist fragment for `open-vsx.org` (registry/API, also covering subdomains such as `ai.open-vsx.org`) and `openvsx.eclipsecontent.org` (the Eclipse content CDN that serves `.vsix` downloads), included from both tool allowlists.

#### How to test

1. `make build && make test && make lint`
2. `./bin/enclave --tool theia` returns immediately (detached) and opens the IDE attached to the container. Confirm with `./bin/enclave ps`.
3. `./bin/enclave shell --tool theia` still gives a foreground container shell (no IDE).
4. In the IDE, open the Extensions view and search the marketplace. Extensions list and install instead of failing with `fetch failed`.

#### Follow-ups

- Attaching a second IDE while one is already running opens an empty, unattached window (the `--attach-container` argument is dropped). This is a Theia desktop (Electron single-instance) issue, not an enclave one. I'm already looking into it on the Theia side and will track it separately in the Theia repository.
- Consider whether the Open VSX domains belong in the shared base allowlist rather than only the Theia tools.

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).