### PR TITLE
fix: improve website accessibility and CTA clarity

### DIFF
--- a/website/css/styles.css
+++ b/website/css/styles.css
@@ -9,8 +9,8 @@
 
 /* ==========================================================================
    Eclipse Enclave marketing site.
-   These tokens are the single source of truth for the look and feel; the
-   Docusaurus theme in website/docs/ mirrors the same values.
+   These tokens are the single source of truth for this page. The Docusaurus
+   theme in website/docs/ carries its own palette and is edited separately.
    ========================================================================== */
 
 :root {
@@ -24,7 +24,7 @@
   /* Text */
   --text: #4a5261;
   --heading: #14181f;
-  --muted: #7a8291;
+  --muted: #616a79;
 
   /* A restrained indigo/violet accent for the AI feel */
   --accent: #4f46e5;
@@ -36,9 +36,9 @@
   /* Signal colors */
   --amber: #b45309;
   --amber-soft: #fef6e7;
-  --green: #059669;
+  --green: #047857;
   --green-soft: #ecfdf5;
-  --red: #dc2626;
+  --red: #b91c1c;
 
   --radius: 16px;
   --radius-sm: 10px;
@@ -142,13 +142,12 @@ h2 + .section-lead { margin-top: 0; }
 /* ------- Hero ------- */
 .hero {
   text-align: center;
-  padding: 104px 24px 84px;
+  padding: 84px 24px 76px;
   background:
     radial-gradient(680px 340px at 50% -8%, rgba(124, 58, 237, 0.10), transparent 70%),
     radial-gradient(520px 300px at 82% 8%, rgba(79, 70, 229, 0.08), transparent 70%),
     var(--bg);
 }
-.hero img.logo { width: 76px; height: 76px; margin-bottom: 22px; }
 .hero h1 {
   font-size: clamp(2.3rem, 5.5vw, 3.4rem);
   font-weight: 850;
@@ -201,19 +200,25 @@ h2 + .section-lead { margin-top: 0; }
 }
 .hero-cmd .note::before { content: '# '; }
 .hero-actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; margin-bottom: 30px; }
-.badges { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; }
-.badge {
-  display: inline-block;
-  padding: 5px 14px;
-  border-radius: 20px;
-  font-size: 0.8rem;
-  font-weight: 600;
-  background: var(--bg-subtle);
-  border: 1px solid var(--border);
+.hero-facts {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 22px;
+  font-size: 0.88rem;
   color: var(--muted);
 }
-.badge.open-source { color: var(--green); border-color: #a7f3d0; background: var(--green-soft); }
-.badge.coming-soon { color: #fff; border-color: transparent; background: var(--grad); }
+.hero-facts li { display: inline-flex; align-items: center; gap: 7px; }
+.hero-facts li::before {
+  content: '';
+  flex: none;
+  width: 13px;
+  height: 13px;
+  background: var(--accent);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E") no-repeat center / contain;
+}
 
 /* ------- Card grids ------- */
 .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
@@ -223,9 +228,7 @@ h2 + .section-lead { margin-top: 0; }
   border-radius: var(--radius);
   padding: 26px 28px;
   box-shadow: var(--shadow-sm);
-  transition: transform 0.12s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
-.card:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); border-color: #dcdbf7; }
 .card h3 { font-size: 1.05rem; font-weight: 700; color: var(--heading); margin-bottom: 8px; }
 .card p { font-size: 0.94rem; color: var(--text); line-height: 1.6; }
 .card .icon {
@@ -254,6 +257,8 @@ h2 + .section-lead { margin-top: 0; }
   box-shadow: var(--shadow-sm);
 }
 .diagram-wrap svg { width: 100%; height: auto; }
+/* Authored near 1:1, so cap the width rather than letting it scale up. */
+.diagram-stacked { display: none; max-width: 340px; margin: 0 auto; }
 .diagram-caption { font-size: 0.9rem; color: var(--muted); margin-top: 16px; }
 
 /* ------- UI preview (coming soon) ------- */
@@ -346,7 +351,7 @@ h2 + .section-lead { margin-top: 0; }
   box-shadow: var(--shadow-md);
 }
 .cli-block .cmd { color: #a5b4fc; }
-.cli-block .comment { color: #6b7280; }
+.cli-block .comment { color: #858e9c; }
 .cli-block .flag { color: #fcd34d; }
 
 /* ------- Compliance ------- */
@@ -394,5 +399,8 @@ footer.site-footer a { font-weight: 600; }
   .nav-links { gap: 16px; }
   .nav-links a.hide-sm { display: none; }
   section { padding: 54px 0; }
-  .hero { padding: 72px 20px 60px; }
+  .hero { padding: 56px 20px 56px; }
+  .diagram-wide { display: none; }
+  .diagram-stacked { display: block; }
+  .diagram-wrap { padding: 24px 16px 18px; }
 }

--- a/website/docs/src/css/custom.css
+++ b/website/docs/src/css/custom.css
@@ -51,7 +51,7 @@
   /* Text */
   --ifm-heading-color: #101d30;
   --ifm-color-content: #43516b;
-  --ifm-color-content-secondary: #6b7791;
+  --ifm-color-content-secondary: #5a6780;
   --ifm-toc-border-color: #e0e8f2;
   --ifm-hr-border-color: #e0e8f2;
   --ifm-menu-color: #55617a;
@@ -368,7 +368,7 @@ div[class^='codeBlockContainer'],
   color: #ffffff;
 }
 .footer__copyright {
-  color: #6b7791;
+  color: #8b97ae;
   font-size: 0.85rem;
 }
 

--- a/website/index.html
+++ b/website/index.html
@@ -46,7 +46,6 @@
 
 <!-- Hero -->
 <header class="hero">
-  <img class="logo" src="assets/appicon.png" alt="Eclipse Enclave logo">
   <p class="hero-eyebrow">Open-source sandbox for AI coding agents</p>
   <h1>Full agent autonomy,<br><span class="grad">safely contained.</span></h1>
   <p class="tagline">Run Claude, Codex, OpenCode, and other coding agents at full autonomy.
@@ -57,16 +56,15 @@
     <span class="note">starts an isolated container and drops you into your agent</span>
   </div>
   <div class="hero-actions">
-    <a class="btn btn-primary" href="docs/getting-started/">Get started</a>
+    <a class="btn btn-primary" href="docs/getting-started/">Install Enclave</a>
     <a class="btn btn-ghost" href="https://github.com/eclipse-enclave/enclave">View on GitHub</a>
   </div>
-  <div class="badges">
-    <span class="badge open-source">Open source</span>
-    <span class="badge">MIT licensed</span>
-    <span class="badge">Docker-based</span>
-    <span class="badge">Claude · Codex · OpenCode</span>
-    <span class="badge coming-soon">GUI · coming soon</span>
-  </div>
+  <ul class="hero-facts">
+    <li>Open source, MIT licensed</li>
+    <li>Docker-based</li>
+    <li>Claude, Codex &amp; OpenCode</li>
+    <li>GUI on the roadmap</li>
+  </ul>
 </header>
 
 <main>
@@ -136,20 +134,22 @@
     <div class="container">
       <p class="eyebrow">Under the hood</p>
       <h2>How it works</h2>
+      <!-- Wide and stacked layouts of the same diagram; CSS shows one per breakpoint. -->
       <div class="diagram-wrap">
-        <svg viewBox="0 0 720 256" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif" role="img" aria-label="Eclipse Enclave overview: the developer starts a session in an isolated Docker container whose traffic passes through a filtering gateway">
+        <svg class="diagram-wide" viewBox="0 0 720 256" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif" role="img" aria-label="Eclipse Enclave overview: the developer starts a session in an isolated Docker container whose traffic passes through a filtering gateway">
           <defs>
-            <marker id="a" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#9aa2b1"/></marker>
             <marker id="a-ac" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#4f46e5"/></marker>
             <marker id="a-am" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#b45309"/></marker>
+            <marker id="a-ok" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#047857"/></marker>
+            <marker id="a-no" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#b91c1c"/></marker>
           </defs>
 
           <!-- Developer -->
           <rect x="14" y="98" width="112" height="56" rx="12" fill="#eef1fe" stroke="#c7d0fc" stroke-width="1.5"/>
           <text x="70" y="122" text-anchor="middle" font-size="12.5" font-weight="700" fill="#3730a3">Developer</text>
-          <text x="70" y="139" text-anchor="middle" font-size="9.5" fill="#7a8291">CLI</text>
+          <text x="70" y="139" text-anchor="middle" font-size="9.5" fill="#5b6472">CLI</text>
           <line x1="126" y1="126" x2="192" y2="126" stroke="#4f46e5" stroke-width="1.6" marker-end="url(#a-ac)"/>
-          <text x="159" y="118" text-anchor="middle" font-size="9" fill="#7a8291">manage</text>
+          <text x="159" y="118" text-anchor="middle" font-size="9.5" fill="#5b6472">manage</text>
 
           <!-- Container -->
           <rect x="196" y="30" width="250" height="196" rx="14" fill="#ffffff" stroke="#4f46e5" stroke-width="1.8"/>
@@ -159,12 +159,12 @@
           <text x="321" y="105" text-anchor="middle" font-size="9.5" fill="#5b6472">Claude · Codex · OpenCode · …</text>
           <rect x="216" y="128" width="210" height="34" rx="8" fill="#f7f8fa" stroke="#e6e8ec"/>
           <text x="321" y="150" text-anchor="middle" font-size="10.5" fill="#14181f">Mounted git worktree</text>
-          <text x="321" y="184" text-anchor="middle" font-size="9.5" fill="#7a8291">Default Docker backend</text>
-          <text x="321" y="200" text-anchor="middle" font-size="9.5" fill="#7a8291">Isolated filesystem and network</text>
+          <text x="321" y="184" text-anchor="middle" font-size="9.5" fill="#5b6472">Default Docker backend</text>
+          <text x="321" y="200" text-anchor="middle" font-size="9.5" fill="#5b6472">Isolated filesystem and network</text>
 
           <!-- to gateway -->
           <line x1="446" y1="98" x2="512" y2="98" stroke="#b45309" stroke-width="1.6" marker-end="url(#a-am)"/>
-          <text x="479" y="90" text-anchor="middle" font-size="9" fill="#7a8291">all traffic</text>
+          <text x="479" y="90" text-anchor="middle" font-size="9.5" fill="#5b6472">all traffic</text>
 
           <!-- Gateway -->
           <rect x="512" y="30" width="192" height="128" rx="14" fill="#ffffff" stroke="#b45309" stroke-width="1.8"/>
@@ -175,12 +175,59 @@
           <text x="608" y="130" text-anchor="middle" font-size="10.5" fill="#7a5b16">Transparent proxy</text>
 
           <!-- outputs -->
-          <line x1="570" y1="158" x2="570" y2="190" stroke="#059669" stroke-width="1.5" marker-end="url(#a)"/>
-          <line x1="646" y1="158" x2="646" y2="190" stroke="#dc2626" stroke-width="1.5" marker-end="url(#a)"/>
+          <line x1="570" y1="158" x2="570" y2="190" stroke="#047857" stroke-width="1.5" marker-end="url(#a-ok)"/>
+          <line x1="646" y1="158" x2="646" y2="190" stroke="#b91c1c" stroke-width="1.5" marker-end="url(#a-no)"/>
           <rect x="512" y="192" width="94" height="40" rx="20" fill="#ecfdf5" stroke="#a7f3d0"/>
-          <text x="559" y="216" text-anchor="middle" font-size="10.5" font-weight="600" fill="#059669">Allowed</text>
+          <text x="559" y="216" text-anchor="middle" font-size="10.5" font-weight="600" fill="#047857">Allowed</text>
           <rect x="610" y="192" width="94" height="40" rx="20" fill="#fef2f2" stroke="#fecaca"/>
-          <text x="657" y="216" text-anchor="middle" font-size="10.5" font-weight="600" fill="#dc2626">Blocked</text>
+          <text x="657" y="216" text-anchor="middle" font-size="10.5" font-weight="600" fill="#b91c1c">Blocked</text>
+        </svg>
+
+        <svg class="diagram-stacked" viewBox="0 0 340 510" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif" role="img" aria-label="Eclipse Enclave overview: the developer starts a session in an isolated Docker container whose traffic passes through a filtering gateway">
+          <defs>
+            <marker id="s-ac" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#4f46e5"/></marker>
+            <marker id="s-am" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#b45309"/></marker>
+            <marker id="s-ok" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#047857"/></marker>
+            <marker id="s-no" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><polygon points="0 0, 7 3, 0 6" fill="#b91c1c"/></marker>
+          </defs>
+
+          <!-- Developer -->
+          <rect x="90" y="2" width="160" height="52" rx="12" fill="#eef1fe" stroke="#c7d0fc" stroke-width="1.5"/>
+          <text x="170" y="26" text-anchor="middle" font-size="13" font-weight="700" fill="#3730a3">Developer</text>
+          <text x="170" y="43" text-anchor="middle" font-size="10.5" fill="#5b6472">CLI</text>
+          <line x1="170" y1="54" x2="170" y2="84" stroke="#4f46e5" stroke-width="1.6" marker-end="url(#s-ac)"/>
+          <text x="181" y="74" font-size="10.5" fill="#5b6472">manage</text>
+
+          <!-- Container -->
+          <rect x="10" y="88" width="320" height="176" rx="14" fill="#ffffff" stroke="#4f46e5" stroke-width="1.8"/>
+          <text x="170" y="110" text-anchor="middle" font-size="11.5" font-weight="800" letter-spacing="0.06em" fill="#4f46e5">CONTAINER</text>
+          <rect x="28" y="122" width="284" height="56" rx="10" fill="#eef1fe" stroke="#c7d0fc"/>
+          <text x="170" y="145" text-anchor="middle" font-size="13" font-weight="700" fill="#14181f">AI coding agent</text>
+          <text x="170" y="164" text-anchor="middle" font-size="10.5" fill="#5b6472">Claude · Codex · OpenCode · …</text>
+          <rect x="28" y="188" width="284" height="36" rx="8" fill="#f7f8fa" stroke="#e6e8ec"/>
+          <text x="170" y="211" text-anchor="middle" font-size="11.5" fill="#14181f">Mounted git worktree</text>
+          <text x="170" y="240" text-anchor="middle" font-size="10.5" fill="#5b6472">Default Docker backend</text>
+          <text x="170" y="256" text-anchor="middle" font-size="10.5" fill="#5b6472">Isolated filesystem and network</text>
+
+          <!-- to gateway -->
+          <line x1="170" y1="264" x2="170" y2="294" stroke="#b45309" stroke-width="1.6" marker-end="url(#s-am)"/>
+          <text x="181" y="284" font-size="10.5" fill="#5b6472">all traffic</text>
+
+          <!-- Gateway -->
+          <rect x="10" y="298" width="320" height="134" rx="14" fill="#ffffff" stroke="#b45309" stroke-width="1.8"/>
+          <text x="170" y="320" text-anchor="middle" font-size="11.5" font-weight="800" letter-spacing="0.06em" fill="#b45309">GATEWAY</text>
+          <rect x="28" y="332" width="284" height="38" rx="8" fill="#fef6e7" stroke="#f3d79a"/>
+          <text x="170" y="356" text-anchor="middle" font-size="11.5" fill="#7a5b16">DNS allowlist</text>
+          <rect x="28" y="378" width="284" height="38" rx="8" fill="#fef6e7" stroke="#f3d79a"/>
+          <text x="170" y="402" text-anchor="middle" font-size="11.5" fill="#7a5b16">Transparent proxy</text>
+
+          <!-- outputs -->
+          <line x1="90" y1="432" x2="90" y2="462" stroke="#047857" stroke-width="1.5" marker-end="url(#s-ok)"/>
+          <line x1="250" y1="432" x2="250" y2="462" stroke="#b91c1c" stroke-width="1.5" marker-end="url(#s-no)"/>
+          <rect x="26" y="464" width="128" height="42" rx="21" fill="#ecfdf5" stroke="#a7f3d0"/>
+          <text x="90" y="490" text-anchor="middle" font-size="11.5" font-weight="600" fill="#047857">Allowed</text>
+          <rect x="186" y="464" width="128" height="42" rx="21" fill="#fef2f2" stroke="#fecaca"/>
+          <text x="250" y="490" text-anchor="middle" font-size="11.5" font-weight="600" fill="#b91c1c">Blocked</text>
         </svg>
       </div>
       <p class="diagram-caption">In the default Docker setup, each session runs in its own
@@ -212,17 +259,17 @@
   </section>
 
 
-  <!-- UI preview (coming soon) -->
+  <!-- UI preview (not released yet) -->
   <section id="ui">
     <div class="container">
-      <p class="eyebrow">Coming soon</p>
+      <p class="eyebrow">On the roadmap</p>
       <h2>Meet HomeShell</h2>
       <p class="section-lead">Today Enclave is a CLI. HomeShell is a graphical companion on the
         way: group your work into projects, split each into workstreams, and run agent sessions
         across them. Start, watch, and switch between sandboxed sessions with a live overview of
         every agent's status.</p>
       <div class="ui-preview">
-        <span class="sticker">Coming soon</span>
+        <span class="sticker">In development</span>
         <div class="ui-frame">
           <img src="assets/homeshell.png" alt="HomeShell: a graphical dashboard listing Enclave projects, workstreams, and running agent sessions">
         </div>
@@ -311,7 +358,7 @@
       <h2>Give your agents room to work, but safely.</h2>
       <p>Install Eclipse Enclave and start your first sandboxed session.</p>
       <div class="cta-actions">
-        <a class="btn btn-primary" href="docs/getting-started/">Get started</a>
+        <a class="btn btn-primary" href="docs/getting-started/">Install Enclave</a>
         <a class="btn btn-ghost" href="docs/">Browse the docs</a>
       </div>
     </div>


### PR DESCRIPTION
Applies a round of marketing and design review feedback on the landing page. Seven points were raised; all seven held up on inspection and are applied here.

## Accessibility

`--muted` was `#7a8291`, **3.87:1** on white — below the 4.5:1 AA threshold for body text. It is the token behind the tagline, section leads, nav links, badge text, diagram caption, and footer, so it accounted for most of the reported failures. Now `#616a79` (5.46:1 on white, 5.14:1 on `--bg-subtle`).

Three further failures of the same kind that were not in the feedback:

- `.cli-block .comment` — `#6b7280` on `#14181f` was 3.68:1
- the diagram's "Allowed" / "Blocked" labels — 3.61:1 and 4.41:1

The docs site carries a separate palette, where `--ifm-color-content-secondary` was **4.49:1** on white while rendering real body copy in `.enclave-box p`; the footer copyright was 4.33:1 on navy. Both fixed.

All 16 changed foreground/background pairs now compute at ≥5.0:1.

## False affordances

- The approach cards had a `translateY` hover lift but are not links. Removed.
- The hero badges were pill-shaped with borders and fills, and the `coming-soon` badge reused the primary CTA's exact gradient. Replaced with a plain attribute list (`.hero-facts`) — no fill, border, or radius, each item prefixed with a small check glyph so it reads as a spec list rather than a row of disabled buttons.

## Mobile diagram

The "how it works" diagram is a 720-wide viewBox with 9px labels, which render around 4px at a 320px viewport. A vertically stacked variant (`340×510`, Developer → Container → Gateway → Allowed/Blocked) now takes over under 720px and the wide one hides. Capped at 340px so it renders near 1:1 instead of scaling up. `display: none` also keeps the inactive variant out of the accessibility tree, so there is no duplicate announcement.

## Copy and layout

- Hero logo removed; it duplicated a mark that is already in the *sticky* nav. With the hero top padding trimmed `104px → 84px`, the headline moves up roughly 120px.
- Eyebrow "Coming soon" → "On the roadmap"; the sticker on the mockup became "In development", since both reading "coming soon" in one section was redundant.
- Both primary CTAs "Get started" → "Install Enclave". The target page covers install and first run, so it is accurate and not merely punchier.

Also corrected a stale comment in `styles.css` claiming the docs theme mirrors these tokens — it has its own palette.

## Verification

- Contrast ratios computed for every changed pair: 16/16 pass AA, zero failures.
- Both diagram SVGs parse as well-formed XML; marker references resolve within their own `<svg>`; no duplicate `id`s across the page.
- Stacked-SVG geometry checked for rect and label overflow against the viewBox: none.
- CSS braces balanced; all five removed class names gone from both HTML and CSS.
- `make check-license-headers` passes (458 files).

**Not verified:** no browser was available in the authoring environment, so these changes have not been seen rendered. The stacked diagram's visual balance and the wrapping of `.hero-facts` at narrow widths are reasoned from geometry rather than observed — worth a look via `website/preview.sh` before merging. `make build`/`test`/`lint` were not run, as no Go code changed.