### PR TITLE
fix: resolve secret env aliases by layer priority

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -159,6 +159,21 @@ echo 'ANTHROPIC_API_KEY=sk-ant-readonly...' > ~/.local/state/enclave/secrets/glo
 echo 'ANTHROPIC_API_KEY=sk-ant-project...' > ~/.local/state/enclave/secrets/projects/<hash>/claude.env
 ```
 
+### Env Aliases
+
+A declared secret may list several env-var aliases for one credential, for
+example `GH_TOKEN` and `GITHUB_TOKEN`. Each alias is looked up on its own — host
+environment first, then the layered secrets files from layer 3 down to layer 1,
+then the host-side env store — and the alias found in the highest layer wins.
+Its value is injected into *every* alias of that secret and written back to the
+env store, so rotating a token in one alias is enough and a stale value in the
+env store heals after one run.
+
+If two aliases resolve from that same winning layer with different values, the
+run fails and the error names the layer — enclave cannot pick between them.
+Aliases that disagree from a lower layer are only logged, since the winning
+value overrides them anyway.
+
 ## Passing Host Environment Variables
 
 Host environment variables do **not** leak into the container unless explicitly opted in.

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -393,11 +393,8 @@ Secrets are split across two `spec.yaml` sections:
 - `credentials.sources.<id>` declares the credential itself: `env` (one or
   more env-var aliases for the same credential) and the enclave-native
   `apiKey` bool (`false` for OAuth/session tokens; omitted/`true` means it's
-  an API key).
-- Env aliases name one value. Precedence: host env, layered secrets files,
-  persisted store; the winner is injected into *every* alias, so a stale
-  persisted value heals after one run. Aliases set in the *same* layer with
-  different values are an error; across layers it is a warning.
+  an API key). See [Authentication](../auth.md#env-aliases) for how multiple
+  aliases are resolved against each other.
 - `credentials.sources.<id>.file` optionally sources the secret from a host
   file: `path` (supports `~`) plus a `parser` — empty for the trimmed raw file
   contents, or `json:<dot.path>` (e.g. `json:auth.token`) to extract a scalar

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -394,6 +394,10 @@ Secrets are split across two `spec.yaml` sections:
   more env-var aliases for the same credential) and the enclave-native
   `apiKey` bool (`false` for OAuth/session tokens; omitted/`true` means it's
   an API key).
+- Env aliases name one value. Precedence: host env, layered secrets files,
+  persisted store; the winner is injected into *every* alias, so a stale
+  persisted value heals after one run. Aliases set in the *same* layer with
+  different values are an error; across layers it is a warning.
 - `credentials.sources.<id>.file` optionally sources the secret from a host
   file: `path` (supports `~`) plus a `parser` — empty for the trimmed raw file
   contents, or `json:<dot.path>` (e.g. `json:auth.token`) to extract a scalar

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -37,40 +37,50 @@ func ReadAllEnvFromFile(path string) (map[string]string, error) {
 	return parseEnvLines(file)
 }
 
-// ResolveLayeredSecrets reads secrets files in layer order and merges them.
-// Layer 1: global.env (always read). Layer 2: global/<tool>.env (when scope
-// is "global" or "both"). Layer 3: projects/<hash>/<tool>.env (when scope is
-// "project" or "both"). Later layers override earlier ones.
-func ResolveLayeredSecrets(home string, projectHash string, tool string, scope string) (map[string]string, error) {
-	result := map[string]string{}
+// SecretsLayer is one secrets file together with the values it contributes.
+type SecretsLayer struct {
+	Path   string
+	Values map[string]string
+}
 
-	globalShared, err := ReadAllEnvFromFile(config.HostSecretsGlobalSharedFile(home))
-	if err != nil {
-		return nil, fmt.Errorf("read global secrets: %w", err)
-	}
-	for k, v := range globalShared {
-		result[k] = v
+// ResolveSecretsLayers reads the secrets files in layer order, lowest
+// precedence first. Layer 1: global.env (always read). Layer 2:
+// global/<tool>.env (when scope is "global" or "both"). Layer 3:
+// projects/<hash>/<tool>.env (when scope is "project" or "both"). Later layers
+// override earlier ones. Files that are missing or empty are omitted.
+func ResolveSecretsLayers(home string, projectHash string, tool string, scope string) ([]SecretsLayer, error) {
+	type candidate struct {
+		path   string
+		errMsg string
 	}
 
+	candidates := []candidate{{
+		path:   config.HostSecretsGlobalSharedFile(home),
+		errMsg: "read global secrets",
+	}}
 	if scope == model.SecretsScopeGlobal || scope == model.SecretsScopeBoth {
-		perTool, err := ReadAllEnvFromFile(config.HostSecretsGlobalFile(home, tool))
-		if err != nil {
-			return nil, fmt.Errorf("read global per-tool secrets: %w", err)
-		}
-		for k, v := range perTool {
-			result[k] = v
-		}
+		candidates = append(candidates, candidate{
+			path:   config.HostSecretsGlobalFile(home, tool),
+			errMsg: "read global per-tool secrets",
+		})
 	}
-
 	if scope == model.SecretsScopeProject || scope == model.SecretsScopeBoth {
-		projectTool, err := ReadAllEnvFromFile(config.HostSecretsProjectFile(home, projectHash, tool))
-		if err != nil {
-			return nil, fmt.Errorf("read project per-tool secrets: %w", err)
-		}
-		for k, v := range projectTool {
-			result[k] = v
-		}
+		candidates = append(candidates, candidate{
+			path:   config.HostSecretsProjectFile(home, projectHash, tool),
+			errMsg: "read project per-tool secrets",
+		})
 	}
 
-	return result, nil
+	layers := make([]SecretsLayer, 0, len(candidates))
+	for _, candidate := range candidates {
+		values, err := ReadAllEnvFromFile(candidate.path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", candidate.errMsg, err)
+		}
+		if len(values) == 0 {
+			continue
+		}
+		layers = append(layers, SecretsLayer{Path: candidate.path, Values: values})
+	}
+	return layers, nil
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -115,7 +115,78 @@ func TestReadAllEnvFromFile(t *testing.T) {
 	})
 }
 
-func TestResolveLayeredSecrets(t *testing.T) {
+// resolveMergedSecrets flattens the layers the way callers that do not care
+// about the originating file see them: later layers override earlier ones.
+func resolveMergedSecrets(home string, projectHash string, tool string, scope string) (map[string]string, error) {
+	layers, err := ResolveSecretsLayers(home, projectHash, tool, scope)
+	if err != nil {
+		return nil, err
+	}
+	merged := map[string]string{}
+	for _, layer := range layers {
+		for key, value := range layer.Values {
+			merged[key] = value
+		}
+	}
+	return merged, nil
+}
+
+func TestResolveSecretsLayers(t *testing.T) {
+	t.Run("layers are ordered lowest precedence first", func(t *testing.T) {
+		home := t.TempDir()
+
+		for _, path := range []string{
+			config.HostSecretsGlobalSharedFile(home),
+			config.HostSecretsGlobalFile(home, "claude"),
+			config.HostSecretsProjectFile(home, "proj", "claude"),
+		} {
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("GITHUB_TOKEN=token\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		layers, err := ResolveSecretsLayers(home, "proj", "claude", model.SecretsScopeBoth)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{
+			config.HostSecretsGlobalSharedFile(home),
+			config.HostSecretsGlobalFile(home, "claude"),
+			config.HostSecretsProjectFile(home, "proj", "claude"),
+		}
+		if len(layers) != len(want) {
+			t.Fatalf("got %d layers, want %d", len(layers), len(want))
+		}
+		for i, path := range want {
+			if layers[i].Path != path {
+				t.Errorf("layer %d path = %q, want %q", i, layers[i].Path, path)
+			}
+		}
+	})
+
+	t.Run("empty layers are omitted", func(t *testing.T) {
+		home := t.TempDir()
+
+		path := config.HostSecretsGlobalFile(home, "claude")
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("# only a comment\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		layers, err := ResolveSecretsLayers(home, "proj", "claude", model.SecretsScopeBoth)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(layers) != 0 {
+			t.Fatalf("got %d layers, want none", len(layers))
+		}
+	})
+
 	t.Run("two-layer merge", func(t *testing.T) {
 		home := t.TempDir()
 
@@ -137,7 +208,7 @@ func TestResolveLayeredSecrets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeBoth)
+		secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeBoth)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -171,7 +242,7 @@ func TestResolveLayeredSecrets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeBoth)
+		secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeBoth)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -183,7 +254,7 @@ func TestResolveLayeredSecrets(t *testing.T) {
 	t.Run("missing layers", func(t *testing.T) {
 		home := t.TempDir()
 
-		secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeBoth)
+		secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeBoth)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -203,7 +274,7 @@ func TestResolveLayeredSecrets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeBoth)
+		secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeBoth)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -223,7 +294,7 @@ func TestResolveLayeredSecrets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeBoth)
+		secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeBoth)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -262,7 +333,7 @@ func TestResolveLayeredSecrets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeBoth)
+		secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeBoth)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -292,7 +363,7 @@ func TestResolveLayeredSecrets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeProject)
+		secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeProject)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -325,7 +396,7 @@ func TestResolveLayeredSecrets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeGlobal)
+		secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeGlobal)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -420,9 +491,9 @@ func TestParseEnvLines(t *testing.T) {
 	})
 }
 
-func TestResolveLayeredSecrets_APIKeyInGlobalShared(t *testing.T) {
+func TestResolveSecretsLayers_APIKeyInGlobalShared(t *testing.T) {
 	// Regression test: API key vars stored in global.env must be found
-	// by ResolveLayeredSecrets. The old ResolveAPIKey function missed
+	// by ResolveSecretsLayers. The old ResolveAPIKey function missed
 	// this layer entirely.
 	home := t.TempDir()
 
@@ -434,7 +505,7 @@ func TestResolveLayeredSecrets_APIKeyInGlobalShared(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	secrets, err := ResolveLayeredSecrets(home, "proj", "claude", model.SecretsScopeBoth)
+	secrets, err := resolveMergedSecrets(home, "proj", "claude", model.SecretsScopeBoth)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/active_secrets.go
+++ b/internal/runtime/active_secrets.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sort"
 
+	"enclave/internal/logx"
 	"enclave/internal/model"
 	"enclave/internal/secretfile"
 )
@@ -121,28 +122,29 @@ func resolveActiveSecretValue(secret activeSecret, hostHome string, layeredSecre
 }
 
 // resolveEnvAliasValue resolves a secret through its env-var aliases, walking
-// host env, then the layered .env secrets, then persisted env.
+// host env, then the layered .env secrets, then persisted env. The highest
+// layer wins; only aliases resolved from the same layer must agree. Cross-layer
+// drift is logged and heals through the persisted write-back.
 func resolveEnvAliasValue(secret activeSecret, layeredSecrets map[string]string, persistedEnv map[string]string) (string, string, bool, error) {
 	type aliasValue struct {
 		envVar   string
 		value    string
 		source   string
 		priority int
-		found    bool
 	}
 
 	values := make([]aliasValue, 0, len(secret.EnvVars))
 	for _, envVar := range secret.EnvVars {
 		if value := os.Getenv(envVar); value != "" {
-			values = append(values, aliasValue{envVar: envVar, value: value, source: "env", priority: 1, found: true})
+			values = append(values, aliasValue{envVar: envVar, value: value, source: "env", priority: 1})
 			continue
 		}
 		if value, ok := layeredSecrets[envVar]; ok && value != "" {
-			values = append(values, aliasValue{envVar: envVar, value: value, source: "secrets", priority: 2, found: true})
+			values = append(values, aliasValue{envVar: envVar, value: value, source: "secrets", priority: 2})
 			continue
 		}
 		if value, ok := persistedEnv[envVar]; ok && value != "" {
-			values = append(values, aliasValue{envVar: envVar, value: value, source: "persisted", priority: 3, found: true})
+			values = append(values, aliasValue{envVar: envVar, value: value, source: "persisted", priority: 3})
 		}
 	}
 
@@ -152,12 +154,19 @@ func resolveEnvAliasValue(secret activeSecret, layeredSecrets map[string]string,
 
 	chosen := values[0]
 	for _, value := range values[1:] {
-		if value.value != chosen.value {
-			return "", "", false, fmt.Errorf("secret %q has conflicting values across env aliases (%s vs %s)", secret.ID, chosen.envVar, value.envVar)
-		}
 		if value.priority < chosen.priority {
 			chosen = value
 		}
+	}
+
+	for _, value := range values {
+		if value.value == chosen.value {
+			continue
+		}
+		if value.priority == chosen.priority {
+			return "", "", false, fmt.Errorf("secret %q has conflicting values across env aliases (%s vs %s, both set in the %s layer)", secret.ID, chosen.envVar, value.envVar, chosen.source)
+		}
+		logx.Warnf("Secret %s: using %s from the %s layer; %s in the %s layer holds a different value and is ignored.", secret.ID, chosen.envVar, chosen.source, value.envVar, value.source)
 	}
 
 	return chosen.value, chosen.source, true, nil

--- a/internal/runtime/active_secrets.go
+++ b/internal/runtime/active_secrets.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sort"
 
+	"enclave/internal/auth"
 	"enclave/internal/logx"
 	"enclave/internal/model"
 	"enclave/internal/secretfile"
@@ -96,7 +97,7 @@ func (r *Runtime) activeSecrets() ([]activeSecret, error) {
 	return secrets, nil
 }
 
-func resolveActiveSecretValue(secret activeSecret, hostHome string, layeredSecrets map[string]string, persistedEnv map[string]string) (string, string, bool, error) {
+func resolveActiveSecretValue(secret activeSecret, hostHome string, secretsLayers []auth.SecretsLayer, persistedEnv map[string]string) (string, string, bool, error) {
 	// priority orders the env aliases against the file source. file-first
 	// consults the file before the env aliases; env-first (the default) does
 	// the reverse. A malformed file parser fails loudly regardless of order.
@@ -108,10 +109,10 @@ func resolveActiveSecretValue(secret activeSecret, hostHome string, layeredSecre
 		if found {
 			return value, source, true, nil
 		}
-		return resolveEnvAliasValue(secret, layeredSecrets, persistedEnv)
+		return resolveEnvAliasValue(secret, secretsLayers, persistedEnv)
 	}
 
-	value, source, found, err := resolveEnvAliasValue(secret, layeredSecrets, persistedEnv)
+	value, source, found, err := resolveEnvAliasValue(secret, secretsLayers, persistedEnv)
 	if err != nil {
 		return "", "", false, err
 	}
@@ -121,30 +122,27 @@ func resolveActiveSecretValue(secret activeSecret, hostHome string, layeredSecre
 	return resolveFileSecretValue(secret, hostHome)
 }
 
-// resolveEnvAliasValue resolves a secret through its env-var aliases, walking
-// host env, then the layered .env secrets, then persisted env. The highest
-// layer wins; only aliases resolved from the same layer must agree. Cross-layer
-// drift is logged and heals through the persisted write-back.
-func resolveEnvAliasValue(secret activeSecret, layeredSecrets map[string]string, persistedEnv map[string]string) (string, string, bool, error) {
-	type aliasValue struct {
-		envVar   string
-		value    string
-		source   string
-		priority int
-	}
+// aliasValue is one env alias resolved from one layer. rank orders the layers,
+// lowest first: host env, then the secrets files from the highest layer down,
+// then the persisted env store.
+type aliasValue struct {
+	envVar string
+	value  string
+	source string
+	layer  string
+	rank   int
+}
 
+// resolveEnvAliasValue resolves a secret through its env-var aliases, walking
+// the host environment, then the layered secrets files (highest layer first),
+// then the persisted env store. The highest layer wins; only aliases resolved
+// from the same layer must agree. Drift between layers is logged and heals
+// through the persisted write-back.
+func resolveEnvAliasValue(secret activeSecret, secretsLayers []auth.SecretsLayer, persistedEnv map[string]string) (string, string, bool, error) {
 	values := make([]aliasValue, 0, len(secret.EnvVars))
 	for _, envVar := range secret.EnvVars {
-		if value := os.Getenv(envVar); value != "" {
-			values = append(values, aliasValue{envVar: envVar, value: value, source: "env", priority: 1})
-			continue
-		}
-		if value, ok := layeredSecrets[envVar]; ok && value != "" {
-			values = append(values, aliasValue{envVar: envVar, value: value, source: "secrets", priority: 2})
-			continue
-		}
-		if value, ok := persistedEnv[envVar]; ok && value != "" {
-			values = append(values, aliasValue{envVar: envVar, value: value, source: "persisted", priority: 3})
+		if resolved, ok := resolveAlias(envVar, secretsLayers, persistedEnv); ok {
+			values = append(values, resolved)
 		}
 	}
 
@@ -154,7 +152,7 @@ func resolveEnvAliasValue(secret activeSecret, layeredSecrets map[string]string,
 
 	chosen := values[0]
 	for _, value := range values[1:] {
-		if value.priority < chosen.priority {
+		if value.rank < chosen.rank {
 			chosen = value
 		}
 	}
@@ -163,13 +161,28 @@ func resolveEnvAliasValue(secret activeSecret, layeredSecrets map[string]string,
 		if value.value == chosen.value {
 			continue
 		}
-		if value.priority == chosen.priority {
-			return "", "", false, fmt.Errorf("secret %q has conflicting values across env aliases (%s vs %s, both set in the %s layer)", secret.ID, chosen.envVar, value.envVar, chosen.source)
+		if value.rank == chosen.rank {
+			return "", "", false, fmt.Errorf("secret %q has conflicting values across env aliases (%s vs %s, both set in %s)", secret.ID, chosen.envVar, value.envVar, chosen.layer)
 		}
-		logx.Warnf("Secret %s: using %s from the %s layer; %s in the %s layer holds a different value and is ignored.", secret.ID, chosen.envVar, chosen.source, value.envVar, value.source)
+		logx.Warnf("Secret %s: using %s from %s; %s in %s holds a different value and is ignored.", secret.ID, chosen.envVar, chosen.layer, value.envVar, value.layer)
 	}
 
 	return chosen.value, chosen.source, true, nil
+}
+
+func resolveAlias(envVar string, secretsLayers []auth.SecretsLayer, persistedEnv map[string]string) (aliasValue, bool) {
+	if value := os.Getenv(envVar); value != "" {
+		return aliasValue{envVar: envVar, value: value, source: "env", layer: "the host environment", rank: 0}, true
+	}
+	for i := len(secretsLayers) - 1; i >= 0; i-- {
+		if value := secretsLayers[i].Values[envVar]; value != "" {
+			return aliasValue{envVar: envVar, value: value, source: "secrets", layer: secretsLayers[i].Path, rank: len(secretsLayers) - i}, true
+		}
+	}
+	if value := persistedEnv[envVar]; value != "" {
+		return aliasValue{envVar: envVar, value: value, source: "persisted", layer: "the host-side env store", rank: len(secretsLayers) + 1}, true
+	}
+	return aliasValue{}, false
 }
 
 // resolveFileSecretValue reads the secret's file source, if any. A missing file

--- a/internal/runtime/active_secrets_test.go
+++ b/internal/runtime/active_secrets_test.go
@@ -10,8 +10,10 @@ package runtime
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"enclave/internal/auth"
 	"enclave/internal/model"
 )
 
@@ -91,5 +93,100 @@ func TestResolveActiveSecretValueEnvFirstBeatsFile(t *testing.T) {
 	}
 	if source != "env" {
 		t.Fatalf("env-first source = %q, want %q", source, "env")
+	}
+}
+
+func TestResolveEnvAliasValue(t *testing.T) {
+	const globalFile = "/secrets/global.env"
+	const projectFile = "/secrets/projects/hash/tool.env"
+
+	layers := func(values ...map[string]string) []auth.SecretsLayer {
+		result := make([]auth.SecretsLayer, 0, len(values))
+		for i, value := range values {
+			path := globalFile
+			if i > 0 {
+				path = projectFile
+			}
+			result = append(result, auth.SecretsLayer{Path: path, Values: value})
+		}
+		return result
+	}
+
+	tests := []struct {
+		name       string
+		hostEnv    map[string]string
+		layers     []auth.SecretsLayer
+		persisted  map[string]string
+		wantValue  string
+		wantSource string
+		wantFound  bool
+		wantErr    string
+	}{{
+		name:       "host env beats the secrets files",
+		hostEnv:    map[string]string{"GH_TOKEN": "env-token"},
+		layers:     layers(map[string]string{"GITHUB_TOKEN": "secrets-token"}),
+		wantValue:  "env-token",
+		wantSource: "env",
+		wantFound:  true,
+	}, {
+		name:       "secrets files beat the persisted store",
+		layers:     layers(map[string]string{"GITHUB_TOKEN": "rotated-token"}),
+		persisted:  map[string]string{"GH_TOKEN": "stale-token"},
+		wantValue:  "rotated-token",
+		wantSource: "secrets",
+		wantFound:  true,
+	}, {
+		name: "a later secrets layer beats an earlier one",
+		layers: layers(
+			map[string]string{"GH_TOKEN": "global-token"},
+			map[string]string{"GITHUB_TOKEN": "project-token"},
+		),
+		wantValue:  "project-token",
+		wantSource: "secrets",
+		wantFound:  true,
+	}, {
+		name:    "aliases conflicting inside one secrets file fail",
+		layers:  layers(map[string]string{"GH_TOKEN": "one", "GITHUB_TOKEN": "two"}),
+		wantErr: globalFile,
+	}, {
+		name:    "aliases conflicting in the host environment fail",
+		hostEnv: map[string]string{"GH_TOKEN": "one", "GITHUB_TOKEN": "two"},
+		wantErr: "the host environment",
+	}, {
+		name:       "drift below the winning layer only warns",
+		hostEnv:    map[string]string{"GH_TOKEN": "env-token"},
+		layers:     layers(map[string]string{"GITHUB_TOKEN": "secrets-token"}),
+		persisted:  map[string]string{"GHE_TOKEN": "stale-token"},
+		wantValue:  "env-token",
+		wantSource: "env",
+		wantFound:  true,
+	}, {
+		name: "no alias set anywhere",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret := activeSecret{ID: "github-token", EnvVars: []string{"GH_TOKEN", "GITHUB_TOKEN", "GHE_TOKEN"}}
+			for _, envVar := range secret.EnvVars {
+				t.Setenv(envVar, tt.hostEnv[envVar])
+			}
+
+			value, source, found, err := resolveEnvAliasValue(secret, tt.layers, tt.persisted)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("resolveEnvAliasValue() error = nil, want %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), "conflicting values across env aliases") || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveEnvAliasValue() error = %q, want conflict naming %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveEnvAliasValue() error = %v", err)
+			}
+			if found != tt.wantFound || value != tt.wantValue || source != tt.wantSource {
+				t.Fatalf("resolveEnvAliasValue() = (%q, %q, %v), want (%q, %q, %v)", value, source, found, tt.wantValue, tt.wantSource, tt.wantFound)
+			}
+		})
 	}
 }

--- a/internal/runtime/auth_manager.go
+++ b/internal/runtime/auth_manager.go
@@ -69,17 +69,17 @@ func (m authManager) Prepare(env *[]string, stores storeSet) (model.AuthState, S
 		logx.Warnf("Auth ready hook failed: %v", err)
 	}
 
-	layeredSecrets, err := auth.ResolveLayeredSecrets(m.host.Home, m.project.Hash, m.profile.Name, m.auth.SecretsScope)
+	secretsLayers, err := auth.ResolveSecretsLayers(m.host.Home, m.project.Hash, m.profile.Name, m.auth.SecretsScope)
 	if err != nil {
 		logx.Warnf("Failed to read layered secrets: %v", err)
-		layeredSecrets = map[string]string{}
+		secretsLayers = nil
 	}
 
 	activeSecrets, err := m.activeSecrets()
 	if err != nil {
 		return model.AuthState{}, SecretMapping{}, fmt.Errorf("resolve active secrets: %w", err)
 	}
-	injection, err := m.injectDeclaredSecrets(hooks, authCtx, env, persistedEnv, layeredSecrets, authStorage, activeSecrets)
+	injection, err := m.injectDeclaredSecrets(hooks, authCtx, env, persistedEnv, secretsLayers, authStorage, activeSecrets)
 	if err != nil {
 		return model.AuthState{}, SecretMapping{}, err
 	}
@@ -152,7 +152,7 @@ func (m authManager) checkProviderSession(authStorage *backend.StoreRef, provide
 	return m.checkSessionFromAuthFiles(authStorage, provider.AuthFiles)
 }
 
-func (m authManager) injectDeclaredSecrets(hooks auth.Hooks, authCtx auth.Context, env *[]string, persistedEnv map[string]string, layeredSecrets map[string]string, authStorage *backend.StoreRef, activeSecrets []activeSecret) (apiKeyInjectionResult, error) {
+func (m authManager) injectDeclaredSecrets(hooks auth.Hooks, authCtx auth.Context, env *[]string, persistedEnv map[string]string, secretsLayers []auth.SecretsLayer, authStorage *backend.StoreRef, activeSecrets []activeSecret) (apiKeyInjectionResult, error) {
 	result := apiKeyInjectionResult{
 		ProviderHasEnvCredential: map[string]bool{},
 		ResolvedSecretIDs:        map[string]bool{},
@@ -170,7 +170,7 @@ func (m authManager) injectDeclaredSecrets(hooks auth.Hooks, authCtx auth.Contex
 	}
 	secretReleaseEnabled := m.shouldUseSecretReleases(eligibleSecrets)
 	for _, secret := range eligibleSecrets {
-		secretValue, secretSource, found, err := resolveActiveSecretValue(secret, m.host.Home, layeredSecrets, persistedEnv)
+		secretValue, secretSource, found, err := resolveActiveSecretValue(secret, m.host.Home, secretsLayers, persistedEnv)
 		if err != nil {
 			return result, fmt.Errorf("resolve secret %q: %w", secret.ID, err)
 		}

--- a/internal/runtime/auth_manager_test.go
+++ b/internal/runtime/auth_manager_test.go
@@ -249,7 +249,7 @@ func TestInjectDeclaredSecretsUsesPlaceholderAndRealHookValue(t *testing.T) {
 
 	env := []string{}
 	hooks := &captureHooks{}
-	injection, err := manager.injectDeclaredSecrets(hooks, authContextForRuntime(r), &env, map[string]string{}, map[string]string{}, nil, activeSecrets)
+	injection, err := manager.injectDeclaredSecrets(hooks, authContextForRuntime(r), &env, map[string]string{}, nil, nil, activeSecrets)
 	if err != nil {
 		t.Fatalf("injectDeclaredSecrets() error = %v", err)
 	}
@@ -295,7 +295,7 @@ func TestInjectDeclaredSecretsUsesPersistedFallbackForAliases(t *testing.T) {
 		authContextForRuntime(r),
 		&env,
 		map[string]string{"PRIMARY_TOKEN": "persisted-token"},
-		map[string]string{},
+		nil,
 		nil,
 		activeSecrets,
 	)
@@ -345,8 +345,8 @@ func TestInjectDeclaredSecretsPrefersLayeredSecretsOverStalePersistedAlias(t *te
 		stubHooks{},
 		authContextForRuntime(r),
 		&env,
-		map[string]string{"GH_TOKEN": "stale-token"},       // persisted
-		map[string]string{"GITHUB_TOKEN": "rotated-token"}, // layered secrets
+		map[string]string{"GH_TOKEN": "stale-token"}, // persisted
+		secretsLayers(map[string]string{"GITHUB_TOKEN": "rotated-token"}),
 		nil,
 		activeSecrets,
 	)
@@ -383,7 +383,7 @@ func TestInjectDeclaredSecretsRejectsConflictingAliasValuesInSameLayer(t *testin
 		authContextForRuntime(r),
 		&[]string{},
 		map[string]string{},
-		map[string]string{},
+		nil,
 		nil,
 		activeSecrets,
 	)
@@ -392,9 +392,6 @@ func TestInjectDeclaredSecretsRejectsConflictingAliasValuesInSameLayer(t *testin
 	}
 	if !strings.Contains(err.Error(), "conflicting values across env aliases") {
 		t.Fatalf("injectDeclaredSecrets() error = %q, want alias conflict", err)
-	}
-	if !strings.Contains(err.Error(), "the env layer") {
-		t.Fatalf("injectDeclaredSecrets() error = %q, want the conflicting layer named", err)
 	}
 }
 
@@ -423,7 +420,7 @@ func TestInjectDeclaredSecretsFallsBackToRealValueWhenPlaceholderFails(t *testin
 		authContextForRuntime(r),
 		&env,
 		map[string]string{},
-		map[string]string{},
+		nil,
 		nil,
 		activeSecrets,
 	)
@@ -448,9 +445,9 @@ func TestInjectDeclaredSecretsOnlyInjectsDeclaredLayeredSecrets(t *testing.T) {
 		1: "DECLARED_KEY=declared\nUNDECLARED_KEY=should-not-leak\n",
 	})
 
-	layeredSecrets, err := auth.ResolveLayeredSecrets(home, projectHash, tool, model.SecretsScopeBoth)
+	layers, err := auth.ResolveSecretsLayers(home, projectHash, tool, model.SecretsScopeBoth)
 	if err != nil {
-		t.Fatalf("ResolveLayeredSecrets() error = %v", err)
+		t.Fatalf("ResolveSecretsLayers() error = %v", err)
 	}
 
 	r := runtimeWithProfile(t, model.Profile{
@@ -471,7 +468,7 @@ func TestInjectDeclaredSecretsOnlyInjectsDeclaredLayeredSecrets(t *testing.T) {
 		authContextForRuntime(r),
 		&env,
 		map[string]string{},
-		layeredSecrets,
+		layers,
 		nil,
 		activeSecrets,
 	)
@@ -563,11 +560,11 @@ func TestInjectDeclaredSecretsSuppressesOnlyProviderAPIKeySecrets(t *testing.T) 
 				authContextForRuntime(r),
 				&env,
 				map[string]string{},
-				map[string]string{
+				secretsLayers(map[string]string{
 					"API_KEY":     "api-secret",
 					"OAUTH_TOKEN": "oauth-secret",
 					"GH_TOKEN":    "github-secret",
-				},
+				}),
 				nil,
 				activeSecrets,
 			)
@@ -679,7 +676,7 @@ func TestInjectDeclaredSecretsUsesDistinctGitLabReleaseShapes(t *testing.T) {
 		authContextForRuntime(r),
 		&env,
 		map[string]string{},
-		map[string]string{},
+		nil,
 		nil,
 		activeSecrets,
 	)
@@ -748,7 +745,7 @@ func TestInjectDeclaredSecretsProxyManagedRestrictsPlaceholderToListedVars(t *te
 		authContextForRuntime(r),
 		&env,
 		map[string]string{},
-		map[string]string{},
+		nil,
 		nil,
 		activeSecrets,
 	)
@@ -886,6 +883,15 @@ func mustActiveSecrets(t *testing.T, r *Runtime) []activeSecret {
 		t.Fatalf("activeSecrets() error = %v", err)
 	}
 	return secrets
+}
+
+// secretsLayers wraps a flat map as a single secrets-file layer for tests that
+// do not care which file a value came from.
+func secretsLayers(values map[string]string) []auth.SecretsLayer {
+	if len(values) == 0 {
+		return nil
+	}
+	return []auth.SecretsLayer{{Path: "global.env", Values: values}}
 }
 
 func setupSecretFiles(t *testing.T, home, tool, projectHash string, layers map[int]string) {

--- a/internal/runtime/auth_manager_test.go
+++ b/internal/runtime/auth_manager_test.go
@@ -323,8 +323,51 @@ func TestInjectDeclaredSecretsUsesPersistedFallbackForAliases(t *testing.T) {
 	}
 }
 
-func TestInjectDeclaredSecretsRejectsConflictingAliasValues(t *testing.T) {
+// A stale persisted alias must lose to the layered secrets files rather than
+// wedge the run, which is the drift that broke token rotation. Every alias then
+// carries the winning value, so the persisted store heals.
+func TestInjectDeclaredSecretsPrefersLayeredSecretsOverStalePersistedAlias(t *testing.T) {
+	// An ambient token in the caller's shell would win as the host env layer.
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	r := runtimeWithProfile(t, model.Profile{
+		Name: "tool",
+		Secrets: map[string]model.SecretConfig{
+			"github-token": secretConfig([]string{"GH_TOKEN", "GITHUB_TOKEN"}, nil),
+		},
+	})
+	manager := newAuthManager(r)
+	activeSecrets := mustActiveSecrets(t, r)
+
+	env := []string{}
+	injection, err := manager.injectDeclaredSecrets(
+		stubHooks{},
+		authContextForRuntime(r),
+		&env,
+		map[string]string{"GH_TOKEN": "stale-token"},       // persisted
+		map[string]string{"GITHUB_TOKEN": "rotated-token"}, // layered secrets
+		nil,
+		activeSecrets,
+	)
+	if err != nil {
+		t.Fatalf("injectDeclaredSecrets() error = %v", err)
+	}
+	for _, envVar := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if got := envValue(env, envVar); got != "rotated-token" {
+			t.Fatalf("%s = %q, want %q", envVar, got, "rotated-token")
+		}
+		if got := injection.SecretValues[envVar]; got != "rotated-token" {
+			t.Fatalf("SecretValues[%s] = %q, want %q", envVar, got, "rotated-token")
+		}
+	}
+}
+
+// Aliases that resolve within the same layer are the one case the user must
+// fix, so that stays fatal.
+func TestInjectDeclaredSecretsRejectsConflictingAliasValuesInSameLayer(t *testing.T) {
 	t.Setenv("FIRST_TOKEN", "first-token")
+	t.Setenv("SECOND_TOKEN", "second-token")
 
 	r := runtimeWithProfile(t, model.Profile{
 		Name: "tool",
@@ -339,7 +382,7 @@ func TestInjectDeclaredSecretsRejectsConflictingAliasValues(t *testing.T) {
 		stubHooks{},
 		authContextForRuntime(r),
 		&[]string{},
-		map[string]string{"SECOND_TOKEN": "second-token"},
+		map[string]string{},
 		map[string]string{},
 		nil,
 		activeSecrets,
@@ -349,6 +392,9 @@ func TestInjectDeclaredSecretsRejectsConflictingAliasValues(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "conflicting values across env aliases") {
 		t.Fatalf("injectDeclaredSecrets() error = %q, want alias conflict", err)
+	}
+	if !strings.Contains(err.Error(), "the env layer") {
+		t.Fatalf("injectDeclaredSecrets() error = %q, want the conflicting layer named", err)
 	}
 }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Aliases were compared for equality before layer precedence was applied, so a stale value in the persisted env store hard-failed the run instead of losing to a rotated value in the layered secrets files. Rotating a token that is declared under two aliases (GH_TOKEN/GITHUB_TOKEN) wedged every project whose persisted store still held the old value.

The highest-priority layer now wins outright. Only aliases resolved from the same layer must agree, since that is the one case the user has to fix; the error names the layer. Cross-layer drift is warned about and heals on the next run, because the winning value is injected into every alias and written back to the persisted store.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Change your GH_TOKEN/GITHUB_TOKEN to a temporary value (if it was set beforehand) and see that the build succeeds, beforehand it would fail with an error.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
