### PR TITLE
test: exercise the website preview workflow

### DIFF
--- a/website/docs/docs/intro.md
+++ b/website/docs/docs/intro.md
@@ -9,6 +9,13 @@ import ThemedImage from '@theme/ThemedImage';
 
 # Eclipse Enclave
 
+:::note Preview workflow test
+
+This note only exists to exercise the PR preview deployment. The pull request
+that adds it is a throwaway and must not be merged.
+
+:::
+
 Eclipse Enclave runs Claude, Codex, OpenCode, and other AI coding agents at full
 autonomy. Each one runs in its own isolated container, with your files and
 network access under your control.


### PR DESCRIPTION
Throwaway PR to test the website PR preview deployment that landed in #5. **Not for merge** — close it once the preview has been verified, which also exercises the preview removal workflow.

What this should exercise:
- `Build website preview` on the PR head (no secrets, untrusted code)
- `Deploy website preview` via `workflow_run` on `main`: artifact download with `actions: read`, push to `eclipse-enclave/enclave-website-previews` with the org-level `DEPLOY_TOKEN`, and a sticky comment with the preview URL
- `Remove website preview` via `pull_request_target` when this PR is closed

The docs in the preview are built with base path `/enclave-website-previews/pr-previews/pr-<number>/docs/`, which matches the GitHub Pages URL, so the docs subsite should render fully here (unlike the production build, whose `/enclave/docs/` prefix awaits the `eclipse.dev/enclave` forwarding).