### PR TITLE
ci: fix rolling package version in Fedora container job

### DIFF
--- a/.github/workflows/reusable-rpm-build.yml
+++ b/.github/workflows/reusable-rpm-build.yml
@@ -73,7 +73,10 @@ jobs:
 
       - name: Set package version
         if: inputs.set_package_version
-        run: echo "VERSION=$(./scripts/rolling-package-version.sh)" >> "$GITHUB_ENV"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          VERSION=$(./scripts/rolling-package-version.sh)
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Build RPM package
         run: make rpm


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Follow-up fix for #26: 
Actions/checkout only registers `safe.directory` in a temporary git config, so the version script's `git show` died with "dubious ownership" and the step silently exported an empty `VERSION`, which `rpmbuild` rejects. Register the workspace as a safe directory and let a version-script failure fail the step.
  
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
