### PR TITLE
docs: update SECURITY.md to Eclipse security-handbook template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,34 +1,30 @@
 # Security Policy
 
-Eclipse Enclave adheres to the [Eclipse Foundation Vulnerability Reporting
-Policy](https://www.eclipse.org/security/policy/).
+This Eclipse Foundation Project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
 
-## How to Report a Vulnerability
+## How To Report a Vulnerability
 
-If you believe you have found a vulnerability, report it through coordinated
-disclosure.
+If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
 
-**Do not report security vulnerabilities through public issues, discussions,
-or pull requests.**
+**Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
 
-Instead, use one of these private channels:
+Instead, please create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker.
 
-- Email the [Eclipse Foundation Security
-  Team](mailto:security@eclipse-foundation.org).
-- Create a [confidential issue in the Eclipse Foundation Vulnerability
-  Reporting
-  Tracker](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability).
+You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
 
-See the [Eclipse Foundation Security page](https://www.eclipse.org/security/)
-for more information about reporting and disclosure.
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
 
-Include as much of the following information as possible:
+* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+* Affected version(s)
+* Impact of the issue, including how an attacker might exploit the issue
+* Step-by-step instructions to reproduce the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Full paths of source file(s) related to the manifestation of the issue
+* Configuration required to reproduce the issue
+* Log files that are related to this issue (if possible)
+* Proof-of-concept or exploit code (if possible)
 
-- The type and impact of the issue.
-- Affected versions, branches, or commits.
-- Steps and configuration required to reproduce it.
-- The relevant source file locations.
-- Related log files, proof-of-concept code, or exploit code when available.
+This information will help us triage your report more quickly.
 
 ## Supported Versions
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Replaces the legacy "Security Policy" with the standardized [eclipse-csi security-handbook](https://github.com/eclipse-csi/security-handbook/blob/main/templates/SECURITY.md) `SECURITY.md` template. This reflects the Eclipse Foundation Security Team no longer accepting vulnerability reports by email.

- Adopt the eclipse-csi security-handbook template for coordinated vulnerability disclosure
- Report vulnerabilities via the Eclipse Foundation confidential issue tracker (email reporting is no longer accepted by the Foundation)

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Pure doc change, please proofread

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
