### PR TITLE
Embed runtime assets in release binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,13 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build (CLI only)
+      - name: Build CLI
         run: CGO_ENABLED=0 go build ./cmd/enclave
 
-      - name: Cross-compile (macOS arm64)
+      - name: Smoke test standalone binary
+        run: ./scripts/smoke-standalone-binary.sh ./enclave
+
+      - name: Cross-compile (macOS and Windows)
         run: make cross-build
 
       - name: Vet

--- a/.github/workflows/reusable-deb-build.yml
+++ b/.github/workflows/reusable-deb-build.yml
@@ -74,6 +74,19 @@ jobs:
           test -f "$tmpdir/usr/share/doc/enclave/LICENSE.md"
           test -f "$tmpdir/usr/share/doc/enclave/NOTICE.md"
 
+          mkdir -p "$tmpdir/home" "$tmpdir/isolated"
+          HOME="$tmpdir/home" XDG_CACHE_HOME="$tmpdir/cache" \
+            "$root/enclave" tools >/dev/null
+          test ! -e "$tmpdir/cache/enclave/assets"
+
+          cp "$root/enclave" "$tmpdir/isolated/enclave"
+          if HOME="$tmpdir/home" XDG_CACHE_HOME="$tmpdir/cache" \
+            "$tmpdir/isolated/enclave" tools >"$tmpdir/isolated/output" 2>&1; then
+            echo "deb binary unexpectedly carried embedded assets" >&2
+            exit 1
+          fi
+          grep -q "embedded assets are unavailable" "$tmpdir/isolated/output"
+
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.artifact_name }}

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            output: enclave-linux-amd64-cli
+            output: enclave-linux-amd64
             cgo: 0
 
     runs-on: ${{ matrix.runner }}
@@ -39,8 +39,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build (CLI only)
+      - name: Build standalone binary
         run: CGO_ENABLED=${{ matrix.cgo }} go build -o ${{ matrix.output }} ./cmd/enclave
+
+      - name: Smoke test embedded asset extraction
+        run: ./scripts/smoke-standalone-binary.sh "${{ matrix.output }}"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -93,14 +96,15 @@ jobs:
           | File | Platform | Notes |
           |------|----------|-------|
           | \`enclave_*_amd64.deb\` | Ubuntu 24.04 | Includes all assets |
-          | \`enclave-linux-amd64-cli\` | Linux x86_64 | CLI only, no system deps |
+          | \`enclave-linux-amd64\` | Linux x86_64 | Self-contained binary with runtime assets |
 
           \`\`\`sh
           # Ubuntu 24.04 (resolves dependencies automatically)
           sudo apt install ./enclave_*_amd64.deb
 
-          # Other Linux
-          chmod +x enclave-*
+          # Other x86-64 Linux distributions
+          chmod +x enclave-linux-amd64
+          sudo install enclave-linux-amd64 /usr/local/bin/enclave
           \`\`\`
           EOF
           )" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Enclave follows platform-standard roots: the XDG base directories on Linux and o
 - Config: `~/.config/enclave/` (`$XDG_CONFIG_HOME`)
 - State: `~/.local/state/enclave/` (`$XDG_STATE_HOME`)
 - Cache: `~/.cache/enclave/` (`$XDG_CACHE_HOME`)
-- Installed assets: `~/.local/share/enclave/` (`$XDG_DATA_HOME`)
+- Embedded runtime assets: `~/.cache/enclave/assets/<content-hash>/`
 - Per-project agent memory: `~/.local/state/enclave/projects/<hash>/<tool>/memory/` (Claude only; agent-writable, never shared between projects or agents)
 - User-defined subcommands: `~/.config/enclave/commands/{host,session}/` (executable files become `enclave <name>` verbs)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -168,8 +168,8 @@ RUN --mount=type=cache,id=enclave-apt-cache,target=/var/cache/apt,sharing=locked
 RUN mkdir -p /opt/enclave/node/bin /opt/enclave/node/lib
 COPY --from=agent-node-runtime /usr/local/bin/node /opt/enclave/node/bin/node
 COPY --from=agent-node-runtime /usr/local/lib/node_modules /opt/enclave/node/lib/node_modules
-# Keep executable-asset rules here in sync with Makefile, debian/rules,
-# internal/app/build_permissions.go, and internal/app/dockerfile_gen.go.
+# Keep executable-asset rules here in sync with debian/rules,
+# internal/appassets, internal/app/build_permissions.go, and internal/app/dockerfile_gen.go.
 COPY runtime-assets/build-scripts /opt/enclave/build-scripts
 RUN chmod -R a+rX /opt/enclave/build-scripts && \
     find /opt/enclave/build-scripts -type f \( -name '*.sh' -o -path '*/bin/*' \) -exec chmod a+rx {} +

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-.PHONY: build cross-build install install-assets uninstall clean clean-lint-cache test deb lint lint-changed lint-report fmt vet generate lint-tools check-go completions check-license-headers
+.PHONY: build cross-build install install-binary clean-legacy-assets uninstall clean clean-lint-cache test deb lint lint-changed lint-report fmt vet generate lint-tools check-go completions check-license-headers
 
 BIN_DIR ?= ./bin
 BINARY ?= enclave
@@ -19,7 +19,6 @@ LINT_GO_DIRS := cmd internal extensions/tools
 LINT_TMP_DIR := ./.tmp
 LINT_GO_CACHE := $(LINT_TMP_DIR)/go-build
 LINT_GOLANGCI_CACHE := $(LINT_TMP_DIR)/golangci-lint-cache
-GATEWAY_PROXY_SOURCE_PATHS_FILE := $(CURDIR)/internal/gateway/gateway_proxy_build_inputs.txt
 BASE_REF ?=
 
 check-go:
@@ -38,64 +37,43 @@ completions:
 	mkdir -p $(COMPLETIONS_DIR)
 	$(BIN_DIR)/$(BINARY) completion bash > $(COMPLETIONS_DIR)/enclave
 
-# Install locations follow each platform's conventions. On macOS the asset dir
-# must match hostDataRoot() in internal/config/host_roots.go so the installed
-# binary's tier-3 asset discovery can find it.
+# make install now installs only the self-contained binary. This fixed path is
+# used solely for conservative cleanup of assets staged by older source
+# installs; unlike the former INSTALL_DIR, it is intentionally not overridable.
 ifeq ($(UNAME_S),Darwin)
-INSTALL_DIR ?= $(HOME)/Library/Application Support/org.eclipse.enclave/data
+override LEGACY_INSTALL_DIR := $(HOME)/Library/Application Support/org.eclipse.enclave/data
 INSTALL_BIN ?= /usr/local/bin
 else
-INSTALL_DIR ?= $(HOME)/.local/share/enclave
+override LEGACY_INSTALL_DIR := $(HOME)/.local/share/enclave
 INSTALL_BIN ?= $(HOME)/.local/bin
 endif
 
 install: build completions
-	$(MAKE) install-assets INSTALL_BINARY_LABEL="$(BINARY)"
+ifeq ($(filter Linux Darwin,$(UNAME_S)),)
+	$(error make install supports Linux and macOS hosts only; on Windows use WSL2)
+endif
+	$(MAKE) install-binary INSTALL_BINARY_LABEL="$(BINARY)"
 
 INSTALL_BINARY_LABEL ?= $(BINARY)
 
-install-assets:
+install-binary: clean-legacy-assets
 	mkdir -p "$(INSTALL_BIN)"
 	cp $(BIN_DIR)/$(BINARY) "$(INSTALL_BIN)/$(BINARY).new"
 	mv -f "$(INSTALL_BIN)/$(BINARY).new" "$(INSTALL_BIN)/$(BINARY)"
-	rm -rf "$(INSTALL_DIR)/extensions" "$(INSTALL_DIR)/runtime-assets"
-	# Remove root files staged by older installs that are no longer shipped.
-	rm -f "$(INSTALL_DIR)/CLAUDE.md" "$(INSTALL_DIR)/AGENTS.md"
-	mkdir -p "$(INSTALL_DIR)/extensions" "$(INSTALL_DIR)/runtime-assets"
-	cp Dockerfile Dockerfile.gateway entrypoint.sh gateway-entrypoint.sh .dockerignore "$(INSTALL_DIR)/"
-	cp LICENSE.md NOTICE.md "$(INSTALL_DIR)/"
-	chmod a+r "$(INSTALL_DIR)/Dockerfile" "$(INSTALL_DIR)/Dockerfile.gateway" "$(INSTALL_DIR)/.dockerignore" "$(INSTALL_DIR)/LICENSE.md" "$(INSTALL_DIR)/NOTICE.md"
-	chmod a+rx "$(INSTALL_DIR)/entrypoint.sh" "$(INSTALL_DIR)/gateway-entrypoint.sh"
-	cp -R extensions/tools extensions/features "$(INSTALL_DIR)/extensions/"
-	cp -R runtime-assets/. "$(INSTALL_DIR)/runtime-assets/"
-	chmod -R u+rwX,go+rX "$(INSTALL_DIR)/extensions" "$(INSTALL_DIR)/runtime-assets"
-	# Keep executable-asset rules here in sync with Dockerfile, debian/rules,
-	# internal/app/build_permissions.go, and internal/app/dockerfile_gen.go.
-	find "$(INSTALL_DIR)/extensions" -type f -name install.sh -exec chmod a+rx {} +
-	find "$(INSTALL_DIR)/runtime-assets/build-scripts" -type f \( -name '*.sh' -o -path '*/bin/*' \) -exec chmod a+rx {} +
-	@if [ -e "$(INSTALL_DIR)/docs" ]; then rm -rf -- "$(INSTALL_DIR)/docs"; fi
-	cp -R docs "$(INSTALL_DIR)/"
-	# Clear previously staged Go sources first; cp -r never deletes, so files removed upstream would otherwise linger and break the gateway build.
-	rm -rf "$(INSTALL_DIR)/internal" "$(INSTALL_DIR)/cmd" "$(INSTALL_DIR)/go.mod" "$(INSTALL_DIR)/go.sum"
-	while IFS= read -r path; do \
-		case "$$path" in ""|\#*) continue ;; esac; \
-		dest="$(INSTALL_DIR)/$$(dirname "$$path")"; \
-		mkdir -p "$$dest"; \
-		cp -r "$$path" "$$dest/"; \
-	done < $(GATEWAY_PROXY_SOURCE_PATHS_FILE)
 ifeq ($(UNAME_S),Linux)
 	# freedesktop shell completion (Linux only).
-	mkdir -p $(HOME)/.local/share/bash-completion/completions
-	cp $(COMPLETIONS_DIR)/enclave $(HOME)/.local/share/bash-completion/completions/enclave
+	mkdir -p "$(HOME)/.local/share/bash-completion/completions"
+	cp $(COMPLETIONS_DIR)/enclave "$(HOME)/.local/share/bash-completion/completions/enclave"
 endif
 	@echo "Installed $(INSTALL_BINARY_LABEL) to $(INSTALL_BIN)/$(BINARY)"
-	@echo "Assets installed to $(INSTALL_DIR)/"
+
+clean-legacy-assets:
+	go run ./cmd/enclave-clean-legacy-assets -root "$(LEGACY_INSTALL_DIR)"
 
 uninstall:
 	rm -f "$(INSTALL_BIN)/$(BINARY)"
-	rm -rf "$(INSTALL_DIR)"
 ifeq ($(UNAME_S),Linux)
-	rm -f $(HOME)/.local/share/bash-completion/completions/enclave
+	rm -f "$(HOME)/.local/share/bash-completion/completions/enclave"
 endif
 	@echo "Uninstalled $(BINARY)"
 
@@ -142,7 +120,14 @@ lint: lint-tools
 		go vet $$pkgs; \
 	fi
 	@echo "Running golangci-lint..."
-	@fail=0; for dir in $(LINT_GO_DIRS); do \
+	@fail=0; \
+	if find . -maxdepth 1 -type f -name '*.go' -print -quit | grep -q .; then \
+		echo "  -> ."; \
+		GOCACHE="$(CURDIR)/$(LINT_GO_CACHE)" \
+		GOLANGCI_LINT_CACHE="$(CURDIR)/$(LINT_GOLANGCI_CACHE)" \
+		golangci-lint run . || fail=1; \
+	fi; \
+	for dir in $(LINT_GO_DIRS); do \
 		if find "$$dir" -type f -name '*.go' -print -quit | grep -q .; then \
 			echo "  -> $$dir"; \
 			( \
@@ -189,6 +174,13 @@ lint-report: lint-tools
 	@mkdir -p $(LINT_GO_CACHE) $(LINT_GOLANGCI_CACHE)
 	@echo "Running golangci-lint..."
 	@{ \
+		if find . -maxdepth 1 -type f -name '*.go' -print -quit | grep -q .; then \
+			echo "== . =="; \
+			GOCACHE="$(CURDIR)/$(LINT_GO_CACHE)" \
+			GOLANGCI_LINT_CACHE="$(CURDIR)/$(LINT_GOLANGCI_CACHE)" \
+			golangci-lint run .; \
+			echo; \
+		fi; \
 		for dir in $(LINT_GO_DIRS); do \
 			if find "$$dir" -type f -name '*.go' | grep -q .; then \
 				echo "== $$dir =="; \
@@ -228,12 +220,11 @@ fmt:
 vet:
 	go vet ./...
 
-# Cross-compile every package for macOS (darwin/arm64) without cgo.
-# CI builds and tests the native Linux binary, but only the release workflow
-# ever compiles for macOS — this guards against platform-specific build breaks
-# (e.g. syscall fields that exist on Linux but not Darwin) reaching main.
+# Cross-compile every package for representative macOS and Windows targets
+# without cgo. Release artifacts remain scoped separately.
 cross-build: check-go
 	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./...
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...
 
 generate:
 	go generate ./internal/config ./cmd/enclave

--- a/README.md
+++ b/README.md
@@ -44,12 +44,23 @@ then install it with APT so runtime dependencies are resolved:
 sudo apt install ./enclave_*_amd64.deb
 ```
 
-The standalone binary attached to the release does not include the Dockerfiles,
-extensions, or other runtime assets and is not a complete installation.
+### Standalone binary
+
+The rolling release also provides a self-contained Linux x86-64 binary. Verify
+it with `checksums.txt`, make it executable, and place it on your `PATH`:
+
+```bash
+sha256sum --check --ignore-missing checksums.txt
+chmod +x enclave-linux-amd64
+sudo install enclave-linux-amd64 /usr/local/bin/enclave
+```
+
+The binary includes the Dockerfiles, extensions, documentation, and other
+runtime assets. It extracts its assets on first use.
 
 ### From source
 
-Clone the repository, then build and install the binary and runtime assets:
+Clone the repository, then build and install the self-contained binary:
 
 ```bash
 git clone https://github.com/eclipse-enclave/enclave.git
@@ -57,12 +68,10 @@ cd enclave
 make install
 ```
 
-On Linux this installs the binary to `~/.local/bin/` and assets to
-`~/.local/share/enclave/`. Make sure `~/.local/bin` is on your `PATH`. On macOS
-the binary goes to `/usr/local/bin/` (the copy may need `sudo` or a writable
-`/usr/local/bin`) and assets to
-`~/Library/Application Support/org.eclipse.enclave/data/`. Override with
-`make install INSTALL_BIN=... INSTALL_DIR=...`.
+On Linux this installs the binary to `~/.local/bin/`. Make sure that directory
+is on your `PATH`. On macOS the default is `/usr/local/bin/`; copying there may
+need `sudo` or a writable `/usr/local/bin`. Override the destination with
+`make install INSTALL_BIN=...`.
 
 ## Quick Start
 

--- a/assets_embed.go
+++ b/assets_embed.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build !enclave_no_embed
+
+// Package assets contains the runtime files embedded in the Enclave CLI.
+package assets
+
+import (
+	"embed"
+	"io/fs"
+
+	"enclave/internal/appassets"
+)
+
+// Keep this inventory aligned with the runtime assets installed by
+// debian/rules. The all prefix includes any dotfiles added below these trees in
+// future. The repository-root .dockerignore must be listed directly.
+//
+//go:embed .dockerignore Dockerfile Dockerfile.gateway entrypoint.sh gateway-entrypoint.sh LICENSE.md NOTICE.md
+//go:embed all:docs all:extensions all:runtime-assets
+//go:embed go.mod go.sum all:cmd/enclave-gateway-proxy
+//go:embed all:internal/appassets all:internal/config all:internal/domainpattern
+//go:embed all:internal/gateway/bundle all:internal/gateway/mitm all:internal/gateway/tlsstore
+//go:embed all:internal/git all:internal/logx all:internal/model all:internal/network all:internal/secretfile all:internal/util
+var files embed.FS
+
+func init() {
+	appassets.Register(files)
+}
+
+// FS returns the embedded asset filesystem rooted at the repository layout.
+func FS() fs.FS {
+	return files
+}

--- a/assets_noembed.go
+++ b/assets_noembed.go
@@ -5,15 +5,14 @@
 //
 // SPDX-License-Identifier: MIT
 
-package main
+//go:build enclave_no_embed
 
-import (
-	"os"
+// Package assets omits the embedded runtime tree from package-managed builds.
+package assets
 
-	_ "enclave"
-	"enclave/internal/app"
-)
+import "io/fs"
 
-func main() {
-	os.Exit(app.Run(os.Args[1:]))
+// FS returns no embedded assets in package-managed builds.
+func FS() fs.FS {
+	return nil
 }

--- a/assets_test.go
+++ b/assets_test.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build !enclave_no_embed
+
+package assets
+
+import (
+	"bufio"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEmbeddedAssetInventory(t *testing.T) {
+	for _, name := range []string{
+		".dockerignore",
+		"Dockerfile",
+		"Dockerfile.gateway",
+		"entrypoint.sh",
+		"gateway-entrypoint.sh",
+		"LICENSE.md",
+		"NOTICE.md",
+		"docs/README.md",
+		"extensions/tools/claude/spec.yaml",
+		"runtime-assets/gateway-allowlists/base.conf",
+	} {
+		if _, err := fs.Stat(files, name); err != nil {
+			t.Errorf("required embedded asset %s: %v", name, err)
+		}
+	}
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md", ".git"} {
+		if _, err := fs.Stat(files, name); !os.IsNotExist(err) {
+			t.Errorf("repository-only path %s was embedded", name)
+		}
+	}
+
+	inputList, err := os.ReadFile("internal/gateway/gateway_proxy_build_inputs.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanner := bufio.NewScanner(strings.NewReader(string(inputList)))
+	for scanner.Scan() {
+		name := strings.TrimSpace(scanner.Text())
+		if name == "" || strings.HasPrefix(name, "#") {
+			continue
+		}
+		if _, err := fs.Stat(files, name); err != nil {
+			t.Errorf("gateway proxy build input %s: %v", name, err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tree := range []string{"docs", "extensions", "runtime-assets"} {
+		assertEmbeddedTreeMatchesCheckout(t, tree)
+	}
+}
+
+func assertEmbeddedTreeMatchesCheckout(t *testing.T, tree string) {
+	t.Helper()
+	err := fs.WalkDir(os.DirFS("."), tree, func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&fs.ModeSymlink != 0 {
+			t.Errorf("asset source %s is a symlink and cannot be embedded", name)
+			return nil
+		}
+		embeddedEntry, err := fs.Stat(files, name)
+		if err != nil {
+			t.Errorf("checkout asset %s is not embedded: %v", name, err)
+			return nil
+		}
+		if embeddedEntry.IsDir() != entry.IsDir() {
+			t.Errorf("embedded asset type differs for %s", name)
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		checkoutContent, err := os.ReadFile(name)
+		if err != nil {
+			return err
+		}
+		embeddedContent, err := fs.ReadFile(files, name)
+		if err != nil {
+			return err
+		}
+		if string(embeddedContent) != string(checkoutContent) {
+			t.Errorf("embedded content differs for %s", name)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("compare embedded tree %s: %v", tree, err)
+	}
+}

--- a/cmd/enclave-clean-legacy-assets/main.go
+++ b/cmd/enclave-clean-legacy-assets/main.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	assets "enclave"
+	"enclave/internal/legacyassets"
+)
+
+func main() {
+	root := flag.String("root", "", "legacy Enclave asset root")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "unexpected positional arguments")
+		os.Exit(2)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve home directory: %v\n", err)
+		os.Exit(1)
+	}
+	result, err := legacyassets.Clean(*root, home, assets.FS())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "clean legacy Enclave assets: %v\n", err)
+		os.Exit(1)
+	}
+	if result.SkipReason != "" {
+		fmt.Printf("Legacy asset cleanup skipped: %s\n", result.SkipReason)
+		return
+	}
+	fmt.Printf("Removed %d known legacy asset entries from %s\n", result.Removed, *root)
+}

--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,8 @@ GATEWAY_PROXY_SOURCE_PATHS_FILE := $(CURDIR)/internal/gateway/gateway_proxy_buil
 override_dh_auto_build:
 	go mod vendor -modcacherw
 	mkdir -p bin
-	go build -mod=vendor -o bin/enclave ./cmd/enclave
+	# The package installs an executable-adjacent asset tree, so do not duplicate it in the binary.
+	go build -tags enclave_no_embed -mod=vendor -o bin/enclave ./cmd/enclave
 	mkdir -p completions
 	bin/enclave completion bash > completions/enclave
 
@@ -43,7 +44,7 @@ override_dh_auto_install:
 	cp -a docs/. $(CURDIR)/debian/enclave/usr/share/enclave/docs/
 	chmod -R u+rwX,go+rX $(CURDIR)/debian/enclave/usr/share/enclave/docs
 
-	# Keep executable-asset rules below in sync with Dockerfile, Makefile,
+	# Keep executable-asset rules below in sync with Dockerfile, internal/appassets,
 	# internal/app/build_permissions.go, and internal/app/dockerfile_gen.go.
 	# Install extensions
 	mkdir -p $(CURDIR)/debian/enclave/usr/share/enclave/extensions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,8 +84,14 @@ The restricted network request flow has a separate
 ## Repository Layout
 
 ### Entry Points
-- [`cmd/enclave/main.go`](../cmd/enclave/main.go) is the binary entrypoint. It delegates to `app.Run`.
+- [`cmd/enclave/main.go`](../cmd/enclave/main.go) is the binary entrypoint. It loads the selected asset variant and delegates to `app.Run`.
 - [`cmd/enclave-gateway-proxy/main.go`](../cmd/enclave-gateway-proxy/main.go) is the gateway sidecar MITM proxy entrypoint used by `Dockerfile.gateway`.
+
+### Distribution assets
+- [`assets_embed.go`](../assets_embed.go) embeds the runtime build context, documentation, extensions, and gateway proxy build sources in standalone CLI binaries. Debian builds select [`assets_noembed.go`](../assets_noembed.go) with the `enclave_no_embed` build tag because the package installs the same tree next to the executable.
+- [`internal/appassets/`](../internal/appassets/) registers the embedded filesystem, computes its content key, and defines normalized extraction modes.
+- [`internal/config/embedded_assets.go`](../internal/config/embedded_assets.go) extracts assets atomically into a content-keyed platform cache directory when no checkout or package asset tree is adjacent to the executable.
+- [`internal/legacyassets/`](../internal/legacyassets/) removes only exact, known files from the asset tree used by older source installs. It preserves unknown files, never follows symlinks, and never recursively removes directories.
 
 ### Orchestration (`internal/app/`)
 - [`internal/app/app.go`](../internal/app/app.go) wires parsing, defaults merging, and command dispatch.
@@ -100,7 +106,7 @@ The restricted network request flow has a separate
 
 ### Configuration and Profiles
 - [`extensions/tools/`](../extensions/tools/) contains per-tool configuration (`spec.yaml`, templates, allowlists, install scripts, optional `check-update.sh` hooks).
-- [`internal/config/paths.go`](../internal/config/paths.go) discovers `Dockerfile`, `entrypoint.sh`, extensions, and runtime assets.
+- [`internal/config/paths.go`](../internal/config/paths.go) resolves `Dockerfile`, `entrypoint.sh`, extensions, and runtime assets from `ENCLAVE_HOME`, an executable-adjacent app root, or the embedded asset store.
 - [`internal/config/profile.go`](../internal/config/profile.go) loads and lists tool profiles from extension directories.
 - [`internal/domainpattern/pattern.go`](../internal/domainpattern/pattern.go) validates and normalizes strict domain patterns used by secret release host mappings.
 
@@ -147,11 +153,13 @@ The restricted network request flow has a separate
 - [`runtime-assets/net.sh`](../runtime-assets/net.sh) holds shared entrypoint network helpers (local resolver and loopback proxy setup).
 - [`runtime-assets/microvm/alpine/`](../runtime-assets/microvm/alpine/) holds the experimental QEMU Alpine bundle init and builder.
 - [`extensions/tools/<tool>/templates/`](../extensions/tools/) holds per-tool settings templates baked into the image during build.
+- [`docs/`](../docs/) is included in the runtime build context so the image can install agent-facing help under `/usr/share/doc/enclave/`.
 
 ## Key Concepts
 
 - **Profiles** (`extensions/tools/<tool>/spec.yaml`, `kind: sandbox`): define tool command, session continuation args (`continueArgs`, `resumeArgs`), config location, optional settings/skills metadata (`settingsFile`, `settingsTarget`, `skillsDir`), optional host passthrough allow-list (`passthroughPaths`), optional QEMU bundle minimum memory (`qemuMinMemoryMiB`) and config-store cache hint (`qemuStoreCacheMmap`), declared credential sources (`credentials.sources`) including API-key metadata, YOLO flag, and per-provider auth configuration (`providers`: credentials, auth files, auth session checks, OAuth ports).
 - **Runtime assets** (`runtime-assets/gateway-allowlists/`, `runtime-assets/build-scripts/`, `runtime-assets/auth-reconcile.sh`, `runtime-assets/net.sh`): DNS allowlists, Docker weaving scripts, and shared entrypoint helpers baked into the image. Tool templates live in `extensions/tools/<tool>/templates/` and are aggregated during build.
+- **Asset discovery**: `ENCLAVE_HOME` has explicit precedence, followed by a valid app root above the resolved executable path. This keeps deb installs on `/usr/share/enclave` and in-tree builds on live checkout files. Other binaries extract their embedded assets into an append-only `assets/<content-hash>/` directory under the platform cache root. The former unversioned data-root lookup is not used.
 - **Image selection**: images are per-tool. The default tag is `enclave-<tool>:latest` for the selected `--tool` (default `claude`); `--slim` uses `enclave-<tool>:slim`. When running from a git checkout on a non-default branch, the tag is prefixed with the branch name and hash (for example, `enclave-codex:branch-<name>-<hash>-latest`) to avoid overwriting main images. `--base-image` or devcontainer mode derives a separate tag (e.g., `enclave-codex:base-<hash>-latest`) unless `--image-name` is set.
 - **Agent Node isolation**: Node-based agent CLIs are installed with a private runtime at `/opt/enclave/node` and launcher shebangs are rewritten to that absolute node path. This keeps agent runtime Node independent from user/project `node` on PATH.
 - **Isolation backend**: `--backend` selects the session isolation backend. `docker` is the default and supports the full feature set. Experimental `qemu` supports foreground slim/no-feature unrestricted sessions in an Alpine microVM bundle. Both backends realize persistent stores from the shared host-directory layout (`internal/backend/hoststore`), so auth, tool config, and persisted env are shared between containers and microVMs.
@@ -184,6 +192,7 @@ Persistent stores are host directories under `~/.local/state/enclave/` (honoring
 
 Other host-side data:
 
+- **Embedded asset cache**: standalone binaries extract into `${XDG_CACHE_HOME:-~/.cache}/enclave/assets/<hash>/` on Linux or `~/Library/Caches/org.eclipse.enclave/assets/<hash>/` on macOS. Extraction uses a per-content lock, temporary sibling directory, and atomic rename so concurrent first runs share one complete entry. Missing or invalid entries are recreated from the binary.
 - **QEMU stores**: the experimental QEMU backend mounts the same host-directory stores as the Docker backend (resolved via `internal/backend/hoststore`) into the guest over 9p, so auth, config, and env state are shared across backends.
 - **QEMU bundles**: generated microVM bundles live under `${XDG_CACHE_HOME:-~/.cache}/enclave/microvm/<tool>/<hash>/` unless `--image-name` points at an explicit bundle directory.
 - **Caches**: `~/.cache/enclave/<tool>/<hash>/` for package managers and build tools:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -6,6 +6,9 @@ Concise notes for contributors working on the enclave codebase.
 
 - Go 1.24.x (see `go.mod` toolchain)
 - Docker daemon running (for runtime testing)
+- Linux or macOS host. Native Windows is unsupported; use WSL2, where the
+  Linux instructions apply. `make cross-build` compiles Windows targets only
+  to guard code portability.
 
 ## Common Commands
 
@@ -42,19 +45,24 @@ make lint-changed BASE_REF=main      # all changes since main
 
 ## Running Changes from the Working Copy
 
-enclave reads its runtime assets from disk — `Dockerfile`, `entrypoint.sh`,
-`runtime-assets/`, and `extensions/tools/<tool>/templates/` are **not** embedded
-in the binary. It locates them by discovering an "app root", in this order
-(`internal/config/paths.go`, `discoverAppRoot`):
+enclave embeds its runtime assets, but a development binary uses checkout files
+first. It locates an "app root" in this order (`internal/config/paths.go`,
+`discoverAppRoot`):
 
-1. `ENCLAVE_HOME` — if set, it must contain the required assets or startup fails.
-2. Walk **up** from the binary's own directory until a valid app root is found.
-3. Data-root fallback (where `make install` puts assets): `~/.local/share/enclave`
-   on Linux, `~/Library/Application Support/org.eclipse.enclave/data` on macOS.
+1. `ENCLAVE_HOME`, which must contain the required assets when set.
+2. Walk up from the binary's directory until a valid app root is found.
+3. Extract the embedded assets into a content-hash-keyed directory under the
+   platform cache root.
 
-Because `bin/enclave` lives inside the checkout, tier 2 walks up to the repo
-root — so building and running the in-tree binary already uses the working
-copy's assets:
+On Linux the extraction store is
+`${XDG_CACHE_HOME:-~/.cache}/enclave/assets/<hash>/`. On macOS it is
+`~/Library/Caches/org.eclipse.enclave/assets/<hash>/`. Each distinct asset set
+uses its own atomically published directory and does not modify other entries. The tree
+is reproducible from the binary, so deleting it is safe; the next run extracts
+it again.
+
+Because `bin/enclave` lives inside the checkout, tier 2 finds the repository
+root. Running an in-tree binary therefore uses the working copy's assets:
 
 ```bash
 make build
@@ -82,10 +90,9 @@ automatic rebuild. To force it, pass `--rebuild`:
 
 Gotchas:
 
-- Invoke `./bin/enclave`, not an installed `enclave` on your `PATH` — an
-  installed binary resolves assets from the data root (`~/.local/share/enclave`
-  on Linux, `~/Library/Application Support/org.eclipse.enclave/data` on
-  macOS), not your checkout.
+- Invoke `./bin/enclave`, not an installed `enclave` on your `PATH`. An
+  installed binary uses the assets embedded when it was built, not your
+  checkout.
 - Canonical full config overrides under `~/.config/enclave/tools/<tool>/`
   and `~/.config/enclave/projects/<hash>/<tool>/config/`, plus JSON/TOML patches
   under the global/project `patches/<tool>/` directories, can shadow your

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
 
 ## Developer Documentation
 
-- [ARCHITECTURE.md](ARCHITECTURE.md) — Architecture, repository layout, and option resolution
+- [ARCHITECTURE.md](ARCHITECTURE.md) — Architecture, repository layout, asset distribution, and option resolution
 - [DEV.md](DEV.md) — Build, test, generation, and contribution workflow
 - [extensions/README.md](extensions/README.md) — Tool and feature extension architecture
 - [extensions/adding-a-tool.md](extensions/adding-a-tool.md) — Adding a tool extension

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -44,12 +44,16 @@ Per-project data is stored on the host and reused across sessions:
 | Shell history | `~/.local/state/enclave/projects/<project-hash>/<tool>/history/` |
 | Agent memory | `~/.local/state/enclave/projects/<project-hash>/<tool>/memory/` (Claude) |
 | Config/env/auth stores | Host directories under `~/.local/state/enclave/` (bind-mounted; no Docker volumes) |
+| Embedded runtime assets | `~/.cache/enclave/assets/<content-hash>/` |
+
+Extracted runtime asset entries are reproducible cache data. Deleting them is
+safe, and Enclave extracts the current entry again on the next run. Enclave does
+not garbage collect entries for older binaries yet.
 
 The paths above use the Linux (XDG) layout. On macOS the same data lives under
-the standard Apple locations, in a reverse-DNS application directory: config,
-state, and data under `~/Library/Application Support/org.eclipse.enclave/`
-(`config/`, `state/`, `data/`) and caches under
-`~/Library/Caches/org.eclipse.enclave/`.
+the standard Apple locations, in a reverse-DNS application directory: config
+and state under `~/Library/Application Support/org.eclipse.enclave/`
+(`config/`, `state/`) and caches under `~/Library/Caches/org.eclipse.enclave/`.
 
 Agent memory is skipped for `--ephemeral` sessions: memory written during them
 is discarded with the session's config store.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tidwall/jsonc v0.3.2
 	golang.org/x/crypto v0.47.0
+	golang.org/x/sys v0.40.0
 	golang.org/x/term v0.39.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -27,6 +28,5 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/internal/app/build_permissions.go
+++ b/internal/app/build_permissions.go
@@ -34,7 +34,7 @@ func warnAppRootModeIssues(appRoot string) {
 		shown = shown[:maxAppRootModeIssues]
 		more = fmt.Sprintf("; and %d more", len(issues)-maxAppRootModeIssues)
 	}
-	logx.Warnf("Installed enclave assets have restrictive permissions that can break image builds: %s%s. Reinstall enclave assets (package reinstall or make install); for a source install, removing %s before reinstalling repairs stale modes.", strings.Join(shown, "; "), more, appRoot)
+	logx.Warnf("Enclave assets have restrictive permissions that can break image builds: %s%s. Reinstall the package or restore the source checkout's asset modes under %s.", strings.Join(shown, "; "), more, appRoot)
 }
 
 func collectAppRootModeIssues(appRoot string) ([]string, error) {
@@ -43,8 +43,10 @@ func collectAppRootModeIssues(appRoot string) ([]string, error) {
 	}
 
 	var issues []string
-	if err := checkAppRootFileMode(appRoot, "entrypoint.sh", true, &issues); err != nil {
-		return nil, err
+	for _, rel := range []string{"entrypoint.sh", "gateway-entrypoint.sh"} {
+		if err := checkAppRootFileMode(appRoot, rel, true, &issues); err != nil {
+			return nil, err
+		}
 	}
 	for _, rel := range []string{
 		filepath.ToSlash(filepath.Join("runtime-assets", "auth-reconcile.sh")),
@@ -52,6 +54,14 @@ func collectAppRootModeIssues(appRoot string) ([]string, error) {
 		filepath.ToSlash(filepath.Join("runtime-assets", "tmux-session.conf")),
 	} {
 		if err := checkAppRootFileMode(appRoot, rel, false, &issues); err != nil {
+			return nil, err
+		}
+	}
+	for _, rel := range []string{
+		filepath.ToSlash(filepath.Join("runtime-assets", "microvm", "alpine", "build-bundle.sh")),
+		filepath.ToSlash(filepath.Join("runtime-assets", "microvm", "alpine", "init")),
+	} {
+		if err := checkAppRootFileMode(appRoot, rel, true, &issues); err != nil {
 			return nil, err
 		}
 	}
@@ -132,7 +142,7 @@ func appendAppRootModeIssue(appRoot string, path string, info os.FileInfo, execu
 }
 
 // These predicates mirror the executable-asset normalization rules in
-// Dockerfile, Makefile, debian/rules, and internal/app/dockerfile_gen.go.
+// Dockerfile, debian/rules, internal/appassets, and dockerfile_gen.go.
 func buildScriptNeedsExecute(rel string) bool {
 	base := filepath.Base(filepath.FromSlash(rel))
 	return strings.HasSuffix(base, ".sh") || strings.Contains(rel, "/bin/")

--- a/internal/app/build_preflight.go
+++ b/internal/app/build_preflight.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"enclave/internal/docker"
 	"enclave/internal/logx"
@@ -93,29 +92,6 @@ func realDockerRootFreeSpace(ctx context.Context) (string, uint64, error) {
 		return rootDir, 0, err
 	}
 	return rootDir, freeBytes, nil
-}
-
-func availableBytesAtPath(path string) (uint64, error) {
-	resolved, err := existingPathForStatfs(path)
-	if err != nil {
-		return 0, err
-	}
-
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(resolved, &stat); err != nil {
-		return 0, fmt.Errorf("stat filesystem for %s: %w", resolved, err)
-	}
-
-	// Statfs reports the available-block count (Bavail) in units of Bsize on
-	// both Linux and macOS. Bsize is the only block-size field common to every
-	// target platform (Linux's Statfs_t also has Frsize; Darwin's does not), but
-	// its type differs across platforms. Guard before the uint64 cast so a
-	// signed negative block size cannot wrap.
-	blockSize := stat.Bsize
-	if blockSize <= 0 {
-		return 0, fmt.Errorf("stat filesystem for %s: invalid block size", resolved)
-	}
-	return stat.Bavail * uint64(blockSize), nil
 }
 
 func existingPathForStatfs(path string) (string, error) {

--- a/internal/app/build_preflight_statfs_unix.go
+++ b/internal/app/build_preflight_statfs_unix.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package app
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func availableBytesAtPath(path string) (uint64, error) {
+	resolved, err := existingPathForStatfs(path)
+	if err != nil {
+		return 0, err
+	}
+
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(resolved, &stat); err != nil {
+		return 0, fmt.Errorf("stat filesystem for %s: %w", resolved, err)
+	}
+
+	// Statfs reports available blocks in units of Bsize on Linux and macOS.
+	// The Bsize type differs across platforms, so reject negative values before
+	// converting it to uint64.
+	blockSize := stat.Bsize
+	if blockSize <= 0 {
+		return 0, fmt.Errorf("stat filesystem for %s: invalid block size", resolved)
+	}
+	availableBlocks := int64(stat.Bavail) // #nosec G115 -- high-bit uint64 values become negative and are rejected below.
+	if availableBlocks < 0 {
+		return 0, fmt.Errorf("stat filesystem for %s: invalid available block count", resolved)
+	}
+	return uint64(availableBlocks) * uint64(blockSize), nil
+}

--- a/internal/app/build_preflight_statfs_windows.go
+++ b/internal/app/build_preflight_statfs_windows.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package app
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func availableBytesAtPath(path string) (uint64, error) {
+	resolved, err := existingPathForStatfs(path)
+	if err != nil {
+		return 0, err
+	}
+	name, err := windows.UTF16PtrFromString(resolved)
+	if err != nil {
+		return 0, fmt.Errorf("encode filesystem path %s: %w", resolved, err)
+	}
+	var available uint64
+	if err := windows.GetDiskFreeSpaceEx(name, &available, nil, nil); err != nil {
+		return 0, fmt.Errorf("stat filesystem for %s: %w", resolved, err)
+	}
+	return available, nil
+}

--- a/internal/app/dockerfile_gen.go
+++ b/internal/app/dockerfile_gen.go
@@ -159,8 +159,8 @@ func dockerfileCopyInstruction(src string, dst string) string {
 	return "COPY " + string(data) + "\n"
 }
 
-// Mirrors the extension install.sh execute rule in Dockerfile, Makefile,
-// debian/rules, and internal/app/build_permissions.go.
+// Mirrors the extension install.sh execute rule in Dockerfile, debian/rules,
+// internal/appassets, and internal/app/build_permissions.go.
 func dockerfileNormalizeExtensionTree(target string) string {
 	quotedTarget := util.ShellQuote(target)
 	installScript := util.ShellQuote(target + "/" + model.InstallScriptFilename)

--- a/internal/appassets/assets.go
+++ b/internal/appassets/assets.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package appassets
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"strings"
+	"sync"
+)
+
+var embedded struct {
+	sync.Mutex
+	files fs.FS
+	once  sync.Once
+	key   string
+	err   error
+}
+
+// Register installs the assets embedded by the repository-root package. The
+// CLI imports that package for its initialization side effect, while binaries
+// that only use internal packages (such as the gateway proxy) remain small.
+func Register(files fs.FS) {
+	if files == nil {
+		panic("register nil embedded asset filesystem")
+	}
+	embedded.Lock()
+	defer embedded.Unlock()
+	if embedded.files != nil {
+		panic("embedded asset filesystem registered more than once")
+	}
+	embedded.files = files
+}
+
+// Embedded returns the registered asset filesystem and its deterministic key.
+func Embedded() (fs.FS, string, error) {
+	embedded.Lock()
+	files := embedded.files
+	embedded.Unlock()
+	if files == nil {
+		return nil, "", fmt.Errorf("embedded assets are unavailable")
+	}
+
+	embedded.once.Do(func() {
+		embedded.key, embedded.err = ContentHash(files)
+	})
+	return files, embedded.key, embedded.err
+}
+
+// ContentHash hashes the paths, normalized extraction modes, and contents of
+// every embedded asset. Framing each field avoids ambiguous concatenations.
+func ContentHash(files fs.FS) (string, error) {
+	if files == nil {
+		return "", fmt.Errorf("asset filesystem is nil")
+	}
+
+	h := sha256.New()
+	err := fs.WalkDir(files, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if name == "." {
+			return nil
+		}
+
+		kind := byte('f')
+		if entry.IsDir() {
+			kind = 'd'
+		} else if !entry.Type().IsRegular() {
+			return fmt.Errorf("embedded asset %s is not a regular file or directory", name)
+		}
+		if err := writeHashField(h, []byte{kind}); err != nil {
+			return err
+		}
+		if err := writeHashField(h, []byte(name)); err != nil {
+			return err
+		}
+		mode := uint32(0o755)
+		if !entry.IsDir() {
+			mode = uint32(FileMode(name))
+		}
+		if err := binary.Write(h, binary.BigEndian, mode); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		file, err := files.Open(name)
+		if err != nil {
+			return err
+		}
+		content, readErr := io.ReadAll(file)
+		closeErr := file.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		return writeHashField(h, content)
+	})
+	if err != nil {
+		return "", fmt.Errorf("hash embedded assets: %w", err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func writeHashField(w io.Writer, value []byte) error {
+	if err := binary.Write(w, binary.BigEndian, uint64(len(value))); err != nil {
+		return err
+	}
+	_, err := w.Write(value)
+	return err
+}
+
+// FileMode returns the normalized mode used when extracting an asset. Embed
+// files do not retain source modes, so executable runtime contracts are listed
+// explicitly and all other files are read-only build inputs.
+func FileMode(name string) fs.FileMode {
+	name = path.Clean(strings.ReplaceAll(name, `\`, "/"))
+	if name == "entrypoint.sh" || name == "gateway-entrypoint.sh" {
+		return 0o755
+	}
+	if name == "runtime-assets/microvm/alpine/build-bundle.sh" || name == "runtime-assets/microvm/alpine/init" {
+		return 0o755
+	}
+	if strings.HasPrefix(name, "runtime-assets/build-scripts/") {
+		base := path.Base(name)
+		if strings.HasSuffix(base, ".sh") || strings.Contains(name, "/bin/") {
+			return 0o755
+		}
+	}
+	if strings.HasPrefix(name, "extensions/") && path.Base(name) == "install.sh" {
+		return 0o755
+	}
+	return 0o644
+}

--- a/internal/appassets/assets_test.go
+++ b/internal/appassets/assets_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package appassets
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestContentHashIncludesPathsContentAndModes(t *testing.T) {
+	base := fstest.MapFS{"docs/file": {Data: []byte("one")}}
+	baseHash, err := ContentHash(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []fstest.MapFS{
+		{"docs/other": {Data: []byte("one")}},
+		{"docs/file": {Data: []byte("two")}},
+		{"extensions/test/install.sh": {Data: []byte("one")}},
+	}
+	for i, files := range cases {
+		hash, err := ContentHash(files)
+		if err != nil {
+			t.Fatalf("case %d: %v", i, err)
+		}
+		if hash == baseHash {
+			t.Fatalf("case %d produced unchanged hash %s", i, hash)
+		}
+	}
+	if len(baseHash) != 64 {
+		t.Fatalf("hash length = %d, want 64", len(baseHash))
+	}
+}
+
+func TestFileMode(t *testing.T) {
+	tests := map[string]uint32{
+		"entrypoint.sh":                                 0o755,
+		"gateway-entrypoint.sh":                         0o755,
+		"extensions/tools/demo/install.sh":              0o755,
+		"extensions/features/demo/install.sh":           0o755,
+		"extensions/tools/demo/check-update.sh":         0o644,
+		"runtime-assets/build-scripts/install.sh":       0o755,
+		"runtime-assets/build-scripts/bin/helper":       0o755,
+		"runtime-assets/build-scripts/data/config":      0o644,
+		"runtime-assets/microvm/alpine/build-bundle.sh": 0o755,
+		"runtime-assets/microvm/alpine/init":            0o755,
+		"docs/README.md":                                0o644,
+	}
+	for name, want := range tests {
+		if got := uint32(FileMode(name)); got != want {
+			t.Errorf("FileMode(%q) = %#o, want %#o", name, got, want)
+		}
+	}
+}

--- a/internal/config/embedded_assets.go
+++ b/internal/config/embedded_assets.go
@@ -1,0 +1,250 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"enclave/internal/appassets"
+	"enclave/internal/util"
+)
+
+const (
+	embeddedAssetStoreDir         = "assets"
+	embeddedAssetExtractionPrefix = ".extract-"
+)
+
+func extractRegisteredAppAssets() (string, error) {
+	files, key, err := appassets.Embedded()
+	if err != nil {
+		return "", err
+	}
+	home, err := ResolveHostHome()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return extractAppAssets(files, key, hostCacheRoot(home))
+}
+
+func extractAppAssets(files fs.FS, key string, cacheRoot string) (string, error) {
+	if files == nil {
+		return "", fmt.Errorf("asset filesystem is nil")
+	}
+	if len(key) != 64 {
+		return "", fmt.Errorf("invalid embedded asset key %q", key)
+	}
+	for _, char := range key {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return "", fmt.Errorf("invalid embedded asset key %q", key)
+		}
+	}
+	if !filepath.IsAbs(cacheRoot) {
+		return "", fmt.Errorf("asset cache root is not absolute: %s", cacheRoot)
+	}
+
+	assetsDir := filepath.Join(cacheRoot, embeddedAssetStoreDir)
+	root := filepath.Join(assetsDir, key)
+	if _, err := os.Lstat(root); err == nil {
+		if validationErr := validatePublishedAppRoot(root, files); validationErr == nil {
+			return root, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect embedded asset cache %s: %w", root, err)
+	}
+
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil { // #nosec G301 -- extracted build contexts must be traversable.
+		return "", fmt.Errorf("create embedded asset cache %s: %w", assetsDir, err)
+	}
+	lockPath := filepath.Join(cacheRoot, ".assets-"+key+".lock")
+	if err := util.WithFileLock(lockPath, func() error {
+		return materializeAppAssets(files, key, assetsDir, root)
+	}); err != nil {
+		return "", err
+	}
+	return root, nil
+}
+
+func materializeAppAssets(files fs.FS, key string, assetsDir string, root string) error {
+	if err := removeInterruptedAppAssetExtractions(assetsDir, key); err != nil {
+		return err
+	}
+
+	if _, err := os.Lstat(root); err == nil {
+		if validationErr := validatePublishedAppRoot(root, files); validationErr == nil {
+			return nil
+		}
+		if err := os.RemoveAll(root); err != nil { // #nosec G703 -- root is a validated hash entry under the cache directory.
+			return fmt.Errorf("remove invalid embedded asset cache %s: %w", root, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect embedded asset cache %s: %w", root, err)
+	}
+
+	tempRoot, err := os.MkdirTemp(assetsDir, embeddedAssetExtractionPrefix+key+"-")
+	if err != nil {
+		return fmt.Errorf("create temporary embedded asset directory: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempRoot) // #nosec G703 -- tempRoot is returned by os.MkdirTemp above.
+	}()
+
+	if err := os.Chmod(tempRoot, 0o755); err != nil { // #nosec G302 -- extracted build contexts must be traversable.
+		return fmt.Errorf("set temporary embedded asset directory mode: %w", err)
+	}
+	if err := writeAppAssets(files, tempRoot); err != nil {
+		return err
+	}
+	if err := validatePublishedAppRoot(tempRoot, files); err != nil {
+		return fmt.Errorf("validate extracted assets: %w", err)
+	}
+
+	if err := os.Rename(tempRoot, root); err != nil {
+		if validationErr := validatePublishedAppRoot(root, files); validationErr == nil {
+			return nil
+		}
+		return fmt.Errorf("publish embedded assets to %s: %w", root, err)
+	}
+	return nil
+}
+
+func removeInterruptedAppAssetExtractions(assetsDir string, key string) error {
+	prefix := embeddedAssetExtractionPrefix + key + "-"
+	entries, err := os.ReadDir(assetsDir)
+	if err != nil {
+		return fmt.Errorf("read embedded asset cache %s: %w", assetsDir, err)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		path := filepath.Join(assetsDir, entry.Name())
+		if err := os.RemoveAll(path); err != nil { // #nosec G703 -- path is a direct child returned by os.ReadDir above.
+			return fmt.Errorf("remove interrupted embedded asset extraction %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func validatePublishedAppRoot(root string, files fs.FS) error {
+	info, err := os.Lstat(root)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("not a real directory")
+	}
+	if err := validateAppRoot(root); err != nil {
+		return err
+	}
+	for _, entry := range []appRootRequiredEntry{
+		{rel: ".dockerignore", label: ".dockerignore"},
+		{rel: "docs", label: "documentation directory", isDir: true},
+	} {
+		path := filepath.Join(root, entry.rel)
+		entryInfo, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("%s not found at %s: %w", entry.label, path, err)
+		}
+		if entryInfo.IsDir() != entry.isDir {
+			return fmt.Errorf("%s has the wrong file type at %s", entry.label, path)
+		}
+	}
+	return validateEmbeddedAssetsPresent(root, files)
+}
+
+// validateEmbeddedAssetsPresent verifies every embedded asset exists with the
+// expected type, so a partially pruned cache entry is re-extracted instead of
+// serving an incomplete build context.
+func validateEmbeddedAssetsPresent(root string, files fs.FS) error {
+	return fs.WalkDir(files, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if name == "." {
+			return nil
+		}
+		if !fs.ValidPath(name) {
+			return fmt.Errorf("invalid embedded asset path %q", name)
+		}
+		info, err := os.Lstat(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			return fmt.Errorf("embedded asset %s is missing: %w", name, err)
+		}
+		if entry.IsDir() {
+			if !info.IsDir() {
+				return fmt.Errorf("embedded asset %s is not a directory", name)
+			}
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("embedded asset %s is not a regular file", name)
+		}
+		return nil
+	})
+}
+
+func writeAppAssets(files fs.FS, root string) error {
+	return fs.WalkDir(files, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if name == "." {
+			return nil
+		}
+		if !fs.ValidPath(name) {
+			return fmt.Errorf("invalid embedded asset path %q", name)
+		}
+
+		target := filepath.Join(root, filepath.FromSlash(name))
+		if entry.IsDir() {
+			if err := os.Mkdir(target, 0o755); err != nil { // #nosec G301 -- build context directories must be traversable.
+				return fmt.Errorf("create embedded asset directory %s: %w", name, err)
+			}
+			if err := os.Chmod(target, 0o755); err != nil { // #nosec G302 -- build context directories must be traversable.
+				return fmt.Errorf("set embedded asset directory mode %s: %w", name, err)
+			}
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("embedded asset %s is not a regular file", name)
+		}
+
+		source, err := files.Open(name)
+		if err != nil {
+			return fmt.Errorf("open embedded asset %s: %w", name, err)
+		}
+		mode := appassets.FileMode(name)
+		// #nosec G304 -- target is under a fresh temp root and name passed fs.ValidPath above.
+		destination, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+		if err != nil {
+			_ = source.Close()
+			return fmt.Errorf("create embedded asset %s: %w", name, err)
+		}
+		_, copyErr := io.Copy(destination, source)
+		closeDestinationErr := destination.Close()
+		closeSourceErr := source.Close()
+		if copyErr != nil {
+			return fmt.Errorf("write embedded asset %s: %w", name, copyErr)
+		}
+		if closeDestinationErr != nil {
+			return fmt.Errorf("close embedded asset %s: %w", name, closeDestinationErr)
+		}
+		if closeSourceErr != nil {
+			return fmt.Errorf("close embedded source %s: %w", name, closeSourceErr)
+		}
+		if err := os.Chmod(target, mode); err != nil {
+			return fmt.Errorf("set embedded asset mode %s: %w", name, err)
+		}
+		return nil
+	})
+}

--- a/internal/config/embedded_assets_test.go
+++ b/internal/config/embedded_assets_test.go
@@ -1,0 +1,334 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"testing/fstest"
+
+	"enclave/internal/appassets"
+	"enclave/internal/model"
+)
+
+func TestDiscoverAppRootDoesNotUseLegacyDataRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	t.Setenv("ENCLAVE_HOME", "")
+	legacyRoot := legacyDataRootForTest(home)
+	if err := os.MkdirAll(legacyRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAppAssets(testAppAssets("legacy"), legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateAppRoot(legacyRoot); err != nil {
+		t.Fatalf("test legacy root is invalid: %v", err)
+	}
+
+	root, err := discoverAppRoot()
+	if err == nil && root == legacyRoot {
+		t.Fatalf("discoverAppRoot returned legacy root %q", root)
+	}
+}
+
+func legacyDataRootForTest(home string) string {
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Application Support", model.AppID, "data")
+	}
+	return filepath.Join(xdgBaseDir("XDG_DATA_HOME", home, filepath.Join(".local", "share")), model.AppName)
+}
+
+func TestExtractAppAssets(t *testing.T) {
+	files := testAppAssets("first")
+	key, err := appassets.ContentHash(files)
+	if err != nil {
+		t.Fatalf("hash assets: %v", err)
+	}
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+
+	root, err := extractAppAssets(files, key, cacheRoot)
+	if err != nil {
+		t.Fatalf("extract assets: %v", err)
+	}
+	wantRoot := filepath.Join(cacheRoot, embeddedAssetStoreDir, key)
+	if root != wantRoot {
+		t.Fatalf("root = %q, want %q", root, wantRoot)
+	}
+	if err := validateAppRoot(root); err != nil {
+		t.Fatalf("extracted root is invalid: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "docs", "README.md"))
+	if err != nil {
+		t.Fatalf("read extracted documentation: %v", err)
+	}
+	if string(content) != "first" {
+		t.Fatalf("documentation content = %q, want first", content)
+	}
+
+	if runtime.GOOS != "windows" {
+		assertExtractedMode(t, root, "entrypoint.sh", 0o755)
+		assertExtractedMode(t, root, "gateway-entrypoint.sh", 0o755)
+		assertExtractedMode(t, root, "extensions/tools/test/install.sh", 0o755)
+		assertExtractedMode(t, root, "runtime-assets/build-scripts/run.sh", 0o755)
+		assertExtractedMode(t, root, "runtime-assets/build-scripts/bin/helper", 0o755)
+		assertExtractedMode(t, root, "runtime-assets/microvm/alpine/build-bundle.sh", 0o755)
+		assertExtractedMode(t, root, "runtime-assets/microvm/alpine/init", 0o755)
+		assertExtractedMode(t, root, "docs/README.md", 0o644)
+	}
+}
+
+func TestExtractAppAssetsConcurrentFirstRun(t *testing.T) {
+	files := testAppAssets("concurrent")
+	key, err := appassets.ContentHash(files)
+	if err != nil {
+		t.Fatalf("hash assets: %v", err)
+	}
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+
+	const workers = 12
+	roots := make([]string, workers)
+	errs := make([]error, workers)
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			roots[i], errs[i] = extractAppAssets(files, key, cacheRoot)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+		if roots[i] != roots[0] {
+			t.Fatalf("worker %d root = %q, want %q", i, roots[i], roots[0])
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(cacheRoot, embeddedAssetStoreDir))
+	if err != nil {
+		t.Fatalf("read asset cache directory: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != key {
+		t.Fatalf("asset cache entries = %v, want only %s", entryNames(entries), key)
+	}
+}
+
+func TestExtractAppAssetsRemovesInterruptedExtraction(t *testing.T) {
+	files := testAppAssets("content")
+	key, err := appassets.ContentHash(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	assetsDir := filepath.Join(cacheRoot, embeddedAssetStoreDir)
+	interruptedRoot := filepath.Join(assetsDir, embeddedAssetExtractionPrefix+key+"-abandoned")
+	if err := os.MkdirAll(interruptedRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(interruptedRoot, "partial"), []byte("partial"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := extractAppAssets(files, key, cacheRoot)
+	if err != nil {
+		t.Fatalf("extract assets: %v", err)
+	}
+	if _, err := os.Lstat(interruptedRoot); !os.IsNotExist(err) {
+		t.Fatalf("interrupted extraction remains: %v", err)
+	}
+	if err := validatePublishedAppRoot(root, files); err != nil {
+		t.Fatalf("extracted root is invalid: %v", err)
+	}
+}
+
+func TestExtractAppAssetsUsesDistinctAppendOnlyCacheEntries(t *testing.T) {
+	firstFiles := testAppAssets("first")
+	secondFiles := testAppAssets("second")
+	firstKey, err := appassets.ContentHash(firstFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondKey, err := appassets.ContentHash(secondFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+
+	firstRoot, err := extractAppAssets(firstFiles, firstKey, cacheRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRoot, err := extractAppAssets(secondFiles, secondKey, cacheRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstRoot == secondRoot {
+		t.Fatalf("distinct content used the same root %q", firstRoot)
+	}
+	firstContent, err := os.ReadFile(filepath.Join(firstRoot, "docs", "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstContent) != "first" {
+		t.Fatalf("first cache entry was modified: %q", firstContent)
+	}
+}
+
+func TestExtractAppAssetsRepairsCacheEntrySymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require elevated privileges on Windows")
+	}
+	files := testAppAssets("content")
+	key, err := appassets.ContentHash(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	assetsDir := filepath.Join(cacheRoot, embeddedAssetStoreDir)
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAppAssets(files, outside); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(assetsDir, key)); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := extractAppAssets(files, key, cacheRoot)
+	if err != nil {
+		t.Fatalf("repair cache entry symlink: %v", err)
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		t.Fatalf("repaired cache entry is not a real directory: %v", info.Mode())
+	}
+	content, err := os.ReadFile(filepath.Join(outside, "docs", "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "content" {
+		t.Fatalf("symlink target was modified: %q", content)
+	}
+}
+
+func TestExtractAppAssetsRepairsInvalidCacheEntry(t *testing.T) {
+	files := testAppAssets("content")
+	key, err := appassets.ContentHash(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	root := filepath.Join(cacheRoot, embeddedAssetStoreDir, key)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(root, "do-not-remove")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	repairedRoot, err := extractAppAssets(files, key, cacheRoot)
+	if err != nil {
+		t.Fatalf("repair invalid cache entry: %v", err)
+	}
+	if repairedRoot != root {
+		t.Fatalf("repaired root = %q, want %q", repairedRoot, root)
+	}
+	if _, err := os.Lstat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("invalid cache contents remain: %v", err)
+	}
+	if err := validatePublishedAppRoot(root, files); err != nil {
+		t.Fatalf("repaired cache entry is invalid: %v", err)
+	}
+}
+
+func TestExtractAppAssetsRepairsPrunedCacheEntry(t *testing.T) {
+	files := testAppAssets("content")
+	key, err := appassets.ContentHash(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheRoot := filepath.Join(t.TempDir(), "cache")
+	root, err := extractAppAssets(files, key, cacheRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pruned := filepath.Join(root, "docs", "README.md")
+	if err := os.Remove(pruned); err != nil {
+		t.Fatal(err)
+	}
+
+	repairedRoot, err := extractAppAssets(files, key, cacheRoot)
+	if err != nil {
+		t.Fatalf("repair pruned cache entry: %v", err)
+	}
+	if repairedRoot != root {
+		t.Fatalf("repaired root = %q, want %q", repairedRoot, root)
+	}
+	content, err := os.ReadFile(pruned)
+	if err != nil {
+		t.Fatalf("pruned file was not restored: %v", err)
+	}
+	if string(content) != "content" {
+		t.Fatalf("restored content = %q, want %q", content, "content")
+	}
+}
+
+func testAppAssets(docContent string) fstest.MapFS {
+	return fstest.MapFS{
+		".dockerignore":                                 {Data: []byte("bin\n")},
+		"Dockerfile":                                    {Data: []byte("FROM scratch\n")},
+		"Dockerfile.gateway":                            {Data: []byte("FROM scratch\n")},
+		"entrypoint.sh":                                 {Data: []byte("#!/bin/sh\n")},
+		"gateway-entrypoint.sh":                         {Data: []byte("#!/bin/sh\n")},
+		"docs/README.md":                                {Data: []byte(docContent)},
+		"extensions/tools/test/spec.yaml":               {Data: []byte("name: test\n")},
+		"extensions/tools/test/install.sh":              {Data: []byte("#!/bin/sh\n")},
+		"runtime-assets/gateway-allowlists/base.conf":   {Data: []byte("server=/test/1.1.1.1\n")},
+		"runtime-assets/build-scripts/run.sh":           {Data: []byte("#!/bin/sh\n")},
+		"runtime-assets/build-scripts/bin/helper":       {Data: []byte("#!/bin/sh\n")},
+		"runtime-assets/microvm/alpine/build-bundle.sh": {Data: []byte("#!/bin/sh\n")},
+		"runtime-assets/microvm/alpine/init":            {Data: []byte("#!/bin/sh\n")},
+	}
+}
+
+func assertExtractedMode(t *testing.T, root string, rel string, want fs.FileMode) {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("stat %s: %v", rel, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode %s = %#o, want %#o", rel, got, want)
+	}
+}
+
+func entryNames(entries []os.DirEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}

--- a/internal/config/host_roots.go
+++ b/internal/config/host_roots.go
@@ -15,22 +15,12 @@ import (
 	"enclave/internal/model"
 )
 
-// Host-side enclave data is split across four roots — config (user-edited),
-// state (machine-generated), cache (regenerable), and data (app assets) — laid
-// out under the base directories that are standard for the host platform:
-//
-//   - Linux and other Unixes follow the XDG Base Directory Specification,
-//     placing each root under its XDG base (config → ~/.config, state →
-//     ~/.local/state, cache → ~/.cache, data → ~/.local/share) in a "enclave"
-//     subdirectory, honoring the XDG_* environment overrides.
-//   - macOS follows the Apple layout, placing config, state, and data under
-//     ~/Library/Application Support and cache under ~/Library/Caches, in a
-//     subdirectory named with the reverse-DNS application identifier
-//     (model.AppID).
-//
-// The four roots must stay distinct on every platform: cleanup targets live
-// under the state root, and a guard forbids them from resolving under the
-// config root that holds user-edited overrides.
+// Host-side enclave files are split across three roots: config (user-edited),
+// state (machine-generated), and cache (regenerable). Linux and other Unixes
+// follow the XDG Base Directory Specification. macOS uses distinct config and
+// state directories under ~/Library/Application Support and the Apple cache
+// directory under ~/Library/Caches. Cleanup targets live under the state root,
+// and a guard forbids them from resolving under the config root.
 
 func hostConfigRoot(home string) string {
 	if runtime.GOOS == "darwin" {
@@ -53,13 +43,6 @@ func hostCacheRoot(home string) string {
 	return xdgCacheRoot(home)
 }
 
-func hostDataRoot(home string) string {
-	if runtime.GOOS == "darwin" {
-		return macDataRoot(home)
-	}
-	return xdgDataRoot(home)
-}
-
 // XDG base directory resolvers. Each returns the enclave-specific subtree
 // under the corresponding XDG base directory, honoring the XDG_* environment
 // overrides with the spec-mandated fallbacks under home. Per the XDG Base
@@ -78,10 +61,6 @@ func xdgCacheRoot(home string) string {
 	return filepath.Join(xdgBaseDir("XDG_CACHE_HOME", home, ".cache"), model.AppName)
 }
 
-func xdgDataRoot(home string) string {
-	return filepath.Join(xdgBaseDir("XDG_DATA_HOME", home, filepath.Join(".local", "share")), model.AppName)
-}
-
 // xdgBaseDir resolves an XDG base directory. It uses the environment override
 // only when it is set to an absolute path; otherwise it falls back to
 // home/relFallback as mandated by the spec (empty or relative values are
@@ -93,12 +72,11 @@ func xdgBaseDir(envVar string, home string, relFallback string) string {
 	return filepath.Join(home, relFallback)
 }
 
-// macOS base directory resolvers. macOS has no separate state/data bases, so
-// config, state, and data live as distinct subtrees of the reverse-DNS
-// application directory under ~/Library/Application Support, keeping the roots
-// separate as the cleanup guard requires. Regenerable caches follow the Apple
-// convention of ~/Library/Caches. macOS ignores the XDG_* environment
-// overrides, matching platform conventions and the Go standard library.
+// macOS base directory resolvers. Config and state are distinct subtrees of the
+// reverse-DNS application directory under ~/Library/Application Support.
+// Regenerable caches follow the Apple convention of ~/Library/Caches. macOS
+// ignores XDG_* overrides, matching platform conventions and the Go standard
+// library.
 
 func macAppSupportDir(home string) string {
 	return filepath.Join(home, "Library", "Application Support", model.AppID)
@@ -110,10 +88,6 @@ func macConfigRoot(home string) string {
 
 func macStateRoot(home string) string {
 	return filepath.Join(macAppSupportDir(home), "state")
-}
-
-func macDataRoot(home string) string {
-	return filepath.Join(macAppSupportDir(home), "data")
 }
 
 func macCacheRoot(home string) string {

--- a/internal/config/host_roots_test.go
+++ b/internal/config/host_roots_test.go
@@ -26,7 +26,6 @@ func TestXDGRootsFallBackUnderHome(t *testing.T) {
 		{"config", xdgConfigRoot(home), filepath.Join(home, ".config", "enclave")},
 		{"state", xdgStateRoot(home), filepath.Join(home, ".local", "state", "enclave")},
 		{"cache", xdgCacheRoot(home), filepath.Join(home, ".cache", "enclave")},
-		{"data", xdgDataRoot(home), filepath.Join(home, ".local", "share", "enclave")},
 	}
 	for _, tc := range cases {
 		if tc.got != tc.want {
@@ -40,7 +39,6 @@ func TestXDGRootsHonorAbsoluteEnvOverride(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
 	t.Setenv("XDG_STATE_HOME", "/custom/state")
 	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
-	t.Setenv("XDG_DATA_HOME", "/custom/data")
 
 	cases := []struct {
 		name string
@@ -50,7 +48,6 @@ func TestXDGRootsHonorAbsoluteEnvOverride(t *testing.T) {
 		{"config", xdgConfigRoot(home), filepath.Join("/custom/config", "enclave")},
 		{"state", xdgStateRoot(home), filepath.Join("/custom/state", "enclave")},
 		{"cache", xdgCacheRoot(home), filepath.Join("/custom/cache", "enclave")},
-		{"data", xdgDataRoot(home), filepath.Join("/custom/data", "enclave")},
 	}
 	for _, tc := range cases {
 		if tc.got != tc.want {
@@ -81,7 +78,6 @@ func TestMacRootsUseAppleLayout(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
 	t.Setenv("XDG_STATE_HOME", "/custom/state")
 	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
-	t.Setenv("XDG_DATA_HOME", "/custom/data")
 
 	home := "/Users/tester"
 	appSupport := filepath.Join(home, "Library", "Application Support", model.AppID)
@@ -92,7 +88,6 @@ func TestMacRootsUseAppleLayout(t *testing.T) {
 	}{
 		{"config", macConfigRoot(home), filepath.Join(appSupport, "config")},
 		{"state", macStateRoot(home), filepath.Join(appSupport, "state")},
-		{"data", macDataRoot(home), filepath.Join(appSupport, "data")},
 		{"cache", macCacheRoot(home), filepath.Join(home, "Library", "Caches", model.AppID)},
 	}
 	for _, tc := range cases {
@@ -132,7 +127,7 @@ func isUnder(path string, root string) bool {
 // environment does not leak into tests that assert the spec fallbacks.
 func unsetXDGEnv(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{"XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME"} {
+	for _, key := range []string{"XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"} {
 		t.Setenv(key, "")
 	}
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -169,16 +169,11 @@ func discoverAppRoot() (string, error) {
 		return root, nil
 	}
 
-	// Tier 3: host data root (XDG ~/.local/share/enclave on Linux, Apple
-	// data root under ~/Library/Application Support on macOS)
-	if home, homeErr := os.UserHomeDir(); homeErr == nil && home != "" {
-		candidate := hostDataRoot(home)
-		if isAppRoot(candidate) {
-			return candidate, nil
-		}
+	root, err := extractRegisteredAppAssets()
+	if err != nil {
+		return "", fmt.Errorf("extract embedded %s assets: %w", model.AppName, err)
 	}
-
-	return "", fmt.Errorf("unable to locate %s assets; set %s to the repo root", model.AppName, model.EnvHome)
+	return root, nil
 }
 
 func findAppRootFromDir(start string) (string, bool) {

--- a/internal/gateway/gateway_proxy_build_inputs.txt
+++ b/internal/gateway/gateway_proxy_build_inputs.txt
@@ -1,8 +1,9 @@
 # Single source of truth for gateway proxy build inputs.
-# Makefile and debian/rules read this file directly, and the Go runtime embeds it.
+# debian/rules reads this file directly, and embedded-asset tests enforce it.
 go.mod
 go.sum
 cmd/enclave-gateway-proxy
+internal/appassets
 internal/config
 internal/domainpattern
 internal/gateway/bundle

--- a/internal/gateway/gateway_proxy_build_inputs_test.go
+++ b/internal/gateway/gateway_proxy_build_inputs_test.go
@@ -41,13 +41,11 @@ func TestParseGatewayProxyBuildInputsRejectsInvalidEntries(t *testing.T) {
 }
 
 // TestGatewayProxyBuildInputsCoverInternalDeps guards against the manifest
-// drifting out of sync with the proxy's real dependency tree. `make install`
-// and debian/rules stage ONLY the packages listed here and then compile the
-// gateway proxy from that staged subset, so a transitive internal dependency
-// that is missing from the manifest builds fine from the repo but fails the
-// install-time gateway build (this is exactly how internal/secretfile slipped
-// through). Every enclave/internal/* package the proxy links must be covered
-// by some manifest entry.
+// drifting out of sync with the proxy's real dependency tree. debian/rules
+// stages only the packages listed here and then compiles the gateway proxy from
+// that subset. A missing transitive dependency therefore builds from the repo
+// but fails from packaged assets. Every enclave/internal/* package the proxy
+// links must be covered by some manifest entry.
 func TestGatewayProxyBuildInputsCoverInternalDeps(t *testing.T) {
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/internal/legacyassets/cleanup.go
+++ b/internal/legacyassets/cleanup.go
@@ -1,0 +1,280 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+// Package legacyassets safely removes files staged by the former source
+// installation layout.
+package legacyassets
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Result summarizes a cleanup attempt. A skipped cleanup never changes root.
+type Result struct {
+	Removed    int
+	SkipReason string
+}
+
+// Clean removes only files whose exact paths are present in knownAssets. It
+// never follows symlinks, recursively removes a directory, or removes root.
+// Unknown files and non-empty directories are preserved.
+func Clean(root string, home string, knownAssets fs.FS) (Result, error) {
+	var result Result
+	if strings.TrimSpace(root) == "" {
+		return result, fmt.Errorf("legacy asset root is empty")
+	}
+	if strings.TrimSpace(home) == "" {
+		return result, fmt.Errorf("home directory is empty")
+	}
+	if !filepath.IsAbs(root) || !filepath.IsAbs(home) {
+		return result, fmt.Errorf("legacy asset root and home directory must be absolute")
+	}
+	root = filepath.Clean(root)
+	home = filepath.Clean(home)
+	if isFilesystemRoot(root) {
+		return result, fmt.Errorf("refusing to clean filesystem root %s", root)
+	}
+	if root == home {
+		return result, fmt.Errorf("refusing to clean home directory %s", root)
+	}
+	insideHome, err := pathWithin(home, root)
+	if err != nil {
+		return result, err
+	}
+	if !insideHome {
+		return result, fmt.Errorf("refusing to clean %s because it is outside home directory %s", root, home)
+	}
+	if knownAssets == nil {
+		return result, fmt.Errorf("known asset filesystem is nil")
+	}
+
+	if reason, err := unsafeRootReason(home, root); err != nil {
+		return result, err
+	} else if reason != "" {
+		result.SkipReason = reason
+		return result, nil
+	}
+	if !looksLikeLegacyAppRoot(root) {
+		result.SkipReason = "directory is not a complete legacy Enclave asset root"
+		return result, nil
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".git")); err == nil {
+		result.SkipReason = "directory contains .git and may be a source checkout"
+		return result, nil
+	} else if !os.IsNotExist(err) {
+		return result, fmt.Errorf("inspect source-control marker: %w", err)
+	}
+
+	files, directories, err := knownAssetPaths(knownAssets)
+	if err != nil {
+		return result, err
+	}
+	files = append(files, "AGENTS.md", "CLAUDE.md")
+	for _, name := range files {
+		removed, err := removeKnownFile(root, name)
+		if err != nil {
+			return result, err
+		}
+		if removed {
+			result.Removed++
+		}
+	}
+	for _, name := range directories {
+		removed, err := removeKnownDirectoryIfEmpty(root, name)
+		if err != nil {
+			return result, err
+		}
+		if removed {
+			result.Removed++
+		}
+	}
+	return result, nil
+}
+
+func isFilesystemRoot(name string) bool {
+	volume := filepath.VolumeName(name)
+	return name == volume+string(filepath.Separator)
+}
+
+func pathWithin(parent string, child string) (bool, error) {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false, fmt.Errorf("compare cleanup paths: %w", err)
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)), nil
+}
+
+func unsafeRootReason(home string, root string) (string, error) {
+	homeInfo, err := os.Lstat(home)
+	if os.IsNotExist(err) {
+		return "home directory does not exist", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("inspect home directory %s: %w", home, err)
+	}
+	if homeInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Sprintf("home directory %s is a symlink", home), nil
+	}
+	if !homeInfo.IsDir() {
+		return fmt.Sprintf("home path %s is not a directory", home), nil
+	}
+
+	rel, err := filepath.Rel(home, root)
+	if err != nil {
+		return "", fmt.Errorf("resolve legacy asset root relative to home: %w", err)
+	}
+	current := home
+	for _, component := range strings.Split(rel, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			return "legacy asset root does not exist", nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("inspect legacy asset path %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Sprintf("legacy asset path %s is a symlink", current), nil
+		}
+		if !info.IsDir() {
+			return fmt.Sprintf("legacy asset path %s is not a directory", current), nil
+		}
+	}
+	return "", nil
+}
+
+func looksLikeLegacyAppRoot(root string) bool {
+	for _, name := range []string{"Dockerfile", "Dockerfile.gateway", "entrypoint.sh", "gateway-entrypoint.sh"} {
+		info, err := os.Lstat(filepath.Join(root, name))
+		if err != nil || !info.Mode().IsRegular() {
+			return false
+		}
+	}
+	for _, name := range []string{"extensions", "runtime-assets"} {
+		info, err := os.Lstat(filepath.Join(root, name))
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func knownAssetPaths(knownAssets fs.FS) ([]string, []string, error) {
+	var files []string
+	var directories []string
+	err := fs.WalkDir(knownAssets, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if name == "." {
+			return nil
+		}
+		if !fs.ValidPath(name) {
+			return fmt.Errorf("invalid known asset path %q", name)
+		}
+		if entry.IsDir() {
+			directories = append(directories, name)
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("known asset %s is not a regular file", name)
+		}
+		files = append(files, name)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("enumerate known legacy assets: %w", err)
+	}
+	sort.Strings(files)
+	sort.Slice(directories, func(i int, j int) bool {
+		leftDepth := strings.Count(directories[i], "/")
+		rightDepth := strings.Count(directories[j], "/")
+		if leftDepth != rightDepth {
+			return leftDepth > rightDepth
+		}
+		return directories[i] > directories[j]
+	})
+	return files, directories, nil
+}
+
+func removeKnownFile(root string, name string) (bool, error) {
+	target, safe, err := safeTarget(root, name)
+	if err != nil || !safe {
+		return false, err
+	}
+	info, err := os.Lstat(target)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect legacy asset %s: %w", target, err)
+	}
+	if !info.Mode().IsRegular() {
+		return false, nil
+	}
+	if err := os.Remove(target); err != nil {
+		return false, fmt.Errorf("remove legacy asset %s: %w", target, err)
+	}
+	return true, nil
+}
+
+func removeKnownDirectoryIfEmpty(root string, name string) (bool, error) {
+	target, safe, err := safeTarget(root, name)
+	if err != nil || !safe {
+		return false, err
+	}
+	info, err := os.Lstat(target)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect legacy asset directory %s: %w", target, err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false, nil
+	}
+	if err := os.Remove(target); err != nil {
+		// A non-empty directory is expected when it contains an unknown file. It
+		// is safer to preserve any failed directory removal than to classify
+		// platform-specific ENOTEMPTY errors and retry recursively.
+		if current, statErr := os.Lstat(target); statErr == nil && current.IsDir() {
+			return false, nil
+		}
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("remove empty legacy asset directory %s: %w", target, err)
+	}
+	return true, nil
+}
+
+func safeTarget(root string, name string) (string, bool, error) {
+	if !fs.ValidPath(name) || name == "." {
+		return "", false, fmt.Errorf("invalid known asset path %q", name)
+	}
+	parts := strings.Split(name, "/")
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		current = filepath.Join(current, filepath.FromSlash(part))
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		if err != nil {
+			return "", false, fmt.Errorf("inspect legacy asset parent %s: %w", current, err)
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return "", false, nil
+		}
+	}
+	return filepath.Join(root, filepath.FromSlash(name)), true, nil
+}

--- a/internal/legacyassets/cleanup_test.go
+++ b/internal/legacyassets/cleanup_test.go
@@ -1,0 +1,213 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package legacyassets
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"testing/fstest"
+)
+
+func TestCleanRemovesOnlyKnownFilesAndEmptyDirectories(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".local", "share", "enclave")
+	known := cleanupTestAssets()
+	writeKnownAssets(t, root, known)
+
+	unknownRoot := filepath.Join(root, "keep-me.txt")
+	unknownNested := filepath.Join(root, "extensions", "tools", "custom", "user-file")
+	writeCleanupFile(t, unknownRoot, "root sentinel")
+	writeCleanupFile(t, unknownNested, "nested sentinel")
+	writeCleanupFile(t, filepath.Join(root, "AGENTS.md"), "old staged file")
+
+	result, err := Clean(root, home, known)
+	if err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	if result.SkipReason != "" {
+		t.Fatalf("cleanup was skipped: %s", result.SkipReason)
+	}
+	if result.Removed == 0 {
+		t.Fatal("cleanup removed no known assets")
+	}
+	for _, name := range []string{"Dockerfile", "entrypoint.sh", "docs/README.md", "AGENTS.md"} {
+		if _, err := os.Lstat(filepath.Join(root, filepath.FromSlash(name))); !os.IsNotExist(err) {
+			t.Errorf("known asset %s remains", name)
+		}
+	}
+	assertCleanupContent(t, unknownRoot, "root sentinel")
+	assertCleanupContent(t, unknownNested, "nested sentinel")
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("cleanup removed root: %v", err)
+	}
+}
+
+func TestCleanDoesNotFollowSymlinkInsideAssetTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require elevated privileges on Windows")
+	}
+	home := t.TempDir()
+	root := filepath.Join(home, ".local", "share", "enclave")
+	known := cleanupTestAssets()
+	writeKnownAssets(t, root, known)
+
+	outside := t.TempDir()
+	victim := filepath.Join(outside, "asset.txt")
+	writeCleanupFile(t, victim, "outside")
+	linkedDir := filepath.Join(root, "extensions", "tools", "linked")
+	if err := os.RemoveAll(linkedDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, linkedDir); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Clean(root, home, known)
+	if err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	if result.SkipReason != "" {
+		t.Fatalf("cleanup was skipped: %s", result.SkipReason)
+	}
+	assertCleanupContent(t, victim, "outside")
+	info, err := os.Lstat(linkedDir)
+	if err != nil {
+		t.Fatalf("nested symlink was removed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("nested path mode = %v, want symlink", info.Mode())
+	}
+}
+
+func TestCleanSkipsSymlinkedRootPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require elevated privileges on Windows")
+	}
+	home := t.TempDir()
+	outside := t.TempDir()
+	known := cleanupTestAssets()
+	writeKnownAssets(t, outside, known)
+	linkParent := filepath.Join(home, ".local", "share")
+	if err := os.MkdirAll(linkParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(linkParent, "enclave")
+	if err := os.Symlink(outside, root); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Clean(root, home, known)
+	if err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	if result.SkipReason == "" {
+		t.Fatal("expected symlinked root to be skipped")
+	}
+	assertCleanupContent(t, filepath.Join(outside, "Dockerfile"), "Dockerfile")
+}
+
+func TestCleanSkipsSourceCheckoutAndIncompleteRoot(t *testing.T) {
+	home := t.TempDir()
+	known := cleanupTestAssets()
+
+	checkout := filepath.Join(home, "checkout")
+	writeKnownAssets(t, checkout, known)
+	if err := os.Mkdir(filepath.Join(checkout, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Clean(checkout, home, known)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SkipReason == "" {
+		t.Fatal("expected source checkout to be skipped")
+	}
+	assertCleanupContent(t, filepath.Join(checkout, "Dockerfile"), "Dockerfile")
+
+	incomplete := filepath.Join(home, "incomplete")
+	writeCleanupFile(t, filepath.Join(incomplete, "Dockerfile"), "unrelated")
+	result, err = Clean(incomplete, home, known)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SkipReason == "" {
+		t.Fatal("expected incomplete root to be skipped")
+	}
+	assertCleanupContent(t, filepath.Join(incomplete, "Dockerfile"), "unrelated")
+}
+
+func TestCleanRejectsDangerousRoots(t *testing.T) {
+	home := t.TempDir()
+	known := cleanupTestAssets()
+	for _, root := range []string{"", home, filepath.Dir(home), string(filepath.Separator)} {
+		if _, err := Clean(root, home, known); err == nil {
+			t.Errorf("Clean(%q) succeeded", root)
+		}
+	}
+}
+
+func cleanupTestAssets() fstest.MapFS {
+	return fstest.MapFS{
+		"Dockerfile":                             {Data: []byte("Dockerfile")},
+		"Dockerfile.gateway":                     {Data: []byte("Dockerfile.gateway")},
+		"entrypoint.sh":                          {Data: []byte("entrypoint.sh")},
+		"gateway-entrypoint.sh":                  {Data: []byte("gateway-entrypoint.sh")},
+		"docs/README.md":                         {Data: []byte("docs")},
+		"extensions/tools/demo/spec.yaml":        {Data: []byte("demo")},
+		"extensions/tools/linked/asset.txt":      {Data: []byte("linked")},
+		"runtime-assets/gateway-allowlists/base": {Data: []byte("base")},
+	}
+}
+
+func writeKnownAssets(t *testing.T, root string, known fs.FS) {
+	t.Helper()
+	err := fs.WalkDir(known, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || name == "." {
+			return walkErr
+		}
+		target := filepath.Join(root, filepath.FromSlash(name))
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		content, err := fs.ReadFile(known, name)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, content, 0o644)
+	})
+	if err != nil {
+		t.Fatalf("write known assets: %v", err)
+	}
+}
+
+func writeCleanupFile(t *testing.T, name string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(name, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertCleanupContent(t *testing.T, name string, want string) {
+	t.Helper()
+	content, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read preserved file %s: %v", name, err)
+	}
+	if string(content) != want {
+		t.Fatalf("preserved file %s = %q, want %q", name, content, want)
+	}
+}

--- a/internal/util/lock.go
+++ b/internal/util/lock.go
@@ -10,7 +10,6 @@ package util
 import (
 	"os"
 	"path/filepath"
-	"syscall"
 )
 
 // WithFileLock runs fn while holding an exclusive lock on path.
@@ -27,12 +26,9 @@ func WithFileLock(path string, fn func() error) error {
 		return err
 	}
 	defer func() { _ = file.Close() }()
-	// #nosec G115 -- file descriptor from os.File.Fd() fits in int on all supported platforms.
-	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+	if err := lockFile(file); err != nil {
 		return err
 	}
-	defer func() {
-		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN) // #nosec G115
-	}()
+	defer func() { _ = unlockFile(file) }()
 	return fn()
 }

--- a/internal/util/lock_unix.go
+++ b/internal/util/lock_unix.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package util
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(file *os.File) error {
+	// #nosec G115 -- file descriptor from os.File.Fd() fits in int on supported Unix platforms.
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN) // #nosec G115
+}

--- a/internal/util/lock_windows.go
+++ b/internal/util/lock_windows.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package util
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped)
+}
+
+func unlockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+}

--- a/scripts/lint-changed.sh
+++ b/scripts/lint-changed.sh
@@ -55,12 +55,16 @@ sh_files=""
 for f in $changed; do
     case "$f" in
         *.go)
-            # Only include .go files under LINT_GO_DIRS
-            for dir in $LINT_GO_DIRS; do
-                case "$f" in
-                    "$dir"/*) go_files="$go_files $f"; break ;;
-                esac
-            done
+            # Root package files and Go files under LINT_GO_DIRS are linted.
+            if [[ "$f" != */* ]]; then
+                go_files="$go_files $f"
+            else
+                for dir in $LINT_GO_DIRS; do
+                    case "$f" in
+                        "$dir"/*) go_files="$go_files $f"; break ;;
+                    esac
+                done
+            fi
             ;;
         *.sh | runtime-assets/build-scripts/bin/*)
             [ -f "$f" ] && sh_files="$sh_files $f"
@@ -94,7 +98,9 @@ if [ -n "$go_pkgs" ]; then
 
     echo "Running golangci-lint..."
     for pkg in $go_pkgs; do
-        if ! golangci-lint run "$pkg/..."; then
+        target="$pkg/..."
+        [ "$pkg" = "./." ] && target="."
+        if ! golangci-lint run "$target"; then
             rc=1
         fi
     done

--- a/scripts/smoke-standalone-binary.sh
+++ b/scripts/smoke-standalone-binary.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 EclipseSource GmbH and others.
+#
+# This program and the accompanying materials are made available under the
+# terms of the MIT License, which is available in the project root.
+#
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+binary=${1:?usage: smoke-standalone-binary.sh <binary>}
+if [[ "$binary" != /* ]]; then
+    binary="$(pwd)/$binary"
+fi
+
+sandbox=$(mktemp -d)
+trap 'rm -rf "$sandbox"' EXIT
+mkdir -p "$sandbox/home" "$sandbox/run" "$sandbox/cwd"
+cp "$binary" "$sandbox/run/enclave"
+
+# A complete unversioned root from an older make install must not win.
+legacy="$sandbox/data/enclave"
+mkdir -p "$legacy/extensions/tools" "$legacy/extensions/features" \
+    "$legacy/runtime-assets/gateway-allowlists" \
+    "$legacy/runtime-assets/build-scripts" "$legacy/docs"
+touch "$legacy/.dockerignore" "$legacy/Dockerfile" \
+    "$legacy/Dockerfile.gateway" "$legacy/entrypoint.sh" \
+    "$legacy/gateway-entrypoint.sh"
+
+pids=()
+for _ in $(seq 1 8); do
+    (
+        cd "$sandbox/cwd"
+        HOME="$sandbox/home" \
+            XDG_CONFIG_HOME="$sandbox/config" \
+            XDG_STATE_HOME="$sandbox/state" \
+            XDG_CACHE_HOME="$sandbox/cache" \
+            XDG_DATA_HOME="$sandbox/data" \
+            "$sandbox/run/enclave" tools >/dev/null
+    ) &
+    pids+=("$!")
+done
+for pid in "${pids[@]}"; do
+    wait "$pid"
+done
+
+assets="$sandbox/cache/enclave/assets"
+mapfile -t roots < <(find "$assets" -mindepth 1 -maxdepth 1 -type d)
+if (( ${#roots[@]} != 1 )); then
+    printf 'expected one extracted asset cache entry, found %d\n' "${#roots[@]}" >&2
+    exit 1
+fi
+root=${roots[0]}
+test -f "$root/.dockerignore"
+test -f "$root/docs/README.md"
+test -f "$root/internal/gateway/mitm/proxy.go"
+test -x "$root/entrypoint.sh"
+test -x "$root/gateway-entrypoint.sh"
+test -x "$root/runtime-assets/build-scripts/bin/enclave-install-tool"
+test ! -e "$root/AGENTS.md"
+test ! -e "$root/CLAUDE.md"
+
+rm "$root/docs/README.md"
+(
+    cd "$sandbox/cwd"
+    HOME="$sandbox/home" \
+        XDG_CONFIG_HOME="$sandbox/config" \
+        XDG_STATE_HOME="$sandbox/state" \
+        XDG_CACHE_HOME="$sandbox/cache" \
+        XDG_DATA_HOME="$sandbox/data" \
+        "$sandbox/run/enclave" tools >/dev/null
+)
+test -f "$root/docs/README.md"


### PR DESCRIPTION

## Summary

To start Enclave, users currently need the `enclave` executable and additional runtime assets, such as build context, extensions, docs, and gateway proxy sources.
While the debian package or a `make install` take care of providing these artifacts, the standalone binary produced by our CI workflow does not.
Instead of offering a tarball and leaving the asset installation to the user, we now produce a self-contained `enclave` binary that contains its runtime assets.

This patch does the following:
- Embed the runtime asset tree () in the `enclave` binary. A binary with no asset tree adjacent to its
  executable (downloaded release binary, `make install`, `go install`)
  extracts them atomically into a content-keyed cache directory
  (`~/.cache/enclave/assets/<hash>/`), making it a complete installation.
- Asset discovery drops the previous data-root tier; deb installs and in-tree
  dev builds resolve exactly as before. `make install` now installs only
  the binary and conservatively removes known files staged by older source
  installs
- The rolling release publishes the self-contained `enclave-linux-amd64`
  and smoke-tests extraction (concurrent first runs, exec bits) in CI.

## Test plan

- [ ] `./scripts/smoke-standalone-binary.sh ./enclave` (also runs in CI)
- [ ] `make build && ./bin/enclave` uses live worktree assets and does not touch assets in cache
- [ ]  The debian package continues to use its installed worktree assets is `/usr/share/enclave/` and does not touch assets in cache
- [ ] A copied binary outside the checkout extracts to the cache and runs