### PR TITLE
Fix rolling release publishing

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -1,9 +1,11 @@
 name: Rolling Release
 
-# Manual-only until the public repository's release policy, permissions, and
-# destinations have been reviewed and explicitly enabled. A dispatch without
-# publish=true only builds artifacts; it cannot touch releases or tags.
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   workflow_dispatch:
     inputs:
       publish:
@@ -56,7 +58,7 @@ jobs:
 
   release:
     needs: [build, build-deb]
-    if: ${{ inputs.publish }}
+    if: ${{ github.event_name == 'push' || inputs.publish }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
+          for f in *; do [ "$f" = "${f//\~/.}" ] || mv "$f" "${f//\~/.}"; done
           sha256sum * > checksums.txt
 
       - name: Create rolling release


### PR DESCRIPTION

## Summary

- Publish rolling releases automatically for non-documentation pushes to `main`, while preserving manual dry runs and publishing.
- Replace tildes in artifact names before generating `checksums.txt` so checksum entries match the published assets.