### PR TITLE
feat: point gitlab-cli at a self-hosted host via GITLAB_HOST

### DIFF
--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -429,12 +429,16 @@ Secrets are split across two `spec.yaml` sections:
 - `network.serviceAuth.<service-id>.hostsFromCredential` names another
   `credentials.sources` id whose resolved value is a host, for services that
   can point at a self-hosted instance. When that credential resolves, its value
-  **replaces** the declared `hosts` for this service — it is not additive,
-  since an instance-specific token must not be released to the public default
-  host as well. The replacement host joins the allow set like a declared one,
-  so one env var is enough to make the tool reach the instance with token
-  injection working. An unset credential keeps the declared hosts; a value that
-  is not a usable host warns and is ignored. Values may be a bare host,
+  becomes the **only** host this service's token is released to, replacing the
+  declared `hosts` and any `serviceDomains` entries pointing at the service —
+  an instance-specific token must not be released to the public default host as
+  well. The network allow set is *not* narrowed: the selected host is added to
+  it, and the declared hosts stay reachable. So one env var is enough to make
+  the tool reach the instance with token injection working. An unset credential
+  keeps the declared hosts as the release targets, and the resolved value is not
+  written to the persisted env store, so it never outlives the run that set it.
+  A value that is not a usable host warns and is ignored; wildcards are
+  rejected, since the point is to name one instance. Values may be a bare host,
   `host:port`, or a full URL — the scheme, port and path are stripped.
 
 The placeholder convention is Go `fmt`-style `%s`, not `{secret}`. An empty

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -428,13 +428,20 @@ Secrets are split across two `spec.yaml` sections:
   `serviceDomains` or from its own `hosts` list.
 - `network.serviceAuth.<service-id>.hostsFromCredential` names another
   `credentials.sources` id whose resolved value is a host, for services that
-  can point at a self-hosted instance. When that credential resolves, its value
+  can point at a self-hosted instance. It does not stand in for the hosts the
+  pairing above requires: the service still needs `hosts` or `serviceDomains`
+  entries, which remain the release targets whenever the credential is unset.
+  When that credential resolves, its value
   becomes the **only** host this service's token is released to, replacing the
   declared `hosts` and any `serviceDomains` entries pointing at the service —
   an instance-specific token must not be released to the public default host as
-  well. The network allow set is *not* narrowed: the selected host is added to
-  it, and the declared hosts stay reachable. So one env var is enough to make
-  the tool reach the instance with token injection working. An unset credential
+  well. Unlike a declared host, which the gateway also applies to everything
+  beneath it, the selected host is matched exactly: the token reaches
+  `gitlab.example.com` and not `runner.gitlab.example.com`. The network allow
+  set is *not* narrowed: the selected host is added to it (with the usual
+  subdomain reach, so the instance's other hosts stay resolvable), and the
+  declared hosts stay reachable. So one env var is enough to make the tool
+  reach the instance with token injection working. An unset credential
   keeps the declared hosts as the release targets, and the resolved value is not
   written to the persisted env store, so it never outlives the run that set it.
   A value that is not a usable host warns and is ignored; wildcards are

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -426,6 +426,16 @@ Secrets are split across two `spec.yaml` sections:
   `network.allowedDomains` instead. The pairing is required in both directions:
   a `serviceAuth` entry also needs at least one host, either from
   `serviceDomains` or from its own `hosts` list.
+- `network.serviceAuth.<service-id>.hostsFromCredential` names another
+  `credentials.sources` id whose resolved value is a host, for services that
+  can point at a self-hosted instance. When that credential resolves, its value
+  **replaces** the declared `hosts` for this service — it is not additive,
+  since an instance-specific token must not be released to the public default
+  host as well. The replacement host joins the allow set like a declared one,
+  so one env var is enough to make the tool reach the instance with token
+  injection working. An unset credential keeps the declared hosts; a value that
+  is not a usable host warns and is ignored. Values may be a bare host,
+  `host:port`, or a full URL — the scheme, port and path are stripped.
 
 The placeholder convention is Go `fmt`-style `%s`, not `{secret}`. An empty
 `valueFormat` means "inject the raw secret value" with no wrapping (see

--- a/extensions/features/gitlab-cli/README.md
+++ b/extensions/features/gitlab-cli/README.md
@@ -8,3 +8,28 @@ requests from the command line. Opt-in (disabled by default).
 ## Installation
 
 Downloads the latest `.deb` release from GitLab's release API. Requires root.
+
+## Auth
+
+`GITLAB_TOKEN`/`GITLAB_ACCESS_TOKEN`, `OAUTH_TOKEN` and
+`JOB_TOKEN`/`CI_JOB_TOKEN` are resolved from the host environment, the layered
+secrets files, or the persisted env store, and injected as env vars. `spec.yaml`
+maps each to the header the gateway injects.
+
+## Self-hosted instances
+
+Set `GITLAB_HOST` to point `glab` at a self-hosted instance:
+
+```bash
+GITLAB_HOST=gitlab.example.com enclave --features +gitlab-cli
+```
+
+That single env var selects the instance for `glab`, retargets token injection,
+and joins the network allowlist — no spec edit or `allow_domains` entry. See
+`serviceAuth.hostsFromCredential` in `docs/extensions/README.md` for the
+accepted value forms and why the host replaces the `gitlab.com` defaults instead
+of adding to them.
+
+To set it persistently, put it in a secrets file rather than the shell — global
+in `~/.local/state/enclave/secrets/global.env`, or per project under
+`~/.local/state/enclave/projects/<hash>/`.

--- a/extensions/features/gitlab-cli/README.md
+++ b/extensions/features/gitlab-cli/README.md
@@ -24,12 +24,14 @@ Set `GITLAB_HOST` to point `glab` at a self-hosted instance:
 GITLAB_HOST=gitlab.example.com enclave --features +gitlab-cli
 ```
 
-That single env var selects the instance for `glab`, retargets token injection,
-and joins the network allowlist — no spec edit or `allow_domains` entry. See
-`serviceAuth.hostsFromCredential` in `docs/extensions/README.md` for the
-accepted value forms and why the host replaces the `gitlab.com` defaults instead
-of adding to them.
+That single env var selects the instance for `glab`, retargets token injection
+at it, and joins the network allowlist — no spec edit or `allow_domains` entry.
+The tokens then go only to that instance, while `gitlab.com` stays reachable.
+See `serviceAuth.hostsFromCredential` in `docs/extensions/README.md` for the
+accepted value forms.
 
-To set it persistently, put it in a secrets file rather than the shell — global
-in `~/.local/state/enclave/secrets/global.env`, or per project under
-`~/.local/state/enclave/projects/<hash>/`.
+`GITLAB_HOST` applies to the run that sets it and is not written to the
+persisted env store. To make it permanent, put it in a secrets file — globally
+in `~/.local/state/enclave/secrets/global.env`, or per project in
+`~/.local/state/enclave/secrets/projects/<hash>/<tool>.env`, which is keyed by
+the agent tool (e.g. `claude.env`), not by this feature.

--- a/extensions/features/gitlab-cli/README.md
+++ b/extensions/features/gitlab-cli/README.md
@@ -26,7 +26,8 @@ GITLAB_HOST=gitlab.example.com enclave --features +gitlab-cli
 
 That single env var selects the instance for `glab`, retargets token injection
 at it, and joins the network allowlist — no spec edit or `allow_domains` entry.
-The tokens then go only to that instance, while `gitlab.com` stays reachable.
+The tokens then go only to that exact host — not to its subdomains, and not to
+`gitlab.com`, which stays reachable but sees no token.
 See `serviceAuth.hostsFromCredential` in `docs/extensions/README.md` for the
 accepted value forms.
 

--- a/extensions/features/gitlab-cli/spec.yaml
+++ b/extensions/features/gitlab-cli/spec.yaml
@@ -18,8 +18,11 @@ credentials:
     gitlab-token: { env: [GITLAB_TOKEN, GITLAB_ACCESS_TOKEN] }
     gitlab-oauth-token: { env: [OAUTH_TOKEN] }
     gitlab-job-token: { env: [JOB_TOKEN, CI_JOB_TOKEN] }
+    # Not a credential: glab reads GITLAB_HOST to pick the instance, and
+    # hostsFromCredential below retargets token injection at it.
+    gitlab-host: { env: [GITLAB_HOST], apiKey: false }
 network:
   serviceAuth:
-    gitlab-token: { headerName: private-token, hosts: [gitlab.com, "*.gitlab.com"] }
-    gitlab-oauth-token: { headerName: authorization, valueFormat: "Bearer %s", hosts: [gitlab.com, "*.gitlab.com"] }
-    gitlab-job-token: { headerName: job-token, hosts: [gitlab.com, "*.gitlab.com"] }
+    gitlab-token: { headerName: private-token, hosts: [gitlab.com, "*.gitlab.com"], hostsFromCredential: gitlab-host }
+    gitlab-oauth-token: { headerName: authorization, valueFormat: "Bearer %s", hosts: [gitlab.com, "*.gitlab.com"], hostsFromCredential: gitlab-host }
+    gitlab-job-token: { headerName: job-token, hosts: [gitlab.com, "*.gitlab.com"], hostsFromCredential: gitlab-host }

--- a/internal/backend/docker/gateway.go
+++ b/internal/backend/docker/gateway.go
@@ -108,6 +108,7 @@ func writeSecretReleaseConfig(secrets []backend.SecretRelease) (string, error) {
 			Hosts:       append([]string(nil), secret.HTTP.Hosts...),
 			Header:      secret.HTTP.Header,
 			Format:      secret.HTTP.Format,
+			ExactHosts:  secret.HTTP.ExactHosts,
 		})
 	}
 	if len(entries) == 0 {

--- a/internal/backend/docker/gateway_test.go
+++ b/internal/backend/docker/gateway_test.go
@@ -68,6 +68,35 @@ func TestWriteSecretReleaseConfig(t *testing.T) {
 	}
 }
 
+// The exact-host flag is what keeps a runtime-selected instance from releasing
+// the token to its subdomains, so it has to survive the host/gateway wire.
+func TestWriteSecretReleaseConfigKeepsExactHosts(t *testing.T) {
+	path, err := writeSecretReleaseConfig([]backend.SecretRelease{
+		{
+			SecretID:    "gitlab-token",
+			Placeholder: "ENCLAVE_SECRET_abc",
+			Value:       "real",
+			HTTP: &backend.HTTPReleaseRule{
+				Hosts:      []string{"gitlab.example.com"},
+				Header:     "private-token",
+				ExactHosts: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("writeSecretReleaseConfig() error = %v", err)
+	}
+	defer func() { _ = os.Remove(path) }()
+
+	loaded, err := mitm.LoadRules(path)
+	if err != nil {
+		t.Fatalf("LoadRules(%q) error = %v", path, err)
+	}
+	if len(loaded) != 1 || !loaded[0].ExactHosts {
+		t.Fatalf("LoadRules(%q) = %#v, want a single exact-host rule", path, loaded)
+	}
+}
+
 func TestWorkspaceIDFromSessionPrefersRealWorktree(t *testing.T) {
 	got := workspaceIDFromSession(backend.SessionMeta{
 		Worktree:     "/workspace/project",

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -217,6 +217,9 @@ type HTTPReleaseRule struct {
 	Hosts  []string
 	Header string
 	Format string
+	// ExactHosts matches Hosts by equality rather than covering subdomains;
+	// see model.SecretReleaseEntry.
+	ExactHosts bool
 }
 
 type PortMapping struct {

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -241,9 +241,10 @@ func normalizeSecretRelease(secretID string, release *model.SecretReleaseConfig)
 
 	return &model.SecretReleaseConfig{
 		HTTP: &model.HTTPSecretReleaseConfig{
-			Hosts:  hosts,
-			Header: header,
-			Format: format,
+			Hosts:           hosts,
+			Header:          header,
+			Format:          format,
+			HostsFromSecret: strings.TrimSpace(release.HTTP.HostsFromSecret),
 		},
 	}, nil
 }

--- a/internal/config/spec.go
+++ b/internal/config/spec.go
@@ -129,6 +129,11 @@ type specServiceAuth struct {
 	// these hosts are unioned with any serviceDomains entries pointing at this
 	// service id.
 	Hosts []string `json:"hosts,omitempty"`
+	// HostsFromCredential names a credentials.sources id whose resolved value
+	// is a host. When that credential resolves at runtime, its value replaces
+	// Hosts for this service, so a self-hosted instance can be selected by
+	// setting one env var instead of editing the spec.
+	HostsFromCredential string `json:"hostsFromCredential,omitempty"`
 }
 
 type specEnvironment struct {

--- a/internal/config/spec_map.go
+++ b/internal/config/spec_map.go
@@ -41,9 +41,17 @@ func validateServiceAuthMappings(doc specDocument, specPath string) error {
 	}
 	// Unknown ids come first: a typo'd id also breaks the pairing, and reporting
 	// the pairing gap would send the author to the wrong line.
-	for id := range doc.Network.ServiceAuth {
+	for id, auth := range doc.Network.ServiceAuth {
 		if _, ok := sources[id]; !ok {
 			return fmt.Errorf("%s: network.serviceAuth[%q] has no matching credentials.sources entry", specPath, id)
+		}
+		if auth.HostsFromCredential == "" {
+			continue
+		}
+		// Same typo class as the service ids above: an unmatched reference
+		// would silently leave the service pinned to its static hosts.
+		if _, ok := sources[auth.HostsFromCredential]; !ok {
+			return fmt.Errorf("%s: network.serviceAuth[%q].hostsFromCredential references credential %q with no matching credentials.sources entry", specPath, id, auth.HostsFromCredential)
 		}
 	}
 	hostedServices := map[string]struct{}{}
@@ -176,9 +184,10 @@ func buildSecrets(doc specDocument) map[string]model.SecretConfig {
 			if auth, ok := doc.Network.ServiceAuth[id]; ok {
 				sc.Release = &model.SecretReleaseConfig{
 					HTTP: &model.HTTPSecretReleaseConfig{
-						Hosts:  hostsByService[id],
-						Header: auth.HeaderName,
-						Format: auth.ValueFormat,
+						Hosts:           hostsByService[id],
+						Header:          auth.HeaderName,
+						Format:          auth.ValueFormat,
+						HostsFromSecret: auth.HostsFromCredential,
 					},
 				}
 			}

--- a/internal/config/spec_map_test.go
+++ b/internal/config/spec_map_test.go
@@ -141,6 +141,46 @@ network:
 		}
 	})
 
+	t.Run("unmatched hostsFromCredential fails", func(t *testing.T) {
+		doc := mustDoc(t, `
+schemaVersion: "1"
+kind: mixin
+name: gitlab-cli
+credentials:
+  sources:
+    gitlab-token: { env: [GITLAB_TOKEN] }
+    gitlab-host: { env: [GITLAB_HOST], apiKey: false }
+network:
+  serviceAuth:
+    gitlab-token: { headerName: private-token, hosts: [gitlab.com], hostsFromCredential: gitlab-hsot }
+`)
+		if err := validateServiceAuthMappings(doc, "gitlab-cli/spec.yaml"); err == nil {
+			t.Fatal("expected error for hostsFromCredential with no matching credentials.sources entry")
+		}
+	})
+
+	t.Run("matching hostsFromCredential passes", func(t *testing.T) {
+		doc := mustDoc(t, `
+schemaVersion: "1"
+kind: mixin
+name: gitlab-cli
+credentials:
+  sources:
+    gitlab-token: { env: [GITLAB_TOKEN] }
+    gitlab-host: { env: [GITLAB_HOST], apiKey: false }
+network:
+  serviceAuth:
+    gitlab-token: { headerName: private-token, hosts: [gitlab.com], hostsFromCredential: gitlab-host }
+`)
+		if err := validateServiceAuthMappings(doc, "gitlab-cli/spec.yaml"); err != nil {
+			t.Fatalf("validateServiceAuthMappings() error = %v, want nil", err)
+		}
+		secrets := buildSecrets(doc)
+		if got := secrets["gitlab-token"].Release.HTTP.HostsFromSecret; got != "gitlab-host" {
+			t.Fatalf("HostsFromSecret = %q, want %q", got, "gitlab-host")
+		}
+	})
+
 	t.Run("matching ids pass", func(t *testing.T) {
 		doc := mustDoc(t, `
 schemaVersion: "1"

--- a/internal/config/testdata/golden/feature-gitlab-cli.json
+++ b/internal/config/testdata/golden/feature-gitlab-cli.json
@@ -5,6 +5,12 @@
   "needs_root": true,
   "priority": 50,
   "secrets": {
+    "gitlab-host": {
+      "env_vars": [
+        "GITLAB_HOST"
+      ],
+      "api_key": false
+    },
     "gitlab-job-token": {
       "env_vars": [
         "JOB_TOKEN",
@@ -16,7 +22,8 @@
             "*.gitlab.com",
             "gitlab.com"
           ],
-          "header": "job-token"
+          "header": "job-token",
+          "hosts_from_secret": "gitlab-host"
         }
       }
     },
@@ -31,7 +38,8 @@
             "gitlab.com"
           ],
           "header": "authorization",
-          "format": "Bearer %s"
+          "format": "Bearer %s",
+          "hosts_from_secret": "gitlab-host"
         }
       }
     },
@@ -46,7 +54,8 @@
             "*.gitlab.com",
             "gitlab.com"
           ],
-          "header": "private-token"
+          "header": "private-token",
+          "hosts_from_secret": "gitlab-host"
         }
       }
     }

--- a/internal/gateway/mitm/proxy.go
+++ b/internal/gateway/mitm/proxy.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -487,11 +488,26 @@ func requiresMITM(host string, rules []model.SecretReleaseEntry) bool {
 		return false
 	}
 	for _, rule := range rules {
-		if hostAllowed(normalizedHost, rule.Hosts) {
+		if releaseHostMatch(normalizedHost, rule) {
 			return true
 		}
 	}
 	return false
+}
+
+// releaseHostMatch reports whether a normalized request host is a release
+// target of rule. Declared patterns keep the allowlist semantics, where a bare
+// host also covers its subdomains; a rule marked ExactHosts matches only the
+// hosts it names, because those were selected at runtime to name one instance.
+func releaseHostMatch(host string, rule model.SecretReleaseEntry) bool {
+	if rule.ExactHosts {
+		normalized, err := domainpattern.NormalizeHost(host)
+		if err != nil {
+			return false
+		}
+		return slices.Contains(rule.Hosts, normalized)
+	}
+	return hostAllowed(host, rule.Hosts)
 }
 
 func shouldMITM(host string, rules []model.SecretReleaseEntry, forceHTTPSMITM bool) bool {
@@ -692,6 +708,12 @@ func normalizeRule(rule model.SecretReleaseEntry) (model.SecretReleaseEntry, err
 		if value == "" {
 			continue
 		}
+		// A wildcard cannot be matched by equality, so an exact rule carrying
+		// one would silently release the secret nowhere. The host selector
+		// already rejects wildcards; fail loudly if one reaches the gateway.
+		if rule.ExactHosts && strings.Contains(value, "*") {
+			return model.SecretReleaseEntry{}, fmt.Errorf("secret release entry has wildcard host %q in exact-host rule for %q", value, rule.SecretID)
+		}
 		normalizedHosts = append(normalizedHosts, value)
 	}
 	hosts := util.Dedupe(normalizedHosts)
@@ -723,7 +745,7 @@ func rewriteHeaders(scheme string, host string, headers http.Header, rules []mod
 				if !secureTransport {
 					return fmt.Errorf("request denied")
 				}
-				if !hostAllowed(normalizedHost, rule.Hosts) {
+				if !releaseHostMatch(normalizedHost, rule) {
 					return fmt.Errorf("request denied")
 				}
 				replacement := rule.Value

--- a/internal/gateway/mitm/proxy_test.go
+++ b/internal/gateway/mitm/proxy_test.go
@@ -88,6 +88,68 @@ func TestRewriteHeadersUnauthorizedHostBlocked(t *testing.T) {
 	}
 }
 
+// A host selected at runtime names one instance, so the token must not reach
+// hosts beneath it the way a declared pattern would allow.
+func TestRewriteHeadersExactHostRejectsSubdomain(t *testing.T) {
+	rule := model.SecretReleaseEntry{
+		Placeholder: "ENCLAVE_SECRET_abc",
+		Value:       "real-secret",
+		Hosts:       []string{"gitlab.example.com"},
+		Header:      "private-token",
+		ExactHosts:  true,
+	}
+
+	headers := http.Header{}
+	headers.Set("Private-Token", "ENCLAVE_SECRET_abc")
+	if err := rewriteHeaders("https", "runner.gitlab.example.com", headers, []model.SecretReleaseEntry{rule}); err == nil {
+		t.Fatal("rewriteHeaders() error = nil, want the subdomain denied")
+	}
+	if got := headers.Get("Private-Token"); got != "ENCLAVE_SECRET_abc" {
+		t.Fatalf("header value = %q, want placeholder unchanged", got)
+	}
+
+	headers = http.Header{}
+	headers.Set("Private-Token", "ENCLAVE_SECRET_abc")
+	if err := rewriteHeaders("https", "gitlab.example.com", headers, []model.SecretReleaseEntry{rule}); err != nil {
+		t.Fatalf("rewriteHeaders() error = %v, want the selected host allowed", err)
+	}
+	if got := headers.Get("Private-Token"); got != "real-secret" {
+		t.Fatalf("header value = %q, want %q", got, "real-secret")
+	}
+}
+
+func TestRequiresMITMExactHostsIgnoresSubdomain(t *testing.T) {
+	rules := []model.SecretReleaseEntry{
+		{
+			Placeholder: "ENCLAVE_SECRET_abc",
+			Value:       "real-secret",
+			Hosts:       []string{"gitlab.example.com"},
+			Header:      "private-token",
+			ExactHosts:  true,
+		},
+	}
+	if !requiresMITM("gitlab.example.com", rules) {
+		t.Fatal("requiresMITM(gitlab.example.com) = false, want true")
+	}
+	if requiresMITM("runner.gitlab.example.com", rules) {
+		t.Fatal("requiresMITM(runner.gitlab.example.com) = true, want false")
+	}
+}
+
+func TestNormalizeRuleRejectsWildcardInExactHostRule(t *testing.T) {
+	_, err := normalizeRule(model.SecretReleaseEntry{
+		SecretID:    "gitlab-token",
+		Placeholder: "ENCLAVE_SECRET_abc",
+		Value:       "real-secret",
+		Hosts:       []string{"*.gitlab.example.com"},
+		Header:      "private-token",
+		ExactHosts:  true,
+	})
+	if err == nil {
+		t.Fatal("normalizeRule() error = nil, want a wildcard in an exact-host rule rejected")
+	}
+}
+
 func TestNormalizeHostStripsLeadingDot(t *testing.T) {
 	got, err := domainpattern.NormalizeHost(".API.EXAMPLE.COM.")
 	if err != nil {

--- a/internal/model/state.go
+++ b/internal/model/state.go
@@ -25,6 +25,12 @@ type SecretReleaseEntry struct {
 	Hosts       []string `json:"hosts"`
 	Header      string   `json:"header"`
 	Format      string   `json:"format,omitempty"`
+	// ExactHosts matches Hosts by equality instead of the allowlist rule where
+	// a bare pattern also covers its subdomains. Set for hosts selected at
+	// runtime through serviceAuth.hostsFromCredential: that value names one
+	// instance the token belongs to, so releasing it to every host beneath it
+	// would widen exactly what naming the instance is meant to narrow.
+	ExactHosts bool `json:"exact_hosts,omitempty"`
 }
 
 func (s AuthState) HasAnyEnvCredential() bool {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -260,6 +260,10 @@ type HTTPSecretReleaseConfig struct {
 	Hosts  []string `json:"hosts"`
 	Header string   `json:"header"`
 	Format string   `json:"format,omitempty"`
+	// HostsFromSecret names another secret id whose resolved value is a host.
+	// When that secret resolves, its value replaces Hosts for this release
+	// rule; see spec.yaml network.serviceAuth.hostsFromCredential.
+	HostsFromSecret string `json:"hosts_from_secret,omitempty"`
 }
 
 // ReleaseHosts returns the sorted, deduplicated HTTP release hosts declared

--- a/internal/runtime/active_secrets.go
+++ b/internal/runtime/active_secrets.go
@@ -9,7 +9,9 @@ package runtime
 
 import (
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -18,6 +20,7 @@ import (
 	"enclave/internal/logx"
 	"enclave/internal/model"
 	"enclave/internal/secretfile"
+	"enclave/internal/util"
 )
 
 type activeSecret struct {
@@ -187,30 +190,40 @@ func resolveAlias(envVar string, secretsLayers []auth.SecretsLayer, persistedEnv
 	return aliasValue{}, false
 }
 
+// hostCredentialRefs maps a host-selector credential id to the secret ids whose
+// release hosts it overrides. Several services commonly share one host
+// credential (gitlab's three tokens), so the reference is resolved once.
+func hostCredentialRefs(secrets []activeSecret) map[string][]string {
+	refs := map[string][]string{}
+	for _, secret := range secrets {
+		if secret.ReleaseHTTP != nil && secret.ReleaseHTTP.HostsFromSecret != "" {
+			ref := secret.ReleaseHTTP.HostsFromSecret
+			refs[ref] = append(refs[ref], secret.ID)
+		}
+	}
+	return refs
+}
+
 // resolveReleaseHostOverrides resolves the credentials named by each release
-// rule's HostsFromSecret and returns secret-id -> replacement hosts. A service
-// whose host credential is unset or unusable keeps its declared hosts, so the
-// default (e.g. gitlab.com) still applies.
+// rule's HostsFromSecret and returns secret-id -> replacement release hosts. A
+// service whose host credential is unset or unusable keeps its declared hosts,
+// so the default (e.g. gitlab.com) still applies.
 //
 // The replacement is deliberately not additive: the referenced credential names
 // the one instance the token belongs to, and injecting an instance-specific
 // token into the default hosts as well would expose it to a service that cannot
-// accept it.
+// accept it. It narrows token release only — the declared hosts stay in the
+// network allow set, see Runtime.releaseHosts.
 func resolveReleaseHostOverrides(secrets []activeSecret, hostHome string, secretsLayers []auth.SecretsLayer, persistedEnv map[string]string) map[string][]string {
-	// Several services commonly share one host credential (gitlab's three
-	// tokens), so group by the reference and resolve each credential once.
 	byID := make(map[string]activeSecret, len(secrets))
-	referencedBy := map[string][]string{}
 	for _, secret := range secrets {
 		byID[secret.ID] = secret
-		if secret.ReleaseHTTP != nil && secret.ReleaseHTTP.HostsFromSecret != "" {
-			ref := secret.ReleaseHTTP.HostsFromSecret
-			referencedBy[ref] = append(referencedBy[ref], secret.ID)
-		}
 	}
 
 	overrides := map[string][]string{}
-	for ref, secretIDs := range referencedBy {
+	refs := hostCredentialRefs(secrets)
+	for _, ref := range slices.Sorted(maps.Keys(refs)) {
+		secretIDs := refs[ref]
 		source, ok := byID[ref]
 		if !ok {
 			continue
@@ -227,6 +240,7 @@ func resolveReleaseHostOverrides(secrets []activeSecret, hostHome string, secret
 		if host == "" {
 			continue
 		}
+		logx.Infof("Host credential %s selects %s for %s", ref, host, strings.Join(secretIDs, ", "))
 		for _, id := range secretIDs {
 			overrides[id] = []string{host}
 		}
@@ -237,7 +251,9 @@ func resolveReleaseHostOverrides(secrets []activeSecret, hostHome string, secret
 // normalizeReleaseHost turns a credential value into an allowlist-comparable
 // host, tolerating the URL forms CLIs accept (glab reads GITLAB_HOST as either
 // a bare host or a full URL). An unusable value warns and is dropped rather
-// than failing the session, since the declared hosts remain valid.
+// than failing the session, since the declared hosts remain valid. The value is
+// redacted in the warning: the credential is declared like any other, so a
+// misconfigured spec could point this at a token.
 func normalizeReleaseHost(secretID string, value string) string {
 	trimmed := value
 	if index := strings.Index(trimmed, "://"); index >= 0 {
@@ -245,6 +261,13 @@ func normalizeReleaseHost(secretID string, value string) string {
 	}
 	if index := strings.IndexAny(trimmed, "/?#"); index >= 0 {
 		trimmed = trimmed[:index]
+	}
+	// A wildcard would release the token to every host under a suffix, which
+	// defeats naming the one instance it belongs to. Normalize accepts them, so
+	// reject before it runs.
+	if strings.Contains(trimmed, "*") {
+		logx.Warnf("Secret %s: value %s is a wildcard pattern, not a host; keeping declared hosts.", secretID, util.RedactSecret(value))
+		return ""
 	}
 	// NormalizeHost strips the port and IPv6 brackets but does not validate the
 	// labels, so the pattern validator runs after it to reject junk that would
@@ -254,7 +277,7 @@ func normalizeReleaseHost(secretID string, value string) string {
 		host, err = domainpattern.Normalize(host)
 	}
 	if err != nil {
-		logx.Warnf("Secret %s: value %q is not a usable host (%v); keeping declared hosts.", secretID, value, err)
+		logx.Warnf("Secret %s: value %s is not a usable host (%v); keeping declared hosts.", secretID, util.RedactSecret(value), err)
 		return ""
 	}
 	return host

--- a/internal/runtime/active_secrets.go
+++ b/internal/runtime/active_secrets.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"enclave/internal/auth"
+	"enclave/internal/domainpattern"
 	"enclave/internal/logx"
 	"enclave/internal/model"
 	"enclave/internal/secretfile"
@@ -183,6 +185,79 @@ func resolveAlias(envVar string, secretsLayers []auth.SecretsLayer, persistedEnv
 		return aliasValue{envVar: envVar, value: value, source: "persisted", layer: "the host-side env store", rank: len(secretsLayers) + 1}, true
 	}
 	return aliasValue{}, false
+}
+
+// resolveReleaseHostOverrides resolves the credentials named by each release
+// rule's HostsFromSecret and returns secret-id -> replacement hosts. A service
+// whose host credential is unset or unusable keeps its declared hosts, so the
+// default (e.g. gitlab.com) still applies.
+//
+// The replacement is deliberately not additive: the referenced credential names
+// the one instance the token belongs to, and injecting an instance-specific
+// token into the default hosts as well would expose it to a service that cannot
+// accept it.
+func resolveReleaseHostOverrides(secrets []activeSecret, hostHome string, secretsLayers []auth.SecretsLayer, persistedEnv map[string]string) map[string][]string {
+	// Several services commonly share one host credential (gitlab's three
+	// tokens), so group by the reference and resolve each credential once.
+	byID := make(map[string]activeSecret, len(secrets))
+	referencedBy := map[string][]string{}
+	for _, secret := range secrets {
+		byID[secret.ID] = secret
+		if secret.ReleaseHTTP != nil && secret.ReleaseHTTP.HostsFromSecret != "" {
+			ref := secret.ReleaseHTTP.HostsFromSecret
+			referencedBy[ref] = append(referencedBy[ref], secret.ID)
+		}
+	}
+
+	overrides := map[string][]string{}
+	for ref, secretIDs := range referencedBy {
+		source, ok := byID[ref]
+		if !ok {
+			continue
+		}
+		value, _, found, err := resolveActiveSecretValue(source, hostHome, secretsLayers, persistedEnv)
+		if err != nil {
+			logx.Warnf("Cannot resolve host credential %s (%v); keeping declared hosts.", ref, err)
+			continue
+		}
+		if !found {
+			continue
+		}
+		host := normalizeReleaseHost(ref, value)
+		if host == "" {
+			continue
+		}
+		for _, id := range secretIDs {
+			overrides[id] = []string{host}
+		}
+	}
+	return overrides
+}
+
+// normalizeReleaseHost turns a credential value into an allowlist-comparable
+// host, tolerating the URL forms CLIs accept (glab reads GITLAB_HOST as either
+// a bare host or a full URL). An unusable value warns and is dropped rather
+// than failing the session, since the declared hosts remain valid.
+func normalizeReleaseHost(secretID string, value string) string {
+	trimmed := value
+	if index := strings.Index(trimmed, "://"); index >= 0 {
+		trimmed = trimmed[index+len("://"):]
+	}
+	if index := strings.IndexAny(trimmed, "/?#"); index >= 0 {
+		trimmed = trimmed[:index]
+	}
+	// NormalizeHost strips the port and IPv6 brackets but does not validate the
+	// labels, so the pattern validator runs after it to reject junk that would
+	// otherwise become a bogus allowlist entry.
+	host, err := domainpattern.NormalizeHost(trimmed)
+	if err == nil {
+		host, err = domainpattern.Normalize(host)
+	}
+	if err != nil {
+		logx.Warnf("Secret %s: value %q is not a usable host (%v); keeping declared hosts.", secretID, value, err)
+		return ""
+	}
+	return host
 }
 
 // resolveFileSecretValue reads the secret's file source, if any. A missing file

--- a/internal/runtime/active_secrets.go
+++ b/internal/runtime/active_secrets.go
@@ -213,7 +213,8 @@ func hostCredentialRefs(secrets []activeSecret) map[string][]string {
 // the one instance the token belongs to, and injecting an instance-specific
 // token into the default hosts as well would expose it to a service that cannot
 // accept it. It narrows token release only — the declared hosts stay in the
-// network allow set, see Runtime.releaseHosts.
+// network allow set, see Runtime.releaseHosts. The selected host is released to
+// by equality rather than as a suffix, see model.SecretReleaseEntry.ExactHosts.
 func resolveReleaseHostOverrides(secrets []activeSecret, hostHome string, secretsLayers []auth.SecretsLayer, persistedEnv map[string]string) map[string][]string {
 	byID := make(map[string]activeSecret, len(secrets))
 	for _, secret := range secrets {

--- a/internal/runtime/auth_manager.go
+++ b/internal/runtime/auth_manager.go
@@ -168,9 +168,8 @@ func (m authManager) injectDeclaredSecrets(hooks auth.Hooks, authCtx auth.Contex
 	for _, secret := range suppressedActiveSecrets {
 		logx.Debugf("Suppressed declared API key secret %s due to %s", secret.ID, suppressionReason)
 	}
-	// Must precede shouldUseSecretReleases: that call resolves and caches the
-	// effective policy, which unions the release hosts into the allow set.
-	m.releaseHostOverrides = resolveReleaseHostOverrides(eligibleSecrets, m.host.Home, secretsLayers, persistedEnv)
+	hostCredentials := hostCredentialRefs(eligibleSecrets)
+	m.setReleaseHostOverrides(resolveReleaseHostOverrides(eligibleSecrets, m.host.Home, secretsLayers, persistedEnv))
 	secretReleaseEnabled := m.shouldUseSecretReleases(eligibleSecrets)
 	for _, secret := range eligibleSecrets {
 		secretValue, secretSource, found, err := resolveActiveSecretValue(secret, m.host.Home, secretsLayers, persistedEnv)
@@ -199,12 +198,18 @@ func (m authManager) injectDeclaredSecrets(hooks auth.Hooks, authCtx auth.Contex
 				})
 			}
 		}
+		// A host selector is a choice, not a credential: persisting it would
+		// pin every later run to the instance one run happened to name, with no
+		// way to go back other than editing the env store.
+		_, isHostSelector := hostCredentials[secret.ID]
 		for _, envVar := range secret.EnvVars {
 			envValue := secretValue
 			if placeholder != "" && placeholderVars[envVar] {
 				envValue = placeholder
 			}
-			result.SecretValues[envVar] = secretValue
+			if !isHostSelector {
+				result.SecretValues[envVar] = secretValue
+			}
 			result.InjectedKeys[envVar] = envValue
 			hookInjectedKeys[envVar] = secretValue
 			*env = append(*env, envVar+"="+envValue)

--- a/internal/runtime/auth_manager.go
+++ b/internal/runtime/auth_manager.go
@@ -168,6 +168,9 @@ func (m authManager) injectDeclaredSecrets(hooks auth.Hooks, authCtx auth.Contex
 	for _, secret := range suppressedActiveSecrets {
 		logx.Debugf("Suppressed declared API key secret %s due to %s", secret.ID, suppressionReason)
 	}
+	// Must precede shouldUseSecretReleases: that call resolves and caches the
+	// effective policy, which unions the release hosts into the allow set.
+	m.releaseHostOverrides = resolveReleaseHostOverrides(eligibleSecrets, m.host.Home, secretsLayers, persistedEnv)
 	secretReleaseEnabled := m.shouldUseSecretReleases(eligibleSecrets)
 	for _, secret := range eligibleSecrets {
 		secretValue, secretSource, found, err := resolveActiveSecretValue(secret, m.host.Home, secretsLayers, persistedEnv)
@@ -190,7 +193,7 @@ func (m authManager) injectDeclaredSecrets(hooks auth.Hooks, authCtx auth.Contex
 					SecretID:    secret.ID,
 					Placeholder: placeholder,
 					Value:       secretValue,
-					Hosts:       append([]string{}, secret.ReleaseHTTP.Hosts...),
+					Hosts:       m.releaseHostsFor(secret),
 					Header:      secret.ReleaseHTTP.Header,
 					Format:      secret.ReleaseHTTP.Format,
 				})
@@ -412,6 +415,15 @@ func (m authManager) apiKeySecretSuppressionReason() string {
 		return "--ephemeral without --pass-api-key"
 	}
 	return ""
+}
+
+// releaseHostsFor returns the hosts a secret's release rule applies to, after
+// any serviceAuth.hostsFromCredential replacement.
+func (m authManager) releaseHostsFor(secret activeSecret) []string {
+	if hosts, ok := m.releaseHostOverrides[secret.ID]; ok {
+		return append([]string{}, hosts...)
+	}
+	return append([]string{}, secret.ReleaseHTTP.Hosts...)
 }
 
 func (m authManager) shouldUseSecretReleases(activeSecrets []activeSecret) bool {

--- a/internal/runtime/auth_manager.go
+++ b/internal/runtime/auth_manager.go
@@ -188,13 +188,15 @@ func (m authManager) injectDeclaredSecrets(hooks auth.Hooks, authCtx auth.Contex
 			} else {
 				placeholder = resolved
 				placeholderVars = m.proxyManagedEnvVars(secret)
+				releaseHosts, exactHosts := m.releaseTargetsFor(secret)
 				result.SecretMapping.Entries = append(result.SecretMapping.Entries, model.SecretReleaseEntry{
 					SecretID:    secret.ID,
 					Placeholder: placeholder,
 					Value:       secretValue,
-					Hosts:       m.releaseHostsFor(secret),
+					Hosts:       releaseHosts,
 					Header:      secret.ReleaseHTTP.Header,
 					Format:      secret.ReleaseHTTP.Format,
+					ExactHosts:  exactHosts,
 				})
 			}
 		}
@@ -422,13 +424,15 @@ func (m authManager) apiKeySecretSuppressionReason() string {
 	return ""
 }
 
-// releaseHostsFor returns the hosts a secret's release rule applies to, after
-// any serviceAuth.hostsFromCredential replacement.
-func (m authManager) releaseHostsFor(secret activeSecret) []string {
-	if hosts, ok := m.releaseHostOverrides[secret.ID]; ok {
-		return append([]string{}, hosts...)
+// releaseTargetsFor returns the hosts a secret's release rule applies to, after
+// any serviceAuth.hostsFromCredential replacement, and whether those hosts must
+// match exactly. A selected host names one instance, so the gateway must not
+// extend it to subdomains the way a declared pattern is extended.
+func (m authManager) releaseTargetsFor(secret activeSecret) (hosts []string, exact bool) {
+	if override, ok := m.releaseHostOverrides[secret.ID]; ok {
+		return append([]string{}, override...), true
 	}
-	return append([]string{}, secret.ReleaseHTTP.Hosts...)
+	return append([]string{}, secret.ReleaseHTTP.Hosts...), false
 }
 
 func (m authManager) shouldUseSecretReleases(activeSecrets []activeSecret) bool {

--- a/internal/runtime/auth_manager_test.go
+++ b/internal/runtime/auth_manager_test.go
@@ -867,9 +867,10 @@ func secretConfig(envVars []string, release *model.HTTPSecretReleaseConfig) mode
 	if release != nil {
 		cfg.Release = &model.SecretReleaseConfig{
 			HTTP: &model.HTTPSecretReleaseConfig{
-				Hosts:  append([]string{}, release.Hosts...),
-				Header: release.Header,
-				Format: release.Format,
+				Hosts:           append([]string{}, release.Hosts...),
+				Header:          release.Header,
+				Format:          release.Format,
+				HostsFromSecret: release.HostsFromSecret,
 			},
 		}
 	}

--- a/internal/runtime/release_hosts_test.go
+++ b/internal/runtime/release_hosts_test.go
@@ -8,6 +8,7 @@
 package runtime
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -63,6 +64,8 @@ func TestNormalizeReleaseHost(t *testing.T) {
 		"gitlab.example.com:8443":          "gitlab.example.com",
 		"  GitLab.Example.com  ":           "gitlab.example.com",
 		"not a host":                       "",
+		// A wildcard would release the token to every host under the suffix.
+		"*.example.com": "",
 	}
 	for value, want := range cases {
 		t.Run(value, func(t *testing.T) {
@@ -84,9 +87,10 @@ func TestResolveReleaseHostOverridesKeepsDeclaredHostsWhenUnset(t *testing.T) {
 	}
 }
 
-// The replacement host must reach the allow set, or the release rule would name
-// a host the sandbox cannot resolve, and it must not leak into the loaded spec,
-// which is shared across the session.
+// The selected host must reach the allow set, or the release rule would name a
+// host the sandbox cannot resolve. The declared hosts stay reachable — only
+// token release is narrowed — and the loaded spec, shared across the session,
+// must not be mutated.
 func TestSpecNetworkDomainsIncludesOverriddenReleaseHost(t *testing.T) {
 	r := runtimeWithProfile(t, gitlabLikeProfile())
 	r.releaseHostOverrides = map[string][]string{
@@ -95,15 +99,83 @@ func TestSpecNetworkDomainsIncludesOverriddenReleaseHost(t *testing.T) {
 	}
 
 	allowed, _ := r.specNetworkDomains()
-	joined := strings.Join(allowed, ",")
 
-	if !strings.Contains(joined, "gitlab.example.com") {
-		t.Fatalf("allowed = %v, want the overridden host included", allowed)
-	}
-	if strings.Contains(joined, "gitlab.com,") || strings.Contains(joined, ",gitlab.com") {
-		t.Fatalf("allowed = %v, want the replaced default host dropped", allowed)
+	for _, want := range []string{"gitlab.example.com", "gitlab.com", "*.gitlab.com"} {
+		if !slices.Contains(allowed, want) {
+			t.Fatalf("allowed = %v, want %q included", allowed, want)
+		}
 	}
 	if hosts := r.profile.Secrets["gitlab-token"].Release.HTTP.Hosts; strings.Join(hosts, ",") != "gitlab.com,*.gitlab.com" {
 		t.Fatalf("profile hosts = %v, want the declared hosts unchanged", hosts)
+	}
+}
+
+// The token itself must still go only to the selected instance.
+func TestReleaseHostsForUsesOnlyTheOverride(t *testing.T) {
+	r := runtimeWithProfile(t, gitlabLikeProfile())
+	r.releaseHostOverrides = map[string][]string{"gitlab-token": {"gitlab.example.com"}}
+	manager := newAuthManager(r)
+
+	secrets := mustActiveSecrets(t, r)
+	for _, secret := range secrets {
+		if secret.ID != "gitlab-token" {
+			continue
+		}
+		if hosts := manager.releaseHostsFor(secret); strings.Join(hosts, ",") != "gitlab.example.com" {
+			t.Fatalf("releaseHostsFor(gitlab-token) = %v, want only the selected host", hosts)
+		}
+	}
+}
+
+// The effective policy is memoized and unions the release hosts into the allow
+// set, so an override arriving after a policy lookup must invalidate it instead
+// of leaving the selected host unresolvable.
+func TestSetReleaseHostOverridesInvalidatesResolvedPolicy(t *testing.T) {
+	r := runtimeWithProfile(t, gitlabLikeProfile())
+	r.policyResolved = true
+
+	r.setReleaseHostOverrides(nil)
+	if !r.policyResolved {
+		t.Fatalf("policyResolved = false, want the memo kept when there is no override")
+	}
+
+	r.setReleaseHostOverrides(map[string][]string{"gitlab-token": {"gitlab.example.com"}})
+	if r.policyResolved {
+		t.Fatalf("policyResolved = true, want the memo dropped so the selected host reaches the allow set")
+	}
+}
+
+// The host selector is a choice, not a credential: persisting it would pin
+// every later run to the instance one run happened to name.
+func TestInjectDeclaredSecretsDoesNotPersistHostSelector(t *testing.T) {
+	t.Setenv("GITLAB_HOST", "gitlab.example.com")
+	t.Setenv("GITLAB_TOKEN", "gitlab-token-value")
+	t.Setenv("JOB_TOKEN", "")
+
+	r := runtimeWithProfile(t, gitlabLikeProfile())
+	manager := newAuthManager(r)
+
+	env := []string{}
+	injection, err := manager.injectDeclaredSecrets(
+		stubHooks{},
+		authContextForRuntime(r),
+		&env,
+		map[string]string{},
+		nil,
+		nil,
+		mustActiveSecrets(t, r),
+	)
+	if err != nil {
+		t.Fatalf("injectDeclaredSecrets() error = %v", err)
+	}
+
+	if got := envValue(env, "GITLAB_HOST"); got != "gitlab.example.com" {
+		t.Fatalf("GITLAB_HOST = %q, want it injected into the container", got)
+	}
+	if _, ok := injection.SecretValues["GITLAB_HOST"]; ok {
+		t.Fatalf("SecretValues = %v, want the host selector left out of the persisted set", injection.SecretValues)
+	}
+	if got := injection.SecretValues["GITLAB_TOKEN"]; got != "gitlab-token-value" {
+		t.Fatalf("SecretValues[GITLAB_TOKEN] = %q, want the token still persisted", got)
 	}
 }

--- a/internal/runtime/release_hosts_test.go
+++ b/internal/runtime/release_hosts_test.go
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+// gitlabLikeProfile mirrors the gitlab-cli shape: several services sharing one
+// host credential via serviceAuth.hostsFromCredential.
+func gitlabLikeProfile() model.Profile {
+	return model.Profile{
+		Name: "tool",
+		Secrets: map[string]model.SecretConfig{
+			"gitlab-host": secretConfig([]string{"GITLAB_HOST"}, nil),
+			"gitlab-token": secretConfig([]string{"GITLAB_TOKEN"}, &model.HTTPSecretReleaseConfig{
+				Hosts:           []string{"gitlab.com", "*.gitlab.com"},
+				Header:          "private-token",
+				HostsFromSecret: "gitlab-host",
+			}),
+			"gitlab-job-token": secretConfig([]string{"JOB_TOKEN"}, &model.HTTPSecretReleaseConfig{
+				Hosts:           []string{"gitlab.com", "*.gitlab.com"},
+				Header:          "job-token",
+				HostsFromSecret: "gitlab-host",
+			}),
+		},
+	}
+}
+
+func TestResolveReleaseHostOverridesReplacesDeclaredHosts(t *testing.T) {
+	t.Setenv("GITLAB_HOST", "gitlab.example.com")
+
+	r := runtimeWithProfile(t, gitlabLikeProfile())
+	overrides := resolveReleaseHostOverrides(mustActiveSecrets(t, r), r.host.Home, nil, nil)
+
+	for _, id := range []string{"gitlab-token", "gitlab-job-token"} {
+		hosts, ok := overrides[id]
+		if !ok {
+			t.Fatalf("overrides[%s] missing, want the resolved host", id)
+		}
+		// Replacement, not addition: the instance token must not be released
+		// to gitlab.com as well.
+		if len(hosts) != 1 || hosts[0] != "gitlab.example.com" {
+			t.Fatalf("overrides[%s] = %v, want [gitlab.example.com]", id, hosts)
+		}
+	}
+	if _, ok := overrides["gitlab-host"]; ok {
+		t.Fatalf("overrides contains the host credential itself, want only referencing services")
+	}
+}
+
+func TestNormalizeReleaseHost(t *testing.T) {
+	cases := map[string]string{
+		"https://gitlab.example.com/group": "gitlab.example.com",
+		"gitlab.example.com:8443":          "gitlab.example.com",
+		"  GitLab.Example.com  ":           "gitlab.example.com",
+		"not a host":                       "",
+	}
+	for value, want := range cases {
+		t.Run(value, func(t *testing.T) {
+			if got := normalizeReleaseHost("gitlab-host", value); got != want {
+				t.Fatalf("normalizeReleaseHost(%q) = %q, want %q", value, got, want)
+			}
+		})
+	}
+}
+
+func TestResolveReleaseHostOverridesKeepsDeclaredHostsWhenUnset(t *testing.T) {
+	t.Setenv("GITLAB_HOST", "")
+
+	r := runtimeWithProfile(t, gitlabLikeProfile())
+	overrides := resolveReleaseHostOverrides(mustActiveSecrets(t, r), r.host.Home, nil, nil)
+
+	if len(overrides) != 0 {
+		t.Fatalf("overrides = %v, want none when the host credential is unset", overrides)
+	}
+}
+
+// The replacement host must reach the allow set, or the release rule would name
+// a host the sandbox cannot resolve, and it must not leak into the loaded spec,
+// which is shared across the session.
+func TestSpecNetworkDomainsIncludesOverriddenReleaseHost(t *testing.T) {
+	r := runtimeWithProfile(t, gitlabLikeProfile())
+	r.releaseHostOverrides = map[string][]string{
+		"gitlab-token":     {"gitlab.example.com"},
+		"gitlab-job-token": {"gitlab.example.com"},
+	}
+
+	allowed, _ := r.specNetworkDomains()
+	joined := strings.Join(allowed, ",")
+
+	if !strings.Contains(joined, "gitlab.example.com") {
+		t.Fatalf("allowed = %v, want the overridden host included", allowed)
+	}
+	if strings.Contains(joined, "gitlab.com,") || strings.Contains(joined, ",gitlab.com") {
+		t.Fatalf("allowed = %v, want the replaced default host dropped", allowed)
+	}
+	if hosts := r.profile.Secrets["gitlab-token"].Release.HTTP.Hosts; strings.Join(hosts, ",") != "gitlab.com,*.gitlab.com" {
+		t.Fatalf("profile hosts = %v, want the declared hosts unchanged", hosts)
+	}
+}

--- a/internal/runtime/release_hosts_test.go
+++ b/internal/runtime/release_hosts_test.go
@@ -110,19 +110,32 @@ func TestSpecNetworkDomainsIncludesOverriddenReleaseHost(t *testing.T) {
 	}
 }
 
-// The token itself must still go only to the selected instance.
-func TestReleaseHostsForUsesOnlyTheOverride(t *testing.T) {
+// The token itself must still go only to the selected instance, and only to
+// that host: a selected host names one instance, so the gateway must match it
+// by equality instead of covering its subdomains.
+func TestReleaseTargetsForUseOnlyTheOverrideAndAreExact(t *testing.T) {
 	r := runtimeWithProfile(t, gitlabLikeProfile())
 	r.releaseHostOverrides = map[string][]string{"gitlab-token": {"gitlab.example.com"}}
 	manager := newAuthManager(r)
 
 	secrets := mustActiveSecrets(t, r)
 	for _, secret := range secrets {
-		if secret.ID != "gitlab-token" {
+		if secret.ReleaseHTTP == nil {
 			continue
 		}
-		if hosts := manager.releaseHostsFor(secret); strings.Join(hosts, ",") != "gitlab.example.com" {
-			t.Fatalf("releaseHostsFor(gitlab-token) = %v, want only the selected host", hosts)
+		hosts, exact := manager.releaseTargetsFor(secret)
+		switch secret.ID {
+		case "gitlab-token":
+			if strings.Join(hosts, ",") != "gitlab.example.com" {
+				t.Fatalf("releaseTargetsFor(gitlab-token) = %v, want only the selected host", hosts)
+			}
+			if !exact {
+				t.Fatal("releaseTargetsFor(gitlab-token) exact = false, want the selected host matched exactly")
+			}
+		case "gitlab-job-token":
+			if exact {
+				t.Fatalf("releaseTargetsFor(gitlab-job-token) exact = true, want declared patterns to keep suffix matching")
+			}
 		}
 	}
 }
@@ -177,5 +190,46 @@ func TestInjectDeclaredSecretsDoesNotPersistHostSelector(t *testing.T) {
 	}
 	if got := injection.SecretValues["GITLAB_TOKEN"]; got != "gitlab-token-value" {
 		t.Fatalf("SecretValues[GITLAB_TOKEN] = %q, want the token still persisted", got)
+	}
+}
+
+// The gateway rule the runtime hands over must carry the selected host and the
+// exact-match flag, or the token would reach every host beneath the instance.
+func TestInjectDeclaredSecretsMarksSelectedHostExact(t *testing.T) {
+	t.Setenv("GITLAB_HOST", "gitlab.example.com")
+	t.Setenv("GITLAB_TOKEN", "gitlab-token-value")
+	t.Setenv("JOB_TOKEN", "")
+
+	r := runtimeWithProfile(t, gitlabLikeProfile())
+	manager := newAuthManager(r)
+
+	env := []string{}
+	injection, err := manager.injectDeclaredSecrets(
+		stubHooks{},
+		authContextForRuntime(r),
+		&env,
+		map[string]string{},
+		nil,
+		nil,
+		mustActiveSecrets(t, r),
+	)
+	if err != nil {
+		t.Fatalf("injectDeclaredSecrets() error = %v", err)
+	}
+
+	var entry model.SecretReleaseEntry
+	for _, candidate := range injection.SecretMapping.Entries {
+		if candidate.SecretID == "gitlab-token" {
+			entry = candidate
+		}
+	}
+	if entry.SecretID == "" {
+		t.Fatalf("SecretMapping.Entries = %v, want a release rule for gitlab-token", injection.SecretMapping.Entries)
+	}
+	if strings.Join(entry.Hosts, ",") != "gitlab.example.com" {
+		t.Fatalf("entry.Hosts = %v, want only the selected host", entry.Hosts)
+	}
+	if !entry.ExactHosts {
+		t.Fatal("entry.ExactHosts = false, want the selected host matched exactly")
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -559,9 +559,10 @@ func secretReleases(mapping SecretMapping) []backend.SecretRelease {
 			Placeholder: entry.Placeholder,
 			Value:       entry.Value,
 			HTTP: &backend.HTTPReleaseRule{
-				Hosts:  append([]string(nil), entry.Hosts...),
-				Header: entry.Header,
-				Format: entry.Format,
+				Hosts:      append([]string(nil), entry.Hosts...),
+				Header:     entry.Header,
+				Format:     entry.Format,
+				ExactHosts: entry.ExactHosts,
 			},
 		})
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -10,6 +10,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -59,7 +60,12 @@ type Runtime struct {
 	policyResolved        bool
 	policyResult          policy.ResolveResult
 	policyErr             error
-	backend               backend.Backend
+	// releaseHostOverrides maps a secret id to the hosts that replace its
+	// declared release hosts, resolved from serviceAuth.hostsFromCredential.
+	// Populated during auth setup, before the effective policy is resolved and
+	// cached, so the replacement host reaches the allow set too.
+	releaseHostOverrides map[string][]string
+	backend              backend.Backend
 }
 
 type ExecutionContext struct {
@@ -985,13 +991,37 @@ func (r *Runtime) specProxyManaged() []string {
 func (r *Runtime) specNetworkDomains() (allowed []string, denied []string) {
 	allowed = append([]string(nil), r.profile.AllowedDomains...)
 	denied = append([]string(nil), r.profile.DeniedDomains...)
-	allowed = append(allowed, model.ReleaseHosts(r.profile.Secrets)...)
+	allowed = append(allowed, r.releaseHosts(r.profile.Secrets)...)
 	for _, feature := range r.features {
 		allowed = append(allowed, feature.AllowedDomains...)
 		denied = append(denied, feature.DeniedDomains...)
-		allowed = append(allowed, model.ReleaseHosts(feature.Secrets)...)
+		allowed = append(allowed, r.releaseHosts(feature.Secrets)...)
 	}
 	return allowed, denied
+}
+
+// releaseHosts is model.ReleaseHosts with any resolved
+// serviceAuth.hostsFromCredential replacement applied, so a host selected at
+// runtime becomes resolvable exactly like a declared one. The loaded spec is
+// left untouched.
+func (r *Runtime) releaseHosts(secrets map[string]model.SecretConfig) []string {
+	if len(r.releaseHostOverrides) == 0 {
+		return model.ReleaseHosts(secrets)
+	}
+	effective := maps.Clone(secrets)
+	for id, hosts := range r.releaseHostOverrides {
+		sc, ok := effective[id]
+		if !ok || sc.Release == nil || sc.Release.HTTP == nil {
+			continue
+		}
+		release := *sc.Release
+		http := *release.HTTP
+		http.Hosts = hosts
+		release.HTTP = &http
+		sc.Release = &release
+		effective[id] = sc
+	}
+	return model.ReleaseHosts(effective)
 }
 
 // addWorktreeMetadataMounts mounts the linked-worktree gitdir/commondir

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1000,10 +1000,12 @@ func (r *Runtime) specNetworkDomains() (allowed []string, denied []string) {
 	return allowed, denied
 }
 
-// releaseHosts is model.ReleaseHosts with any resolved
-// serviceAuth.hostsFromCredential replacement applied, so a host selected at
-// runtime becomes resolvable exactly like a declared one. The loaded spec is
-// left untouched.
+// releaseHosts is model.ReleaseHosts plus any host selected at runtime through
+// serviceAuth.hostsFromCredential, so that host becomes resolvable exactly like
+// a declared one. The override narrows where the token is released, not what
+// the session can reach: dropping the declared hosts here would make e.g.
+// gitlab.com unresolvable for tools whose allowlist has no other source for it.
+// The loaded spec is left untouched.
 func (r *Runtime) releaseHosts(secrets map[string]model.SecretConfig) []string {
 	if len(r.releaseHostOverrides) == 0 {
 		return model.ReleaseHosts(secrets)
@@ -1016,12 +1018,27 @@ func (r *Runtime) releaseHosts(secrets map[string]model.SecretConfig) []string {
 		}
 		release := *sc.Release
 		http := *release.HTTP
-		http.Hosts = hosts
+		http.Hosts = append(append([]string{}, http.Hosts...), hosts...)
 		release.HTTP = &http
 		sc.Release = &release
 		effective[id] = sc
 	}
 	return model.ReleaseHosts(effective)
+}
+
+// setReleaseHostOverrides records the release hosts selected at runtime. The
+// effective policy unions release hosts into the allow set and is memoized, so
+// a policy resolved before this point would miss the selected host; drop the
+// memo instead of relying on call order.
+func (r *Runtime) setReleaseHostOverrides(overrides map[string][]string) {
+	r.releaseHostOverrides = overrides
+	if len(overrides) == 0 || !r.policyResolved {
+		return
+	}
+	logx.Debugf("Effective network policy was resolved before the release host overrides; recomputing it.")
+	r.policyResolved = false
+	r.policyResult = policy.ResolveResult{}
+	r.policyErr = nil
 }
 
 // addWorktreeMetadataMounts mounts the linked-worktree gitdir/commondir


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Reaching a self-hosted GitLab needed two manual steps: declare GITLAB_HOST so it reached the container, then edit the mixin spec to put the host in serviceAuth.hosts. Both are now unnecessary.

serviceAuth entries gain hostsFromCredential, naming a credential whose resolved value is a host. When it resolves, its value replaces that service's declared hosts. Replacement rather than addition is deliberate: an instance-specific token must not be released to gitlab.com as well.

The override is resolved during auth setup, before the effective policy is resolved and cached, so the host flows into the allow set through the existing ReleaseHosts union and stays reachable. gitlab-cli declares GITLAB_HOST as a non-apiKey credential and wires all three tokens to it.

Closes #4
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
