### PR TITLE
Preserve config store timestamps during overlay

### DIFF
--- a/internal/backend/docker/overlay.go
+++ b/internal/backend/docker/overlay.go
@@ -57,7 +57,8 @@ func overlayConfigDir(targetDir string, sourceDir string, preservePaths []string
 // enumerated separately: checking ancestor matches instead of preserve staging
 // existence avoids treating an unrelated sibling as already handled.
 func stagePreservedPaths(targetDir string, preserveDir string, preservePaths []string) error {
-	return filepath.WalkDir(targetDir, func(p string, _ fs.DirEntry, err error) error {
+	stagedParents := make(map[string]struct{})
+	if err := filepath.WalkDir(targetDir, func(p string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -72,8 +73,54 @@ func stagePreservedPaths(targetDir string, preserveDir string, preservePaths []s
 		if !preserveMatch(rel, preservePaths) || preserveHasMatchingParent(rel, preservePaths) {
 			return nil
 		}
+		if err := stageParentDirs(targetDir, preserveDir, rel, stagedParents); err != nil {
+			return err
+		}
 		return copyPath(p, filepath.Join(preserveDir, filepath.FromSlash(rel)))
-	})
+	}); err != nil {
+		return err
+	}
+	return stampStagedParentTimes(targetDir, preserveDir, stagedParents)
+}
+
+// stageParentDirs creates rel's ancestor directories under preserveDir with the
+// permissions of their targetDir counterparts, recording each one in staged.
+// Without this, copyPath creates them on the way to a nested preserved node as
+// 0o700 directories stamped with the current time, and the restore step copies
+// those substitutes back over the store.
+func stageParentDirs(targetDir string, preserveDir string, rel string, staged map[string]struct{}) error {
+	var parents []string
+	for parent := parentPath(rel); parent != ""; parent = parentPath(parent) {
+		parents = append(parents, parent)
+	}
+	// Outermost first, so each MkdirAll applies its own source permissions.
+	for i := len(parents) - 1; i >= 0; i-- {
+		info, err := os.Lstat(filepath.Join(targetDir, filepath.FromSlash(parents[i])))
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Join(preserveDir, filepath.FromSlash(parents[i])), info.Mode().Perm()); err != nil {
+			return err
+		}
+		staged[parents[i]] = struct{}{}
+	}
+	return nil
+}
+
+// stampStagedParentTimes applies the store modification times to the staged
+// ancestor directories. It runs after all staging copies so that populating a
+// directory does not bump the time again.
+func stampStagedParentTimes(targetDir string, preserveDir string, staged map[string]struct{}) error {
+	for parent := range staged {
+		info, err := os.Lstat(filepath.Join(targetDir, filepath.FromSlash(parent)))
+		if err != nil {
+			return err
+		}
+		if err := os.Chtimes(filepath.Join(preserveDir, filepath.FromSlash(parent)), info.ModTime(), info.ModTime()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // preserveMatch reports whether rel matches any preserve pattern, using the
@@ -109,7 +156,8 @@ func parentPath(rel string) string {
 
 // copyPath copies src (file, directory tree, or symlink) to dst, replicating
 // `cp -a`: symlinks are recreated as symlinks (not dereferenced), directories
-// are merged into dst, and file permissions are carried over.
+// are merged into dst, and permissions and modification times are carried over
+// for files and directories. Symlinks keep the link itself, not its times.
 func copyPath(src string, dst string) error {
 	info, err := os.Lstat(src)
 	if err != nil {

--- a/internal/backend/docker/overlay.go
+++ b/internal/backend/docker/overlay.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"enclave/internal/config"
 )
@@ -130,9 +131,9 @@ func copyPath(src string, dst string) error {
 				return err
 			}
 		}
-		return nil
+		return os.Chtimes(dst, info.ModTime(), info.ModTime())
 	default:
-		return copyRegularFile(src, dst, info.Mode().Perm())
+		return copyRegularFile(src, dst, info.Mode().Perm(), info.ModTime())
 	}
 }
 
@@ -150,7 +151,7 @@ func copySymlink(src string, dst string) error {
 	return os.Symlink(target, dst)
 }
 
-func copyRegularFile(src string, dst string, mode fs.FileMode) error {
+func copyRegularFile(src string, dst string, mode fs.FileMode, modTime time.Time) error {
 	data, err := os.ReadFile(src) // #nosec G304 -- src is within the enclave config store being overlaid.
 	if err != nil {
 		return err
@@ -158,7 +159,10 @@ func copyRegularFile(src string, dst string, mode fs.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(dst, data, mode) // #nosec G703 -- dst is within the runtime-managed config store overlay.
+	if err := os.WriteFile(dst, data, mode); err != nil { // #nosec G703 -- dst is within the runtime-managed config store overlay.
+		return err
+	}
+	return os.Chtimes(dst, modTime, modTime)
 }
 
 // clearDirContents removes every entry inside dir while keeping dir itself.

--- a/internal/backend/docker/overlay_test.go
+++ b/internal/backend/docker/overlay_test.go
@@ -258,6 +258,65 @@ func TestOverlayConfigDirPreservesModificationTimes(t *testing.T) {
 	}
 }
 
+func TestOverlayConfigDirPreservesModificationTimesOfNestedPreserveParents(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	targetDir := filepath.Join(root, "target")
+	// agent/sessions/ is a nested preserve pattern, so agent/ exists in the
+	// store only as a directory on the way to the preserved node.
+	agentDir := filepath.Join(targetDir, "agent")
+	sessionDir := filepath.Join(agentDir, "sessions")
+	transcriptPath := filepath.Join(sessionDir, "resume.jsonl")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "settings.json"), []byte("new"), 0o600); err != nil {
+		t.Fatalf("write source settings: %v", err)
+	}
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	if err := os.WriteFile(transcriptPath, []byte(`{"id":"keep"}`), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	oldTime := time.Date(2025, time.January, 2, 3, 4, 5, 123456789, time.UTC)
+	for _, p := range []string{transcriptPath, sessionDir, agentDir} {
+		if err := os.Chtimes(p, oldTime, oldTime); err != nil {
+			t.Fatalf("set timestamps on %s: %v", p, err)
+		}
+	}
+	agentDirBefore, err := os.Stat(agentDir)
+	if err != nil {
+		t.Fatalf("stat agent directory before overlay: %v", err)
+	}
+
+	profile := model.Profile{Name: "pi"}
+	if err := overlayConfigDir(targetDir, sourceDir, yaruntime.ConfigSourcePreservePaths(profile)); err != nil {
+		t.Fatalf("overlay failed: %v", err)
+	}
+
+	transcript, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatalf("read preserved transcript: %v", err)
+	}
+	if string(transcript) != `{"id":"keep"}` {
+		t.Fatalf("preserved transcript = %q", transcript)
+	}
+	agentDirAfter, err := os.Stat(agentDir)
+	if err != nil {
+		t.Fatalf("stat agent directory after overlay: %v", err)
+	}
+	if !agentDirAfter.ModTime().Equal(agentDirBefore.ModTime()) {
+		t.Fatalf("agent directory mtime = %v, want %v", agentDirAfter.ModTime(), agentDirBefore.ModTime())
+	}
+	if agentDirAfter.Mode().Perm() != agentDirBefore.Mode().Perm() {
+		t.Fatalf("agent directory mode = %v, want %v", agentDirAfter.Mode().Perm(), agentDirBefore.Mode().Perm())
+	}
+}
+
 func TestOverlayConfigDirPreservesRuntimeState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/docker/overlay_test.go
+++ b/internal/backend/docker/overlay_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"enclave/internal/model"
 	yaruntime "enclave/internal/runtime"
@@ -182,6 +183,78 @@ func TestOverlayConfigDirPreservesDevcontainerStamps(t *testing.T) {
 	}
 	if string(freshSettings) != `{"source":"fresh"}` {
 		t.Fatalf("unexpected fresh settings content: %s", string(freshSettings))
+	}
+}
+
+func TestOverlayConfigDirPreservesModificationTimes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "source")
+	targetDir := filepath.Join(root, "target")
+	sessionDir := filepath.Join(targetDir, "projects", "repo")
+	transcriptPath := filepath.Join(sessionDir, "session.jsonl")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "settings.json"), []byte("new"), 0o600); err != nil {
+		t.Fatalf("write source settings: %v", err)
+	}
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	if err := os.WriteFile(transcriptPath, []byte(`{"session":"keep"}`), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	oldTime := time.Date(2025, time.January, 2, 3, 4, 5, 123456789, time.UTC)
+	if err := os.Chtimes(transcriptPath, oldTime, oldTime); err != nil {
+		t.Fatalf("set transcript timestamps: %v", err)
+	}
+	if err := os.Chtimes(sessionDir, oldTime, oldTime); err != nil {
+		t.Fatalf("set session directory timestamps: %v", err)
+	}
+	transcriptBefore, err := os.Stat(transcriptPath)
+	if err != nil {
+		t.Fatalf("stat transcript before overlay: %v", err)
+	}
+	sessionDirBefore, err := os.Stat(sessionDir)
+	if err != nil {
+		t.Fatalf("stat session directory before overlay: %v", err)
+	}
+
+	profile := model.Profile{Name: "claude"}
+	if err := overlayConfigDir(targetDir, sourceDir, yaruntime.ConfigSourcePreservePaths(profile)); err != nil {
+		t.Fatalf("overlay failed: %v", err)
+	}
+
+	settings, err := os.ReadFile(filepath.Join(targetDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read overlaid settings: %v", err)
+	}
+	if string(settings) != "new" {
+		t.Fatalf("overlaid settings = %q, want new", settings)
+	}
+	transcript, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatalf("read preserved transcript: %v", err)
+	}
+	if string(transcript) != `{"session":"keep"}` {
+		t.Fatalf("preserved transcript = %q", transcript)
+	}
+	transcriptAfter, err := os.Stat(transcriptPath)
+	if err != nil {
+		t.Fatalf("stat transcript after overlay: %v", err)
+	}
+	if !transcriptAfter.ModTime().Equal(transcriptBefore.ModTime()) {
+		t.Fatalf("transcript mtime = %v, want %v", transcriptAfter.ModTime(), transcriptBefore.ModTime())
+	}
+	sessionDirAfter, err := os.Stat(sessionDir)
+	if err != nil {
+		t.Fatalf("stat session directory after overlay: %v", err)
+	}
+	if !sessionDirAfter.ModTime().Equal(sessionDirBefore.ModTime()) {
+		t.Fatalf("session directory mtime = %v, want %v", sessionDirAfter.ModTime(), sessionDirBefore.ModTime())
 	}
 }
 

--- a/internal/backend/docker/storage.go
+++ b/internal/backend/docker/storage.go
@@ -208,6 +208,8 @@ func seedStorePath(src string, target string, mode fs.FileMode) error {
 // destination node is not a pre-existing symlink before creating a directory or
 // writing a file at that path. Source symlinks are dereferenced (via os.Stat)
 // as before; only destination symlinks are the escape risk and are rejected.
+// Permissions and modification times are carried over, matching the qemu
+// backend's seed copy.
 func copyTreeNoFollow(src string, dst string) error {
 	if err := rejectExistingSymlink(dst); err != nil {
 		return err
@@ -229,13 +231,17 @@ func copyTreeNoFollow(src string, dst string) error {
 				return err
 			}
 		}
-		return nil
+		// After the children, so populating dst does not bump its time again.
+		return os.Chtimes(dst, info.ModTime(), info.ModTime())
 	}
 	data, err := os.ReadFile(src) // #nosec G304 -- src is a caller-provided seed source path.
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(dst, data, info.Mode().Perm()) // #nosec G703 -- dst is validated against destination symlinks before copying.
+	if err := os.WriteFile(dst, data, info.Mode().Perm()); err != nil { // #nosec G703 -- dst is validated against destination symlinks before copying.
+		return err
+	}
+	return os.Chtimes(dst, info.ModTime(), info.ModTime())
 }
 
 // rejectExistingSymlink returns an error when p already exists and is a

--- a/internal/backend/docker/storage_test.go
+++ b/internal/backend/docker/storage_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"enclave/internal/backend"
 	"enclave/internal/config"
@@ -135,6 +136,45 @@ func TestStoreManagerSeedCopiesFilesAndDirsAndAppliesMode(t *testing.T) {
 	}
 	if string(nested) != "hi" {
 		t.Fatalf("seeded tree file = %q, want %q", nested, "hi")
+	}
+}
+
+func TestStoreManagerSeedPreservesModificationTimes(t *testing.T) {
+	store := newFSStore(t)
+	key := backend.StoreKey{Owner: "codex", ProjectHash: "abc123abc123"}
+
+	srcRoot := t.TempDir()
+	dirSrc := filepath.Join(srcRoot, "tree")
+	nestedSrc := filepath.Join(dirSrc, "nested")
+	fileSrc := filepath.Join(nestedSrc, "a.txt")
+	if err := os.MkdirAll(nestedSrc, 0o755); err != nil {
+		t.Fatalf("mkdir seed tree: %v", err)
+	}
+	if err := os.WriteFile(fileSrc, []byte("hi"), 0o600); err != nil {
+		t.Fatalf("write seed tree file: %v", err)
+	}
+	oldTime := time.Date(2025, time.January, 2, 3, 4, 5, 123456789, time.UTC)
+	for _, p := range []string{fileSrc, nestedSrc, dirSrc} {
+		if err := os.Chtimes(p, oldTime, oldTime); err != nil {
+			t.Fatalf("set timestamps on %s: %v", p, err)
+		}
+	}
+
+	if err := store.Seed(context.Background(), key, backend.StoreKindConfig, []backend.SeedItem{
+		{HostPath: dirSrc, StoreRel: "agent/tree"},
+	}); err != nil {
+		t.Fatalf("Seed() error = %v", err)
+	}
+
+	base := config.HostStoreConfigDir(store.host.Home, key.Owner, key.ProjectHash, "default")
+	for _, rel := range []string{"agent/tree", "agent/tree/nested", "agent/tree/nested/a.txt"} {
+		info, err := os.Stat(filepath.Join(base, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("stat seeded %s: %v", rel, err)
+		}
+		if !info.ModTime().Equal(oldTime) {
+			t.Fatalf("seeded %s mtime = %v, want %v", rel, info.ModTime(), oldTime)
+		}
 	}
 }
 

--- a/internal/backend/qemu/storage.go
+++ b/internal/backend/qemu/storage.go
@@ -295,9 +295,12 @@ func copyPath(src string, dst string, mode fs.FileMode) error {
 				return err
 			}
 		}
-		return nil
+		return os.Chtimes(dst, info.ModTime(), info.ModTime())
 	default:
-		return copyFile(src, dst, firstNonZeroMode(mode, info.Mode().Perm()))
+		if err := copyFile(src, dst, firstNonZeroMode(mode, info.Mode().Perm())); err != nil {
+			return err
+		}
+		return os.Chtimes(dst, info.ModTime(), info.ModTime())
 	}
 }
 

--- a/internal/backend/qemu/storage_test.go
+++ b/internal/backend/qemu/storage_test.go
@@ -12,10 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"enclave/internal/backend"
 	"enclave/internal/config"
 	"enclave/internal/model"
+	yaruntime "enclave/internal/runtime"
 )
 
 func TestStoreManagerReadWriteRemove(t *testing.T) {
@@ -154,6 +156,84 @@ func TestPrepareStoresConfigOverlayPreservesAuthFiles(t *testing.T) {
 	}
 	if string(settings) != "new" {
 		t.Fatalf("settings = %q, want new", settings)
+	}
+}
+
+func TestPrepareStoresConfigOverlayPreservesModificationTimes(t *testing.T) {
+	be := New(Options{Host: model.Host{Home: t.TempDir()}})
+	key := backend.StoreKey{Owner: "claude", ProjectHash: "abc123def456"}
+	ctx := context.Background()
+
+	root, err := be.storage.MountSource(key, backend.StoreKindConfig)
+	if err != nil {
+		t.Fatalf("mount source: %v", err)
+	}
+	sessionDir := filepath.Join(root, "projects", "repo")
+	transcriptPath := filepath.Join(sessionDir, "session.jsonl")
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	if err := os.WriteFile(transcriptPath, []byte(`{"session":"keep"}`), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	oldTime := time.Date(2025, time.January, 2, 3, 4, 5, 123456789, time.UTC)
+	if err := os.Chtimes(transcriptPath, oldTime, oldTime); err != nil {
+		t.Fatalf("set transcript timestamps: %v", err)
+	}
+	if err := os.Chtimes(sessionDir, oldTime, oldTime); err != nil {
+		t.Fatalf("set session directory timestamps: %v", err)
+	}
+	transcriptBefore, err := os.Stat(transcriptPath)
+	if err != nil {
+		t.Fatalf("stat transcript before overlay: %v", err)
+	}
+	sessionDirBefore, err := os.Stat(sessionDir)
+	if err != nil {
+		t.Fatalf("stat session directory before overlay: %v", err)
+	}
+
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "settings.json"), []byte("new"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if _, err := be.PrepareStores(ctx, backend.StorePrep{Config: &backend.ConfigStorePrep{
+		Key: key,
+		Overlay: &backend.ConfigOverlaySpec{
+			SourceDir:     source,
+			PreservePaths: yaruntime.ConfigSourcePreservePaths(model.Profile{Name: "claude"}),
+		},
+	}}); err != nil {
+		t.Fatalf("PrepareStores: %v", err)
+	}
+
+	settings, err := os.ReadFile(filepath.Join(root, "settings.json"))
+	if err != nil {
+		t.Fatalf("read overlaid settings: %v", err)
+	}
+	if string(settings) != "new" {
+		t.Fatalf("overlaid settings = %q, want new", settings)
+	}
+	transcript, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatalf("read preserved transcript: %v", err)
+	}
+	if string(transcript) != `{"session":"keep"}` {
+		t.Fatalf("preserved transcript = %q", transcript)
+	}
+	transcriptAfter, err := os.Stat(transcriptPath)
+	if err != nil {
+		t.Fatalf("stat transcript after overlay: %v", err)
+	}
+	if !transcriptAfter.ModTime().Equal(transcriptBefore.ModTime()) {
+		t.Fatalf("transcript mtime = %v, want %v", transcriptAfter.ModTime(), transcriptBefore.ModTime())
+	}
+	sessionDirAfter, err := os.Stat(sessionDir)
+	if err != nil {
+		t.Fatalf("stat session directory after overlay: %v", err)
+	}
+	if !sessionDirAfter.ModTime().Equal(sessionDirBefore.ModTime()) {
+		t.Fatalf("session directory mtime = %v, want %v", sessionDirAfter.ModTime(), sessionDirBefore.ModTime())
 	}
 }
 


### PR DESCRIPTION

## Problem

Enclave keeps the tool's config directory (for Claude: `.claude/`) in a persistent store on the host. When a launch generates a fresh tool config, `overlayConfigDir` swaps the store's contents for the generated tree in four steps: copy the paths that must survive (like `projects/`) to a temp dir, delete everything in the store, copy the generated tree in, copy the saved paths back.

Those copies carried content and permissions, but wrote the files with the current time as their modification time. Claude stores its session transcripts under `.claude/projects/` and sorts resume candidates by mtime, so after such a launch every past session looked like it had just been touched and `claude --resume` showed them in arbitrary order.

## Solution

Preserve file and directory modification times in the copy paths of both the Docker and QEMU backends, covered by regression tests over the full overlay flow.