### PR TITLE
fix: correct Pi metadata and provider support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -335,7 +335,8 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod a+rx /usr/local/bin/entrypoint.sh \
         /usr/local/share/enclave/auth-reconcile.sh \
         /usr/local/share/enclave/net.sh && \
-    chmod a+r /usr/local/share/enclave/tmux-session.conf
+    chmod a+r /usr/local/share/enclave/tmux-session.conf \
+        /usr/local/share/enclave/kit-init.sh
 USER ${USERNAME}
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -118,6 +118,10 @@ are denied.
 
 Codex OAuth note: the OAuth callback redirects to `http://localhost:1455/auth/callback`. enclave auto-maps port 1455 when no session exists. If you need to re-login, add `-p 1455`. Gateway logs will show `Loopback proxy (socat) enabled on port 1455` when forwarding is active.
 
+Pi Anthropic OAuth note: Enclave does not auto-map the callback port. Add
+`-p 53692` when starting a Pi session in which you intend to log in with
+Anthropic OAuth.
+
 OpenCode ChatGPT subscription note: for `opencode`, complete OpenAI browser auth from the CLI inside the container rather than from `/connect` in the TUI. Use:
 
 ```bash

--- a/extensions/tools/pi/README.md
+++ b/extensions/tools/pi/README.md
@@ -1,7 +1,7 @@
 # Pi
 
 Pi is a coding agent by Mario Zechner (`@earendil-works/pi-coding-agent`). It
-supports multiple LLM providers (OpenAI, Anthropic, Google).
+supports multiple LLM providers (OpenAI, Anthropic, Google, Mistral).
 
 ## Configuration
 
@@ -17,25 +17,29 @@ supports multiple LLM providers (OpenAI, Anthropic, Google).
 | `OPENAI_API_KEY` | OpenAI API access |
 | `ANTHROPIC_API_KEY` | Anthropic API access |
 | `GEMINI_API_KEY` | Google Gemini API access |
+| `MISTRAL_API_KEY` | Mistral API access |
 
 ## Auth Files
 
 - `agent/auth.json`
 
-Pi uses Codex OAuth for OpenAI subscriptions. enclave auto-maps port 1455
-when the `openai-codex` entry is missing from `agent/auth.json`; add `-p 1455`
-(or `-p 1455:1455`) to re-login.
+Enclave recognizes Pi's `openai`, `openai-codex`, `anthropic`, `google`, and
+`mistral` credentials in this file. For browser-based login, enclave auto-maps
+port 1455 for Codex OAuth and port 53692 for Anthropic OAuth when the corresponding entry
+is missing. Add an explicit mapping for the relevant port to re-login.
 
 ## Network Access
 
-Allowlisted domains include OpenAI, Anthropic, Google, GitHub, and common
-package registries (npm, PyPI, Go, CDNs, TLS/OCSP).
+Allowlisted domains include Pi's model catalog, OpenAI, Anthropic, Google,
+Mistral, GitHub, and common package registries (npm, PyPI, Go, CDNs, TLS/OCSP).
 
 ## Settings
 
 Pi settings are seeded from `templates/settings.json` on first run. The upstream
 Pi settings schema supports `defaultProjectTrust`, but the default template stays
 empty so host settings passthrough behaves the same inside and outside Enclave.
+Enclave disables Pi's install telemetry and version check while leaving model
+catalog refresh enabled.
 
 Enclave runs Pi with `--approve` by default, so project-local Pi resources
 are trusted inside the sandbox without showing Pi's project trust prompt. This

--- a/extensions/tools/pi/README.md
+++ b/extensions/tools/pi/README.md
@@ -31,8 +31,9 @@ entry already exists.
 
 ## Network Access
 
-Allowlisted domains include Pi's model catalog, OpenAI, Anthropic, Google,
-Mistral, GitHub, and common package registries (npm, PyPI, Go, CDNs, TLS/OCSP).
+Allowlisted domains include `pi.dev` for Pi's model catalog, OpenAI, Anthropic,
+Google, Mistral, GitHub, and common package registries (npm, PyPI, Go, CDNs,
+TLS/OCSP).
 
 ## Settings
 

--- a/extensions/tools/pi/README.md
+++ b/extensions/tools/pi/README.md
@@ -10,6 +10,12 @@ supports multiple LLM providers (OpenAI, Anthropic, Google, Mistral).
 - **Config directory**: `~/.pi`
 - **Settings file**: `~/.pi/agent/settings.json`
 
+## Environment
+
+Enclave sets `PI_TELEMETRY=0` and `PI_SKIP_VERSION_CHECK=1` to disable Pi's
+install/update telemetry and version check while leaving model catalog refresh
+enabled. See Pi's upstream [environment-variable reference](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/environment-variables.md).
+
 ## API Keys
 
 | Variable | Purpose |
@@ -40,8 +46,6 @@ TLS/OCSP).
 Pi settings are seeded from `templates/settings.json` on first run. The upstream
 Pi settings schema supports `defaultProjectTrust`, but the default template stays
 empty so host settings passthrough behaves the same inside and outside Enclave.
-Enclave disables Pi's install telemetry and version check while leaving model
-catalog refresh enabled.
 
 Enclave runs Pi with `--approve` by default, so project-local Pi resources
 are trusted inside the sandbox without showing Pi's project trust prompt. This

--- a/extensions/tools/pi/README.md
+++ b/extensions/tools/pi/README.md
@@ -24,9 +24,10 @@ supports multiple LLM providers (OpenAI, Anthropic, Google, Mistral).
 - `agent/auth.json`
 
 Enclave recognizes Pi's `openai`, `openai-codex`, `anthropic`, `google`, and
-`mistral` credentials in this file. For browser-based login, enclave auto-maps
-port 1455 for Codex OAuth and port 53692 for Anthropic OAuth when the corresponding entry
-is missing. Add an explicit mapping for the relevant port to re-login.
+`mistral` credentials in this file. For browser-based login, Enclave auto-maps
+port 1455 when the `openai-codex` entry is missing. Anthropic OAuth is opt-in;
+add `-p 53692` when logging in. Add `-p 1455` to re-login with Codex when an
+entry already exists.
 
 ## Network Access
 

--- a/extensions/tools/pi/gateway-allowlist.conf
+++ b/extensions/tools/pi/gateway-allowlist.conf
@@ -10,6 +10,9 @@ no-resolv
 no-poll
 address=/#/
 
+# Pi model catalogs
+server=/pi.dev/8.8.8.8
+
 # OpenAI
 conf-file=/etc/dnsmasq.allowlists/fragments/openai.conf
 
@@ -18,6 +21,9 @@ conf-file=/etc/dnsmasq.allowlists/fragments/anthropic.conf
 
 # Google / Gemini
 conf-file=/etc/dnsmasq.allowlists/fragments/google.conf
+
+# Mistral
+conf-file=/etc/dnsmasq.allowlists/fragments/mistral.conf
 
 # Common Infrastructure
 conf-file=/etc/dnsmasq.allowlists/fragments/github.conf

--- a/extensions/tools/pi/gateway-allowlist.conf
+++ b/extensions/tools/pi/gateway-allowlist.conf
@@ -22,7 +22,8 @@ conf-file=/etc/dnsmasq.allowlists/fragments/anthropic.conf
 # Google / Gemini
 conf-file=/etc/dnsmasq.allowlists/fragments/google.conf
 
-# Mistral
+# Pi uses Mistral's general API; the shared fragment also allows Codestral,
+# which uses a separate credential.
 server=/api.mistral.ai/8.8.8.8
 
 # Common Infrastructure

--- a/extensions/tools/pi/gateway-allowlist.conf
+++ b/extensions/tools/pi/gateway-allowlist.conf
@@ -23,7 +23,7 @@ conf-file=/etc/dnsmasq.allowlists/fragments/anthropic.conf
 conf-file=/etc/dnsmasq.allowlists/fragments/google.conf
 
 # Mistral
-conf-file=/etc/dnsmasq.allowlists/fragments/mistral.conf
+server=/api.mistral.ai/8.8.8.8
 
 # Common Infrastructure
 conf-file=/etc/dnsmasq.allowlists/fragments/github.conf

--- a/extensions/tools/pi/spec.yaml
+++ b/extensions/tools/pi/spec.yaml
@@ -51,7 +51,6 @@ network:
     "*.anthropic.com": anthropic-api-key
     generativelanguage.googleapis.com: gemini-api-key
     api.mistral.ai: mistral-api-key
-    codestral.mistral.ai: mistral-api-key
   serviceAuth:
     openai-api-key: { headerName: authorization, valueFormat: "Bearer %s" }
     anthropic-api-key: { headerName: x-api-key }

--- a/extensions/tools/pi/spec.yaml
+++ b/extensions/tools/pi/spec.yaml
@@ -77,7 +77,8 @@ providers:
     authSession:
       checks:
         - { file: agent/auth.json, type: json_pointer_non_null, pointer: /anthropic }
-    oauthPorts: [{ port: "53692" }]
+    oauthPorts:
+      - { port: "53692", autoHintWhenNoSession: false, requireMappingWhenNoCredentials: false }
   - name: google
     credentials: [gemini-api-key]
     authFiles: [agent/auth.json]

--- a/extensions/tools/pi/spec.yaml
+++ b/extensions/tools/pi/spec.yaml
@@ -8,8 +8,8 @@
 schemaVersion: "1"
 kind: sandbox
 name: pi
-displayName: Anthropic Claude Pi
-description: Anthropic Claude Pi
+displayName: Pi Coding Agent
+description: Coding agent CLI with read, bash, edit, write tools and session management
 
 sandbox:
   entrypoint: { run: [pi] }
@@ -31,11 +31,17 @@ sandbox:
     - agent/skills/
     - agent/themes/
 
+environment:
+  variables:
+    PI_SKIP_VERSION_CHECK: "1"
+    PI_TELEMETRY: "0"
+
 credentials:
   sources:
     openai-api-key: { env: [OPENAI_API_KEY] }
     anthropic-api-key: { env: [ANTHROPIC_API_KEY] }
     gemini-api-key: { env: [GEMINI_API_KEY] }
+    mistral-api-key: { env: [MISTRAL_API_KEY] }
 
 network:
   serviceDomains:
@@ -44,21 +50,43 @@ network:
     api.anthropic.com: anthropic-api-key
     "*.anthropic.com": anthropic-api-key
     generativelanguage.googleapis.com: gemini-api-key
+    api.mistral.ai: mistral-api-key
+    codestral.mistral.ai: mistral-api-key
   serviceAuth:
     openai-api-key: { headerName: authorization, valueFormat: "Bearer %s" }
     anthropic-api-key: { headerName: x-api-key }
     gemini-api-key: { headerName: x-goog-api-key }
+    mistral-api-key: { headerName: authorization, valueFormat: "Bearer %s" }
 
 providers:
-  - name: openai-codex
+  - name: openai
     credentials: [openai-api-key]
     authFiles: [agent/auth.json]
     authSession:
-      mode: any
+      checks:
+        - { file: agent/auth.json, type: json_pointer_non_null, pointer: /openai }
+  - name: openai-codex
+    authFiles: [agent/auth.json]
+    authSession:
       checks:
         - { file: agent/auth.json, type: json_pointer_non_null, pointer: /openai-codex }
     oauthPorts: [{ port: "1455" }]
   - name: anthropic
     credentials: [anthropic-api-key]
-  - name: gemini
+    authFiles: [agent/auth.json]
+    authSession:
+      checks:
+        - { file: agent/auth.json, type: json_pointer_non_null, pointer: /anthropic }
+    oauthPorts: [{ port: "53692" }]
+  - name: google
     credentials: [gemini-api-key]
+    authFiles: [agent/auth.json]
+    authSession:
+      checks:
+        - { file: agent/auth.json, type: json_pointer_non_null, pointer: /google }
+  - name: mistral
+    credentials: [mistral-api-key]
+    authFiles: [agent/auth.json]
+    authSession:
+      checks:
+        - { file: agent/auth.json, type: json_pointer_non_null, pointer: /mistral }

--- a/extensions/tools/pi/spec.yaml
+++ b/extensions/tools/pi/spec.yaml
@@ -9,7 +9,7 @@ schemaVersion: "1"
 kind: sandbox
 name: pi
 displayName: Pi Coding Agent
-description: Coding agent CLI with read, bash, edit, write tools and session management
+description: A minimal terminal coding harness
 
 sandbox:
   entrypoint: { run: [pi] }

--- a/internal/app/build_permissions.go
+++ b/internal/app/build_permissions.go
@@ -50,6 +50,7 @@ func collectAppRootModeIssues(appRoot string) ([]string, error) {
 	}
 	for _, rel := range []string{
 		filepath.ToSlash(filepath.Join("runtime-assets", "auth-reconcile.sh")),
+		filepath.ToSlash(filepath.Join("runtime-assets", "kit-init.sh")),
 		filepath.ToSlash(filepath.Join("runtime-assets", "net.sh")),
 		filepath.ToSlash(filepath.Join("runtime-assets", "tmux-session.conf")),
 	} {

--- a/internal/app/build_permissions_test.go
+++ b/internal/app/build_permissions_test.go
@@ -20,6 +20,7 @@ func TestCollectAppRootModeIssuesReportsRestrictiveAssets(t *testing.T) {
 	writeModeTestFile(t, filepath.Join(root, "runtime-assets", "build-scripts", "lib", "common.sh"), 0o640)
 	writeModeTestFile(t, filepath.Join(root, "runtime-assets", "build-scripts", "bin", "helper"), 0o644)
 	writeModeTestFile(t, filepath.Join(root, "runtime-assets", "auth-reconcile.sh"), 0o640)
+	writeModeTestFile(t, filepath.Join(root, "runtime-assets", "kit-init.sh"), 0o640)
 	writeModeTestFile(t, filepath.Join(root, "runtime-assets", "net.sh"), 0o644)
 	writeModeTestFile(t, filepath.Join(root, "runtime-assets", "tmux-session.conf"), 0o644)
 	writeModeTestFile(t, filepath.Join(root, "extensions", "tools", "claude", "spec.yaml"), 0o640)
@@ -35,6 +36,7 @@ func TestCollectAppRootModeIssuesReportsRestrictiveAssets(t *testing.T) {
 		"runtime-assets/build-scripts/lib/common.sh lacks world read/execute permission",
 		"runtime-assets/build-scripts/bin/helper lacks world execute permission",
 		"runtime-assets/auth-reconcile.sh lacks world read permission",
+		"runtime-assets/kit-init.sh lacks world read permission",
 		"extensions/tools/claude/spec.yaml lacks world read permission",
 		"extensions/tools/claude/install.sh lacks world execute permission",
 	} {

--- a/internal/config/testdata/golden/tool-ext-pi.json
+++ b/internal/config/testdata/golden/tool-ext-pi.json
@@ -1,7 +1,7 @@
 {
   "type": "sandbox",
   "name": "pi",
-  "description": "Coding agent CLI with read, bash, edit, write tools and session management",
+  "description": "A minimal terminal coding harness",
   "default_included": true,
   "priority": 100,
   "secrets": {

--- a/internal/config/testdata/golden/tool-ext-pi.json
+++ b/internal/config/testdata/golden/tool-ext-pi.json
@@ -39,8 +39,7 @@
       "release": {
         "http": {
           "hosts": [
-            "api.mistral.ai",
-            "codestral.mistral.ai"
+            "api.mistral.ai"
           ],
           "header": "authorization",
           "format": "Bearer %s"

--- a/internal/config/testdata/golden/tool-ext-pi.json
+++ b/internal/config/testdata/golden/tool-ext-pi.json
@@ -1,7 +1,7 @@
 {
   "type": "sandbox",
   "name": "pi",
-  "description": "Anthropic Claude Pi",
+  "description": "Coding agent CLI with read, bash, edit, write tools and session management",
   "default_included": true,
   "priority": 100,
   "secrets": {
@@ -32,6 +32,21 @@
         }
       }
     },
+    "mistral-api-key": {
+      "env_vars": [
+        "MISTRAL_API_KEY"
+      ],
+      "release": {
+        "http": {
+          "hosts": [
+            "api.mistral.ai",
+            "codestral.mistral.ai"
+          ],
+          "header": "authorization",
+          "format": "Bearer %s"
+        }
+      }
+    },
     "openai-api-key": {
       "env_vars": [
         "OPENAI_API_KEY"
@@ -47,5 +62,9 @@
         }
       }
     }
+  },
+  "environment": {
+    "PI_SKIP_VERSION_CHECK": "1",
+    "PI_TELEMETRY": "0"
   }
 }

--- a/internal/config/testdata/golden/tool-pi.json
+++ b/internal/config/testdata/golden/tool-pi.json
@@ -25,7 +25,7 @@
   ],
   "providers": [
     {
-      "name": "openai-codex",
+      "name": "openai",
       "credential_secrets": [
         "openai-api-key"
       ],
@@ -33,7 +33,23 @@
         "agent/auth.json"
       ],
       "auth_session": {
-        "mode": "any",
+        "mode": "",
+        "checks": [
+          {
+            "file": "agent/auth.json",
+            "type": "json_pointer_non_null",
+            "pointer": "/openai"
+          }
+        ]
+      }
+    },
+    {
+      "name": "openai-codex",
+      "auth_files": [
+        "agent/auth.json"
+      ],
+      "auth_session": {
+        "mode": "",
         "checks": [
           {
             "file": "agent/auth.json",
@@ -52,13 +68,63 @@
       "name": "anthropic",
       "credential_secrets": [
         "anthropic-api-key"
+      ],
+      "auth_files": [
+        "agent/auth.json"
+      ],
+      "auth_session": {
+        "mode": "",
+        "checks": [
+          {
+            "file": "agent/auth.json",
+            "type": "json_pointer_non_null",
+            "pointer": "/anthropic"
+          }
+        ]
+      },
+      "oauth_ports": [
+        {
+          "port": "53692"
+        }
       ]
     },
     {
-      "name": "gemini",
+      "name": "google",
       "credential_secrets": [
         "gemini-api-key"
-      ]
+      ],
+      "auth_files": [
+        "agent/auth.json"
+      ],
+      "auth_session": {
+        "mode": "",
+        "checks": [
+          {
+            "file": "agent/auth.json",
+            "type": "json_pointer_non_null",
+            "pointer": "/google"
+          }
+        ]
+      }
+    },
+    {
+      "name": "mistral",
+      "credential_secrets": [
+        "mistral-api-key"
+      ],
+      "auth_files": [
+        "agent/auth.json"
+      ],
+      "auth_session": {
+        "mode": "",
+        "checks": [
+          {
+            "file": "agent/auth.json",
+            "type": "json_pointer_non_null",
+            "pointer": "/mistral"
+          }
+        ]
+      }
     }
   ],
   "secrets": {
@@ -89,6 +155,21 @@
         }
       }
     },
+    "mistral-api-key": {
+      "env_vars": [
+        "MISTRAL_API_KEY"
+      ],
+      "release": {
+        "http": {
+          "hosts": [
+            "api.mistral.ai",
+            "codestral.mistral.ai"
+          ],
+          "header": "authorization",
+          "format": "Bearer %s"
+        }
+      }
+    },
     "openai-api-key": {
       "env_vars": [
         "OPENAI_API_KEY"
@@ -107,5 +188,9 @@
   },
   "host_config_dir": "",
   "host_credentials_file": "",
-  "host_oauth_json": ""
+  "host_oauth_json": "",
+  "environment": {
+    "PI_SKIP_VERSION_CHECK": "1",
+    "PI_TELEMETRY": "0"
+  }
 }

--- a/internal/config/testdata/golden/tool-pi.json
+++ b/internal/config/testdata/golden/tool-pi.json
@@ -164,8 +164,7 @@
       "release": {
         "http": {
           "hosts": [
-            "api.mistral.ai",
-            "codestral.mistral.ai"
+            "api.mistral.ai"
           ],
           "header": "authorization",
           "format": "Bearer %s"

--- a/internal/config/testdata/golden/tool-pi.json
+++ b/internal/config/testdata/golden/tool-pi.json
@@ -84,7 +84,9 @@
       },
       "oauth_ports": [
         {
-          "port": "53692"
+          "port": "53692",
+          "auto_hint_when_no_session": false,
+          "require_mapping_when_no_credentials": false
         }
       ]
     },

--- a/runtime-assets/microvm/alpine/build-bundle.sh
+++ b/runtime-assets/microvm/alpine/build-bundle.sh
@@ -114,6 +114,7 @@ cp /src/runtime-assets/auth-reconcile.sh "$root/usr/local/share/enclave/auth-rec
 cp /src/runtime-assets/net.sh "$root/usr/local/share/enclave/net.sh"
 cp /src/runtime-assets/kit-init.sh "$root/usr/local/share/enclave/kit-init.sh"
 chmod 0755 "$root/usr/local/bin/entrypoint.sh" "$root/usr/local/share/enclave/auth-reconcile.sh" "$root/usr/local/share/enclave/net.sh"
+chmod 0644 "$root/usr/local/share/enclave/kit-init.sh"
 
 if [ -d /src/docs ]; then cp -a /src/docs "$root/usr/share/doc/enclave/docs"; fi
 


### PR DESCRIPTION

#### What it does

Fixes the Pi tool extension so a Pi session comes up with correct metadata, the right provider set, and a working model catalog:

- Corrects the extension metadata and its provider IDs and auth storage names.
- Makes Anthropic OAuth opt-in rather than always released into the session.
- Restricts Mistral credential release to the cases that need it.
- Adds `pi.dev` to the gateway allowlist so Pi's model catalog update works under network isolation.

It also fixes an unrelated image-build defect found while testing this branch: `enclave --tool pi shell` died right after startup with

```
/usr/local/bin/entrypoint.sh: line 289: /usr/local/share/enclave/kit-init.sh: Permission denied
```

`Dockerfile` and `runtime-assets/microvm/alpine/build-bundle.sh` both copy `runtime-assets/kit-init.sh` into the image but never normalized its mode, unlike every other asset they copy. The entrypoint sources it as the unprivileged agent user under `set -e`, so a source checkout with a restrictive umask (files at `0660`) produced a root-owned unreadable file and killed the container before any feature entrypoint ran. Installed builds were unaffected: they build from embedded assets, which `appassets.FileMode` writes as `0644`.

#### How to test

Pi extension:

1. `make build && make test`
2. `bin/enclave --tool pi` — the session starts, and Pi's model catalog update succeeds with network isolation active.

Image permissions:

1. From a source checkout, ensure the asset is group-only readable: `chmod 0660 runtime-assets/kit-init.sh`.
2. `bin/enclave --tool pi shell` — before this change the container exits with the `Permission denied` error above; after it, the shell comes up.
3. `docker run --rm --entrypoint /bin/sh <image> -c 'ls -l /usr/local/share/enclave/kit-init.sh'` reports a world-readable mode.

#### Follow-ups

Two hardening items around the `kit-init.sh` failure, neither included here:

- `entrypoint.sh` guards this source with `[ -f ]` where the sibling asset loads (`net.sh`, `build-scripts/lib/common.sh`) use `[ -r ]`. With `-r` an unreadable asset would fail open and degrade instead of killing the container.
- `collectAppRootModeIssues` in `internal/app/build_permissions.go` warns about restrictive modes on the other copied runtime assets but omits `runtime-assets/kit-init.sh`, so nothing pointed at the offending file.

The image-permission fix is independent of the Pi changes and can be split into its own PR if you would rather keep this one scoped to Pi.

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).