### PR TITLE
Add project-scoped feature state stores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -335,7 +335,8 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod a+rx /usr/local/bin/entrypoint.sh \
         /usr/local/share/enclave/auth-reconcile.sh \
         /usr/local/share/enclave/net.sh && \
-    chmod a+r /usr/local/share/enclave/tmux-session.conf
+    chmod a+r /usr/local/share/enclave/tmux-session.conf \
+        /usr/local/share/enclave/kit-init.sh
 USER ${USERNAME}
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,7 @@ flowchart LR
         EnvStore["projects/&lt;hash&gt;/&lt;tool&gt;/env<br/>persisted env secrets, not mounted into the tool container"]
         SharedAuthStore["tools/&lt;tool&gt;/auth<br/>shared tool auth store, only with --auth-scope=shared"]
         FeatureAuthStore["features/&lt;feature&gt;/auth<br/>shared feature auth store, only with --auth-scope=shared"]
+        FeatureStateStore["projects/&lt;hash&gt;/features/&lt;feature&gt;/state<br/>project-scoped state shared across tools"]
     end
 
     subgraph Docker
@@ -54,6 +55,7 @@ flowchart LR
     EnvStore -.->|"host-side read/write env file"| Tool
     SharedAuthStore -->|"bind mount (~/.enclave-auth)"| Tool
     FeatureAuthStore -->|"bind mount (~/.enclave-feature-auth/&lt;feature&gt;)"| Tool
+    FeatureStateStore -->|"bind mount (~/.enclave-feature-state/&lt;feature&gt;)"| Tool
     Gateway --> DnsNet
     Tool --> DnsNet
     Tool -.->|"resolver/proxy"| Gateway
@@ -166,7 +168,7 @@ The restricted network request flow has a separate
 - **User-defined subcommands**: executables under `~/.config/enclave/commands/{host,session}/` become `enclave <name>` verbs. `cli.Parse` discovers them, registers name-only stub commands (Cobra group "User Commands") so they list in `--help` and shell completion, and intercepts a matching first positional *before* `normalizeArgs`/Cobra so the trailing line reaches the script verbatim (preserving the unknown-command rejection for everything else). enclave flags must precede the name: host commands accept only the global group, session commands accept the full session flag set. `host/` commands exec directly on the host (`os/exec`, exit code/stdin/stdout passthrough, `ENCLAVE_BIN`/`ENCLAVE_PROJECT_ROOT`/`ENCLAVE_CONFIG_DIR` injected). `session/` commands run through the normal run pipeline as a shell-style execution (`opts.Shell=true`, argv `bash -c 'exec "$@"' <name> <container-path> <args>` so the script's shebang is honored via execve).
 - **Session command isolation boundary**: session commands mount only the `session/` tree, read-only, at the fixed neutral container path `/opt/enclave/commands` (`model.UserCommandsContainerDir`) via a dedicated `model.UserCommandMount` — never through `mounts.AddAdditional` (which mirrors host paths and would leak the home layout). No mount/backend code path ever references the `host/` tree, and no enclave host-data directory is otherwise mounted, so host commands stay invisible in-container by construction. Session commands receive no `ENCLAVE_*` env injection.
 - **Detached sessions**: `--background` runs detached tool containers that can be reattached. There is no separate daemon run mode.
-- **Persistent stores**: per-tool/project stores hold tool configs; an optional env store persists env auth and `--pass-env` values when persistence is enabled (default unless `--ephemeral`). Stores are host directories under `~/.local/state/enclave/` bind-mounted into the container (no Docker volumes). See [`docs/runtime/stores.md`](runtime/stores.md) for detailed store lifecycle, auth symlinks, and scoping documentation.
+- **Persistent stores**: per-tool/project stores hold tool configs; an optional env store persists env auth and `--pass-env` values; opted-in mixins receive per-feature/project state shared across tools. Persistence is enabled by default unless `--ephemeral`. Stores are host directories under `~/.local/state/enclave/` bind-mounted into the container (no Docker volumes). See [`docs/runtime/stores.md`](runtime/stores.md) for detailed store lifecycle, auth symlinks, and scoping documentation.
 - **Caches/history**: host-side caches are stored under `~/.cache/enclave/` and shell history under `~/.local/state/enclave/projects/`.
 - **Network isolation**: by default, a gateway sidecar (dnsmasq + transparent proxy) restricts outbound domains. DNS blocks unknown domains, and the proxy is passthrough-by-default with MITM only for hosts that need secret release rewriting unless `network_log=requests` forces MITM for all allowlisted HTTPS.
 - **Declared secrets and HTTP release**: tool profiles and enabled feature manifests can declare `secrets`. Each secret lists env-var aliases and can optionally define `release.http` target hosts/header formatting. Declared secrets are resolved from host env, layered secrets files, or persisted env; when gateway release is enabled, matching secrets are replaced with `ENCLAVE_SECRET_*` placeholders inside the container. The flow is: extension `secrets` config → `PlaceholderResolver` generates placeholders → `SecretMapping` entries written to a JSON file → gateway proxy loads secret release rules and performs header rewriting on HTTPS requests. Plaintext HTTP requests carrying placeholders are denied. This protection is limited to env-var injection: credential files written by auth hooks can still contain the real secret in the config/auth store.
@@ -189,11 +191,12 @@ Persistent stores are host directories under `~/.local/state/enclave/` (honoring
 - **Env store**: `~/.local/state/enclave/projects/<hash>/<tool>/env/` stores persisted env auth data and additional `--pass-env` values when persistence is enabled (default unless `--ephemeral`).
 - **Shared auth store** (when `--auth-scope=shared`): `~/.local/state/enclave/tools/<tool>/auth/<identity>/` stores OAuth files shared across projects for the tool; `<identity>` is `default` or the `--auth-name` slug.
 - **Feature auth store** (when `--auth-scope=shared` and feature defines `authFiles`): `~/.local/state/enclave/features/<feature>/auth/` stores feature auth files shared across tools/projects (for example `github-cli`).
+- **Feature state store** (when an enabled mixin declares `state: true`): `~/.local/state/enclave/projects/<hash>/features/<feature>/state/` stores feature-owned project data shared across tools. It is not created for ephemeral sessions and is independent of auth scope.
 
 Other host-side data:
 
 - **Embedded asset cache**: standalone binaries extract into `${XDG_CACHE_HOME:-~/.cache}/enclave/assets/<hash>/` on Linux or `~/Library/Caches/org.eclipse.enclave/assets/<hash>/` on macOS. Extraction uses a per-content lock, temporary sibling directory, and atomic rename so concurrent first runs share one complete entry. Missing or invalid entries are recreated from the binary.
-- **QEMU stores**: the experimental QEMU backend mounts the same host-directory stores as the Docker backend (resolved via `internal/backend/hoststore`) into the guest over 9p, so auth, config, and env state are shared across backends.
+- **QEMU stores**: the experimental QEMU backend mounts the same host-directory stores as the Docker backend (resolved via `internal/backend/hoststore`) into the guest over 9p. The store layer supports feature state, but current QEMU bundles disable all mixins, so normal QEMU runs do not request it.
 - **QEMU bundles**: generated microVM bundles live under `${XDG_CACHE_HOME:-~/.cache}/enclave/microvm/<tool>/<hash>/` unless `--image-name` points at an explicit bundle directory.
 - **Caches**: `~/.cache/enclave/<tool>/<hash>/` for package managers and build tools:
   - `npm/` - npm package cache

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -115,7 +115,7 @@ Mutation commands (`add-domain`, `remove-domain`, `set-mode`) apply the new poli
 | `enclave cleanup --all` | All projects and tools |
 | `enclave cleanup --ephemeral` | Remove stopped containers and ephemeral session stores |
 | `enclave cleanup --dry-run` | Preview what would be removed |
-| `enclave cleanup --keep cache,history,auth,memory` | Preserve the listed stores (comma-separated or repeated `--keep`): `cache` (package caches), `history` (shell history), `auth` (auth stores, with `--all`), `memory` (per-project agent memory, no selective effect with `--all`) |
+| `enclave cleanup --keep cache,history,auth,memory,feature-state` | Preserve the listed stores (comma-separated or repeated `--keep`): `cache` (package caches), `history` (shell history), `auth` (auth stores, with `--all`), `memory` (per-project agent memory, no selective effect with `--all`), `feature-state` (project-scoped feature state) |
 | `enclave cleanup --build-cache` | Prune Docker build cache (requires confirmation) |
 
 ---

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -112,13 +112,15 @@ aptPackages: [<packages>]
 needsRoot: <bool>
 failOnInstallError: <bool>
 defaultEnabled: <bool>
+state: <bool, default false> # project-scoped persistent state shared across tools
 
 # tool-only field (kind: sandbox)
 defaultIncluded: <bool>
 ```
 
 `name` and `kind` are validated against the file's location and directory
-name at load time.
+name at load time. The sandbox name `features` is reserved for the
+project-scoped feature-state namespace.
 
 ### Reserved and deferred fields
 
@@ -524,6 +526,31 @@ every host the proxy injects credentials for is unioned into the session
 allow set so it resolves. A service mixin thus declares its own reachability
 without help from the tool spec.
 
+Set `state: true` only when a feature owns persistent project data that must be
+shared across tools. Enclave mounts the store at
+`~/.enclave-feature-state/<feature>/` and exports
+`ENCLAVE_FEATURE_STATE_DIR` while sourcing that feature's
+`feature-entrypoint.d/*.sh`. The variable is unset afterward. State is not
+created under `--ephemeral` and is independent of `--auth-scope`.
+
+```yaml
+schemaVersion: "1"
+kind: mixin
+name: state-probe
+state: true
+```
+
+A setup script can link the feature's native path to the neutral store:
+
+```sh
+if [ -n "${ENCLAVE_FEATURE_STATE_DIR:-}" ] && [ ! -e "$HOME/.state-probe" ] && [ ! -L "$HOME/.state-probe" ]; then
+    ln -s "$ENCLAVE_FEATURE_STATE_DIR" "$HOME/.state-probe"
+fi
+```
+
+The store may be mounted into multiple sessions concurrently. Stateful
+features must provide their own process-safe locking or database concurrency.
+
 ### Optional Files
 
 | File | Purpose |
@@ -618,6 +645,7 @@ resolved port appears in the printed `openUrl` and in `enclave ps`.
 | `needsRoot` | N/A | Controls install user |
 | `aptPackages` | N/A | Auto-installed apt packages |
 | Declared `ports` | Published for every session of the tool | Published when the feature is enabled |
+| `state: true` | Invalid | Opts into project-scoped state shared across tools |
 
 ## How It Works
 
@@ -665,7 +693,7 @@ CLI sets it to the single selected tool):
 
 1. Determines current tool from `$TOOL` env var
 2. Sources scripts from `extensions/tools/{tool}/entrypoint.d/*.sh` (tool-specific)
-3. Sources scripts from `extensions/*/feature-entrypoint.d/*.sh` (all features)
+3. Sources scripts from `extensions/*/feature-entrypoint.d/*.sh` (all enabled features), setting `ENCLAVE_FEATURE_STATE_DIR` only for a feature that declares `state: true`
 
 ### Go Registration (Tools Only)
 
@@ -725,6 +753,7 @@ Hooks run in a fixed order during runtime auth preparation:
 3. Optionally add:
    - `install.sh` for custom installation (set `needsRoot: true` if it needs root)
    - `feature-entrypoint.d/setup.sh` for runtime initialization
+   - `state: true` when the feature needs persistent project data shared across tools
 
 ### Feature Guidelines
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -44,6 +44,7 @@ Per-project data is stored on the host and reused across sessions:
 | Shell history | `~/.local/state/enclave/projects/<project-hash>/<tool>/history/` |
 | Agent memory | `~/.local/state/enclave/projects/<project-hash>/<tool>/memory/` (Claude) |
 | Config/env/auth stores | Host directories under `~/.local/state/enclave/` (bind-mounted; no Docker volumes) |
+| Feature state | `~/.local/state/enclave/projects/<project-hash>/features/<feature>/state/` for enabled mixins that opt in with `state: true`; shared across tools |
 | Embedded runtime assets | `~/.cache/enclave/assets/<content-hash>/` |
 
 Extracted runtime asset entries are reproducible cache data. Deleting them is
@@ -55,8 +56,9 @@ the standard Apple locations, in a reverse-DNS application directory: config
 and state under `~/Library/Application Support/org.eclipse.enclave/`
 (`config/`, `state/`) and caches under `~/Library/Caches/org.eclipse.enclave/`.
 
-Agent memory is skipped for `--ephemeral` sessions: memory written during them
-is discarded with the session's config store.
+Agent memory and feature state are skipped for `--ephemeral` sessions. Feature
+state is independent of auth scope and is shared by all tools running the same
+enabled feature in a project.
 
 Disable specific persistence:
 
@@ -81,7 +83,7 @@ Options:
 |------|--------|
 | `--all` | Remove stores and caches for all projects and tools |
 | `--ephemeral` | Remove stopped containers and ephemeral session stores |
-| `--keep <kinds>` | Preserve the listed stores (comma-separated or repeated): `cache` (package caches), `history` (shell history), `memory` (per-project agent memory, removed by default; no selective effect with `--all`), `auth` (auth stores, with `--all`) |
+| `--keep <kinds>` | Preserve the listed stores (comma-separated or repeated): `cache` (package caches), `history` (shell history), `memory` (per-project agent memory, removed by default; no selective effect with `--all`), `auth` (auth stores, with `--all`), `feature-state` (project-scoped feature state) |
 | `--build-cache` | Prune Docker build cache (requires confirmation) |
 | `--dry-run` | Preview what would be removed |
 
@@ -91,6 +93,7 @@ Examples:
 enclave cleanup --dry-run
 enclave cleanup --keep cache
 enclave cleanup --keep cache,history
+enclave cleanup --keep feature-state
 enclave cleanup --ephemeral
 enclave cleanup --all
 ```

--- a/docs/runtime/stores.md
+++ b/docs/runtime/stores.md
@@ -14,6 +14,7 @@ how auth files are synchronized, and how CLI flags affect store behavior.
 | Env | `~/.local/state/enclave/projects/<hash>/<tool>/env/` | Per-tool, per-project | Persisted declared secret and `--pass-env` values |
 | Shared auth | `~/.local/state/enclave/tools/<tool>/auth/<identity>/` | Per-tool, all projects | OAuth/session files shared across projects; `<identity>` is `default` or the `--auth-name` slug |
 | Feature auth | `~/.local/state/enclave/features/<feature>/auth/` | Per-feature, all tools/projects | Feature-specific auth (e.g. `github-cli`) |
+| Feature state | `~/.local/state/enclave/projects/<hash>/features/<feature>/state/` | Per-feature, per-project, all tools | Feature-owned project data shared across tools |
 
 The `<hash>` segment is a 12-character hex string derived from the project
 directory path, making per-project stores unique per project. The config store
@@ -219,6 +220,40 @@ destination.
 Source: [`internal/runtime/volume_manager.go`](../../internal/runtime/volume_manager.go) `BuildPrep`/`authSyncSpec` (intent), [`internal/backend/docker/authsync.go`](../../internal/backend/docker/authsync.go) `syncFeatureAuthStore` (mechanics),
 [`entrypoint.sh`](../../entrypoint.sh)
 
+## Feature State Store
+
+A mixin opts into project-scoped persistent state with `state: true` in its
+`spec.yaml`. Enclave creates the store only while that feature is enabled in a
+persistent session. Features without the opt-in get no directory.
+
+The host directory
+`~/.local/state/enclave/projects/<hash>/features/<feature>/state/` is mounted at
+`~/.enclave-feature-state/<feature>/`. The key contains the feature name and
+project hash, but not the selected tool or config-store suffix, so Claude,
+Codex, and other tools in the same project see the same files. Auth scope does
+not affect this store. `--ephemeral` suppresses it rather than creating a
+throwaway copy.
+
+While `entrypoint.sh` sources that feature's `feature-entrypoint.d/*.sh`, it
+exports `ENCLAVE_FEATURE_STATE_DIR` with the feature's mount path. The variable
+is unset before the next feature and before the agent starts. A feature can use
+it to connect its native state path to the persistent store:
+
+```sh
+if [ -n "${ENCLAVE_FEATURE_STATE_DIR:-}" ] && [ ! -e "$HOME/.state-probe" ] && [ ! -L "$HOME/.state-probe" ]; then
+    ln -s "$ENCLAVE_FEATURE_STATE_DIR" "$HOME/.state-probe"
+fi
+```
+
+The directory is intentionally writable by concurrent sessions. Features that
+use databases or lock files must support access from multiple processes and
+containers. This is also a cross-tool trust channel: one agent can consume data
+written by another agent through the enabled feature.
+
+The QEMU store layer understands the feature-state kind, but QEMU sessions
+currently build tool-only bundles and disable all mixins, so normal QEMU runs do
+not mount feature state.
+
 ## Lifecycle
 
 ```
@@ -229,6 +264,7 @@ Source: [`internal/runtime/volume_manager.go`](../../internal/runtime/volume_man
    ├─ Env store: create or reuse
    ├─ Shared auth store: create or reuse
    ├─ Feature auth stores: create or reuse
+   ├─ Opted-in feature state stores: create or reuse
    │  (created as the invoking user; no chown needed)
    └─ Reset auth files if --reset-auth
                          │
@@ -243,9 +279,10 @@ Source: [`internal/runtime/volume_manager.go`](../../internal/runtime/volume_man
    └─ Write env back to env store (host filesystem write)
                          │
 4. Bind-mount stores     │
-   ├─ Config store   → $HOME/<ConfigDir>
-   ├─ Auth store     → $HOME/.enclave-auth/
-   └─ Feature stores → $HOME/.enclave-feature-auth/<feature>/
+   ├─ Config store       → $HOME/<ConfigDir>
+   ├─ Auth store         → $HOME/.enclave-auth/
+   ├─ Feature auth       → $HOME/.enclave-feature-auth/<feature>/
+   └─ Feature state      → $HOME/.enclave-feature-state/<feature>/
                          │
 5. Start container ──────┼──────────────────────────────────┐
                          │                                  │
@@ -254,6 +291,8 @@ Source: [`internal/runtime/volume_manager.go`](../../internal/runtime/volume_man
                          │                 │  (config path → auth path)
                          │                 ├─ Symlink feature auth files
                          │                 │  (config path → feature auth path)
+                         │                 ├─ Export state dir to each opted-in
+                         │                 │  feature entrypoint
                          │                 └─ Apply settings template
                          │                                  │
                          │              7. Tool executes     │
@@ -279,6 +318,7 @@ Source: [`internal/runtime/volume_manager.go`](../../internal/runtime/volume_man
   is `default` or the `--auth-name` slug — see
   [Named auth identities](../auth.md#named-auth-identities)).
 - Feature auth stores are created for qualifying features.
+- Enabled features with `state: true` receive project-scoped feature state.
 - Auth files are symlinked via the entrypoint.
 - Foreground exit, exec exit, background stop, and GUI stop/remove finalize provider credentials to shared auth stores.
 - Logging into a tool in one project makes the session available to all projects.
@@ -287,6 +327,8 @@ Source: [`internal/runtime/volume_manager.go`](../../internal/runtime/volume_man
 
 - **No** shared auth store is created.
 - **No** feature auth stores are created.
+- Enabled features with `state: true` still receive project-scoped feature
+  state; it is not authentication data.
 - Auth files live only in the per-project config store.
 - No cross-project credential sharing.
 - `--auth-name` has no effect here (there is no shared auth store to select) and
@@ -296,25 +338,28 @@ Source: [`internal/runtime/volume_manager.go`](../../internal/runtime/volume_man
 
 | Flag | Default | Effect on Stores |
 |------|---------|------------------|
-| `--ephemeral` | No | Config store gets a unique suffix key; removed on exit. Env and auth stores are not created. |
-| `--auth-scope=shared` | Yes (default) | Creates shared auth and feature auth stores; enables symlinks and post-exit sync. |
-| `--auth-scope=project` | No | No shared/feature auth stores; auth stays in the project config store only. |
+| `--ephemeral` | No | Config store gets a unique suffix key; removed on exit. Env, auth, and feature-state stores are not created. |
+| `--auth-scope=shared` | Yes (default) | Creates shared auth and feature auth stores; enables symlinks and post-exit sync. Feature state is unaffected. |
+| `--auth-scope=project` | No | No shared/feature auth stores; auth stays in the project config store only. Feature state is unaffected. |
 | `--reset-auth` | No | Deletes auth files from the shared auth and current config stores when scope is shared, or from the config store when scope is project. Also deletes persisted env. |
 
 ## Cleanup
 
 `enclave cleanup` removes persistent stores and other host-side data.
 `--ephemeral` cleanup removes ephemeral config-store directories (every
-`config-store/<key>` other than `default`).
+`config-store/<key>` other than `default`). Normal project cleanup removes all
+feature state for that project, independent of `--tool`; use
+`--keep feature-state` to preserve it. The keep selector also works with
+`cleanup --all`.
 
 ## Source Files
 
-- [`internal/config/host_paths.go`](../../internal/config/host_paths.go) — Store path helpers (`HostStoreConfigDir`, `HostStoreEnvDir`, `HostStoreAuthDir`, `HostStoreFeatureAuthDir`)
+- [`internal/config/host_paths.go`](../../internal/config/host_paths.go) — Store path helpers (`HostStoreConfigDir`, `HostStoreEnvDir`, `HostStoreAuthDir`, `HostStoreFeatureAuthDir`, `HostStoreFeatureStateDir`)
 - [`internal/backend/hoststore/hoststore.go`](../../internal/backend/hoststore/hoststore.go) — Neutral store-identity → host-directory mapping and cross-process store lock, shared by the Docker and QEMU backends (stores are backend-independent: sessions share auth/config/env state across backends)
 - [`internal/backend/docker/storage.go`](../../internal/backend/docker/storage.go) — Host-directory store manager (create, read/write, seed, remove, locking, path-traversal validation)
 - [`internal/runtime/volume_manager.go`](../../internal/runtime/volume_manager.go) — Store intent (which stores exist, reset flags, sync spec)
 - [`internal/backend/docker/prepare.go`](../../internal/backend/docker/prepare.go), [`internal/backend/docker/authsync.go`](../../internal/backend/docker/authsync.go) — Store mechanics: preparation, auth reset, overlay, post-exit sync, stop/remove finalize
 - [`internal/runtime/skills_mount.go`](../../internal/runtime/skills_mount.go) — Managed skill overlay and bind mount assembly
 - [`internal/runtime/auth_manager.go`](../../internal/runtime/auth_manager.go) — Declared secret injection, env persistence, session checks
-- [`internal/runtime/runtime.go`](../../internal/runtime/runtime.go) — Mount assembly (`addConfigMount`, `addAuthMount`, `addFeatureAuthMounts`), execution flow
+- [`internal/runtime/runtime.go`](../../internal/runtime/runtime.go) — Mount assembly (`addConfigMount`, `addAuthMount`, `addFeatureAuthMounts`, `addFeatureStateMounts`), execution flow
 - [`entrypoint.sh`](../../entrypoint.sh), [`runtime-assets/auth-reconcile.sh`](../../runtime-assets/auth-reconcile.sh) — In-container and helper-container symlink/reconcile logic for shared and feature auth

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -19,6 +19,9 @@ workflow. Rootless Docker is [not currently supported](rootless.md).
 - Per-project Enclave config is keyed by project hash under the host config root,
   outside the worktree. Project-scoped config cannot enable guarded options such
   as unrestricted networking or writable project mounts.
+- Feature state stores are writable by every session that enables the feature
+  in the same project and are shared across tools. Treat them as a cross-tool
+  trust channel: one agent can influence data consumed by another.
 
 ## Project-controlled execution
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -296,9 +296,15 @@ fi
 # feature's install never ran, so its runtime entrypoint must not fire either.
 # enclave_feature_enabled fails open when the manifest is absent (or the
 # helper is unavailable), preserving the prior all-features behavior.
+enclave_feature_state_root="${ENCLAVE_FEATURE_STATE_ROOT:-}"
 for ext_dir in "$enclave_features_dir"/*/; do
+    feature_name="$(basename "${ext_dir%/}")"
     if command -v enclave_feature_enabled >/dev/null 2>&1; then
-        enclave_feature_enabled "$(basename "${ext_dir%/}")" || continue
+        enclave_feature_enabled "$feature_name" || continue
+    fi
+    unset ENCLAVE_FEATURE_STATE_DIR
+    if [ -n "$enclave_feature_state_root" ] && [ -d "$enclave_feature_state_root/$feature_name" ]; then
+        export ENCLAVE_FEATURE_STATE_DIR="$enclave_feature_state_root/$feature_name"
     fi
     if [ -d "${ext_dir}feature-entrypoint.d" ]; then
         for script in "${ext_dir}feature-entrypoint.d"/*.sh; do
@@ -306,7 +312,9 @@ for ext_dir in "$enclave_features_dir"/*/; do
             [ -f "$script" ] && . "$script"
         done
     fi
+    unset ENCLAVE_FEATURE_STATE_DIR
 done
+unset ENCLAVE_FEATURE_STATE_ROOT enclave_feature_state_root
 
 # Seed extension init files declared in spec.yaml commands.initFiles, copy any
 # files/workspace trees into the project (never clobbering host files), then run

--- a/internal/app/cleanup.go
+++ b/internal/app/cleanup.go
@@ -176,6 +176,10 @@ func resolveEphemeralStoreDirs(run model.RunOptions, cleanup model.CleanupOption
 			tools = []string{run.Tool}
 		}
 		for _, tool := range tools {
+			// The project-level features namespace is not a tool config-store root.
+			if config.HostProjectToolDir(home, hash, tool) == config.HostStoreFeatureStateRootDir(home, hash) {
+				continue
+			}
 			storeRoot := config.HostStoreConfigRootDir(home, tool, hash)
 			for _, key := range listSubdirs(storeRoot) {
 				if key == persistentConfigStoreKey {
@@ -214,12 +218,15 @@ func resolveCleanupDirs(run model.RunOptions, cleanup model.CleanupOptions, home
 	if cleanup.CleanupAll {
 		dirs := []cleanupDir{
 			{Kind: "cache", Path: config.HostCacheDir(home)},
-			// The state projects tree holds every project's config/env stores
-			// and history, so a full cleanup removes them all at once.
-			{Kind: "history", Path: config.HostProjectsDir(home)},
 			// The image inbox is global (not project-scoped), so it is only
 			// removed by a full cleanup. Held images are user-imported content.
 			{Kind: "inbox", Path: config.HostImageInboxDir(home)},
+		}
+		if cleanup.CleanupKeepHist || cleanup.CleanupKeepFeatureState {
+			dirs = append(dirs, selectiveAllProjectCleanupDirs(home, cleanup)...)
+		} else {
+			// Without selective project-state retention, remove the whole tree.
+			dirs = append(dirs, cleanupDir{Kind: "history", Path: config.HostProjectsDir(home)})
 		}
 		// Shared tool/feature auth stores live outside the projects tree; they
 		// are removed on a full cleanup unless `--keep auth` is set.
@@ -236,7 +243,42 @@ func resolveCleanupDirs(run model.RunOptions, cleanup model.CleanupOptions, home
 		{Kind: "history", Path: config.HostStoreConfigRootDir(home, run.Tool, project.Hash)},
 		{Kind: "history", Path: config.HostStoreEnvDir(home, run.Tool, project.Hash)},
 		{Kind: "memory", Path: config.HostProjectMemoryDir(home, project.Hash, run.Tool)},
+		{Kind: "feature-state", Path: config.HostStoreFeatureStateRootDir(home, project.Hash)},
 	}
+}
+
+// selectiveAllProjectCleanupDirs expands the projects tree only when a keep
+// flag needs to retain one project-scoped namespace while deleting another.
+// Projects without matching retained data can still be removed as a whole.
+func selectiveAllProjectCleanupDirs(home string, cleanup model.CleanupOptions) []cleanupDir {
+	var dirs []cleanupDir
+	for _, hash := range listSubdirs(config.HostProjectsDir(home)) {
+		projectDir := config.HostProjectDir(home, hash)
+		featureStateRoot := config.HostStoreFeatureStateRootDir(home, hash)
+		children := listSubdirs(projectDir)
+		keepsChild := false
+		for _, child := range children {
+			path := filepath.Join(projectDir, child)
+			if path == featureStateRoot {
+				keepsChild = keepsChild || cleanup.CleanupKeepFeatureState
+			} else {
+				keepsChild = keepsChild || cleanup.CleanupKeepHist
+			}
+		}
+		if !keepsChild {
+			dirs = append(dirs, cleanupDir{Kind: "project", Path: projectDir})
+			continue
+		}
+		for _, child := range children {
+			path := filepath.Join(projectDir, child)
+			kind := "history"
+			if path == featureStateRoot {
+				kind = "feature-state"
+			}
+			dirs = append(dirs, cleanupDir{Kind: kind, Path: path})
+		}
+	}
+	return dirs
 }
 
 // authStoreCleanupDirs enumerates the shared tool and feature auth store
@@ -269,6 +311,9 @@ func cleanupDirsForRemoval(run model.RunOptions, cleanup model.CleanupOptions, h
 	}
 	if cleanup.CleanupKeepAuth {
 		dirs = filterDirs(dirs, "auth")
+	}
+	if cleanup.CleanupKeepFeatureState {
+		dirs = filterDirs(dirs, "feature-state")
 	}
 	return dirs
 }

--- a/internal/app/cleanup_test.go
+++ b/internal/app/cleanup_test.go
@@ -232,17 +232,20 @@ func TestResolveEphemeralStoreDirsSkipsDefaultKey(t *testing.T) {
 	}
 }
 
-func TestResolveEphemeralStoreDirsSkipsFeatureStateNamespace(t *testing.T) {
+func TestResolveEphemeralStoreDirsAllSkipsFeatureStateNamespace(t *testing.T) {
 	home := t.TempDir()
 	project := model.Project{Hash: "projhash1234"}
 	stateDir := config.HostStoreFeatureStateDir(home, project.Hash, "config-store")
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		t.Fatalf("mkdir %q: %v", stateDir, err)
+	ephemeralDir := config.HostStoreConfigDir(home, "codex", project.Hash, "session-a")
+	for _, dir := range []string{stateDir, ephemeralDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %q: %v", dir, err)
+		}
 	}
 
-	run := model.RunOptions{Tool: filepath.Base(config.HostStoreFeatureStateRootDir(home, project.Hash))}
-	if dirs := resolveEphemeralStoreDirs(run, model.CleanupOptions{}, home, project); len(dirs) != 0 {
-		t.Fatalf("resolveEphemeralStoreDirs() returned feature state paths: %v", dirs)
+	dirs := resolveEphemeralStoreDirs(model.RunOptions{}, model.CleanupOptions{CleanupAll: true}, home, model.Project{})
+	if len(dirs) != 1 || dirs[0].Kind != "ephemeral" || dirs[0].Path != ephemeralDir {
+		t.Fatalf("resolveEphemeralStoreDirs() = %v, want only %q", dirs, ephemeralDir)
 	}
 }
 

--- a/internal/app/cleanup_test.go
+++ b/internal/app/cleanup_test.go
@@ -34,6 +34,7 @@ func TestResolveCleanupDirs(t *testing.T) {
 		config.HostStoreConfigRootDir(home, run.Tool, project.Hash):                                          true,
 		config.HostStoreEnvDir(home, run.Tool, project.Hash):                                                 true,
 		config.HostProjectMemoryDir(home, project.Hash, run.Tool):                                            true,
+		config.HostStoreFeatureStateRootDir(home, project.Hash):                                              true,
 	}
 
 	if len(dirs) != len(expected) {
@@ -139,6 +140,68 @@ func TestCleanupDirGatingForMemory(t *testing.T) {
 	}
 }
 
+func TestCleanupDirGatingForFeatureState(t *testing.T) {
+	t.Parallel()
+
+	home := "/tmp/test-home"
+	project := model.Project{Hash: "projhash"}
+	run := model.RunOptions{Tool: "codex"}
+	stateRoot := config.HostStoreFeatureStateRootDir(home, project.Hash)
+
+	withoutKeep := cleanupDirsForRemoval(run, model.CleanupOptions{}, home, project)
+	withKeep := cleanupDirsForRemoval(run, model.CleanupOptions{CleanupKeepFeatureState: true}, home, project)
+	contains := func(dirs []cleanupDir, path string) bool {
+		for _, dir := range dirs {
+			if dir.Path == path {
+				return true
+			}
+		}
+		return false
+	}
+	if !contains(withoutKeep, stateRoot) {
+		t.Fatal("default cleanup should remove feature state")
+	}
+	if contains(withKeep, stateRoot) {
+		t.Fatal("--keep feature-state should preserve feature state")
+	}
+}
+
+func TestCleanupAllKeepsFeatureStateIndependently(t *testing.T) {
+	home := t.TempDir()
+	hash := "projhash1234"
+	toolDir := config.HostProjectToolDir(home, hash, "codex")
+	stateRoot := config.HostStoreFeatureStateRootDir(home, hash)
+	for _, dir := range []string{toolDir, config.HostStoreFeatureStateDir(home, hash, "state-probe")} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	pathsByKind := func(dirs []cleanupDir) map[string][]string {
+		result := map[string][]string{}
+		for _, dir := range dirs {
+			result[dir.Kind] = append(result[dir.Kind], dir.Path)
+		}
+		return result
+	}
+
+	keepState := pathsByKind(cleanupDirsForRemoval(model.RunOptions{}, model.CleanupOptions{CleanupAll: true, CleanupKeepFeatureState: true}, home, model.Project{}))
+	if len(keepState["feature-state"]) != 0 {
+		t.Fatalf("--keep feature-state cleanup targets state: %v", keepState["feature-state"])
+	}
+	if len(keepState["history"]) == 0 || keepState["history"][0] != toolDir {
+		t.Fatalf("--keep feature-state should still remove tool project data, got %v", keepState["history"])
+	}
+
+	keepHistory := pathsByKind(cleanupDirsForRemoval(model.RunOptions{}, model.CleanupOptions{CleanupAll: true, CleanupKeepHist: true}, home, model.Project{}))
+	if len(keepHistory["history"]) != 0 {
+		t.Fatalf("--keep history cleanup targets tool data: %v", keepHistory["history"])
+	}
+	if len(keepHistory["feature-state"]) != 1 || keepHistory["feature-state"][0] != stateRoot {
+		t.Fatalf("--keep history should still remove feature state, got %v", keepHistory["feature-state"])
+	}
+}
+
 func TestResolveEphemeralStoreDirsSkipsDefaultKey(t *testing.T) {
 	home := t.TempDir()
 	project := model.Project{Hash: "projhash1234"}
@@ -166,6 +229,20 @@ func TestResolveEphemeralStoreDirsSkipsDefaultKey(t *testing.T) {
 		if !want[dir.Path] {
 			t.Fatalf("unexpected ephemeral store dir %q", dir.Path)
 		}
+	}
+}
+
+func TestResolveEphemeralStoreDirsSkipsFeatureStateNamespace(t *testing.T) {
+	home := t.TempDir()
+	project := model.Project{Hash: "projhash1234"}
+	stateDir := config.HostStoreFeatureStateDir(home, project.Hash, "config-store")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir %q: %v", stateDir, err)
+	}
+
+	run := model.RunOptions{Tool: filepath.Base(config.HostStoreFeatureStateRootDir(home, project.Hash))}
+	if dirs := resolveEphemeralStoreDirs(run, model.CleanupOptions{}, home, project); len(dirs) != 0 {
+		t.Fatalf("resolveEphemeralStoreDirs() returned feature state paths: %v", dirs)
 	}
 }
 

--- a/internal/backend/docker/docker_test.go
+++ b/internal/backend/docker/docker_test.go
@@ -36,6 +36,7 @@ func TestDockerConfigBindMountsStoresFromExactStoreDirs(t *testing.T) {
 			{Kind: backend.StoreKindAuth, Key: backend.StoreKey{Owner: "codex"}, ContainerPath: "/auth", ReadOnly: true},
 			{Kind: backend.StoreKindEnv, Key: backend.StoreKey{Owner: "codex", ProjectHash: hash}, ContainerPath: "/env"},
 			{Kind: backend.StoreKindFeatureAuth, Key: backend.StoreKey{Owner: "playwright"}, ContainerPath: "/feature"},
+			{Kind: backend.StoreKindFeatureState, Key: backend.StoreKey{Owner: "state-probe", ProjectHash: hash}, ContainerPath: "/feature-state"},
 		},
 	}
 
@@ -45,10 +46,11 @@ func TestDockerConfigBindMountsStoresFromExactStoreDirs(t *testing.T) {
 		source   string
 		readOnly bool
 	}{
-		"/config":  {config.HostStoreConfigDir(home, "codex", hash, "default"), false},
-		"/auth":    {config.HostStoreAuthDir(home, "codex", ""), true},
-		"/env":     {config.HostStoreEnvDir(home, "codex", hash), false},
-		"/feature": {config.HostStoreFeatureAuthDir(home, "playwright"), false},
+		"/config":        {config.HostStoreConfigDir(home, "codex", hash, "default"), false},
+		"/auth":          {config.HostStoreAuthDir(home, "codex", ""), true},
+		"/env":           {config.HostStoreEnvDir(home, "codex", hash), false},
+		"/feature":       {config.HostStoreFeatureAuthDir(home, "playwright"), false},
+		"/feature-state": {config.HostStoreFeatureStateDir(home, hash, "state-probe"), false},
 	}
 
 	got := map[string]dockercmd.Mount{}

--- a/internal/backend/docker/prepare.go
+++ b/internal/backend/docker/prepare.go
@@ -34,7 +34,7 @@ func (b *Backend) PrepareStores(ctx context.Context, prep backend.StorePrep) (ba
 		b.prepareConfigStore(*prep.Config)
 	}
 	if prep.Auth != nil {
-		b.ensureStoreDir(prep.Auth.Kind, prep.Auth.Key, util.TitleCase(prep.Auth.Key.Owner)+" shared auth store")
+		b.ensureStoreDir(backend.StoreKindAuth, prep.Auth.Key, util.TitleCase(prep.Auth.Key.Owner)+" shared auth store")
 	}
 	if prep.Env != nil {
 		b.ensureStoreDir(backend.StoreKindEnv, prep.Env.Key, "persistent "+model.AppName+" env store")

--- a/internal/backend/docker/prepare.go
+++ b/internal/backend/docker/prepare.go
@@ -34,14 +34,15 @@ func (b *Backend) PrepareStores(ctx context.Context, prep backend.StorePrep) (ba
 		b.prepareConfigStore(*prep.Config)
 	}
 	if prep.Auth != nil {
-		b.ensureStoreDir(backend.StoreKindAuth, prep.Auth.Key, util.TitleCase(prep.Auth.Key.Owner)+" shared auth store")
+		b.ensureStoreDir(prep.Auth.Kind, prep.Auth.Key, util.TitleCase(prep.Auth.Key.Owner)+" shared auth store")
 	}
 	if prep.Env != nil {
 		b.ensureStoreDir(backend.StoreKindEnv, prep.Env.Key, "persistent "+model.AppName+" env store")
 		state.PersistedEnvAvailable = b.envFileExists(prep.Env.Key)
 	}
-	for _, feature := range prep.Features {
-		b.ensureStoreDir(backend.StoreKindFeatureAuth, feature.Key, util.TitleCase(feature.Key.Owner)+" feature auth store")
+	for _, store := range prep.FeatureStores {
+		label := util.TitleCase(store.Key.Owner) + " " + store.Kind.FeatureStoreLabel()
+		b.ensureStoreDir(store.Kind, store.Key, label)
 	}
 	if prep.Env != nil && prep.Env.Reset {
 		b.resetPersistedEnv(prep.Env.Key)

--- a/internal/backend/docker/storage_test.go
+++ b/internal/backend/docker/storage_test.go
@@ -27,6 +27,21 @@ func newFSStore(t *testing.T) StoreManager {
 	return StoreManager{host: model.Host{Home: t.TempDir(), UID: "1000", GID: "1000"}}
 }
 
+func TestPrepareStoresUsesSharedAuthStoreKind(t *testing.T) {
+	home := t.TempDir()
+	b := New(Options{Host: model.Host{Home: home}})
+	key := backend.StoreKey{Owner: "claude"}
+
+	if _, err := b.PrepareStores(context.Background(), backend.StorePrep{
+		Auth: &backend.StorePrepEntry{Key: key},
+	}); err != nil {
+		t.Fatalf("PrepareStores(auth): %v", err)
+	}
+	if _, err := os.Stat(config.HostStoreAuthDir(home, key.Owner, "")); err != nil {
+		t.Fatalf("shared auth store not created: %v", err)
+	}
+}
+
 func TestPrepareStoresCreatesFeatureStateStore(t *testing.T) {
 	home := t.TempDir()
 	b := New(Options{Host: model.Host{Home: home}})

--- a/internal/backend/docker/storage_test.go
+++ b/internal/backend/docker/storage_test.go
@@ -27,6 +27,21 @@ func newFSStore(t *testing.T) StoreManager {
 	return StoreManager{host: model.Host{Home: t.TempDir(), UID: "1000", GID: "1000"}}
 }
 
+func TestPrepareStoresCreatesFeatureStateStore(t *testing.T) {
+	home := t.TempDir()
+	b := New(Options{Host: model.Host{Home: home}})
+	key := backend.StoreKey{Owner: "state-probe", ProjectHash: "abc123def456"}
+
+	if _, err := b.PrepareStores(context.Background(), backend.StorePrep{
+		FeatureStores: []backend.StorePrepEntry{{Kind: backend.StoreKindFeatureState, Key: key}},
+	}); err != nil {
+		t.Fatalf("PrepareStores(feature state): %v", err)
+	}
+	if _, err := os.Stat(config.HostStoreFeatureStateDir(home, key.ProjectHash, key.Owner)); err != nil {
+		t.Fatalf("feature state store not created: %v", err)
+	}
+}
+
 func TestStoreManagerWriteReadRoundTripCreatesDirsAndAppliesMode(t *testing.T) {
 	store := newFSStore(t)
 	key := backend.StoreKey{Owner: "codex", ProjectHash: "abc123abc123"}

--- a/internal/backend/hoststore/hoststore.go
+++ b/internal/backend/hoststore/hoststore.go
@@ -9,8 +9,8 @@
 // plus backend.StoreKind) to the host directories that back them, and provides
 // the cross-process lock shared by every store consumer. All isolation
 // backends (Docker bind mounts, QEMU 9p shares) realize stores from this
-// single layout, so auth, env, and config state stay shared between containers
-// and microVMs.
+// single layout, so auth, env, config, and feature state stay shared between
+// containers and microVMs.
 package hoststore
 
 import (
@@ -52,13 +52,19 @@ func DirFor(home string, key backend.StoreKey, kind backend.StoreKind) (string, 
 		return config.HostStoreAuthDir(home, owner, identity), nil
 	case backend.StoreKindFeatureAuth:
 		return config.HostStoreFeatureAuthDir(home, owner), nil
+	case backend.StoreKindFeatureState:
+		hash, err := validateStoreSegment(key.ProjectHash)
+		if err != nil {
+			return "", fmt.Errorf("store project hash: %w", err)
+		}
+		return config.HostStoreFeatureStateDir(home, hash, owner), nil
 	case backend.StoreKindEnv:
 		hash, err := validateStoreSegment(key.ProjectHash)
 		if err != nil {
 			return "", fmt.Errorf("store project hash: %w", err)
 		}
 		return config.HostStoreEnvDir(home, owner, hash), nil
-	default:
+	case backend.StoreKindConfig:
 		hash, err := validateStoreSegment(key.ProjectHash)
 		if err != nil {
 			return "", fmt.Errorf("store project hash: %w", err)
@@ -68,6 +74,8 @@ func DirFor(home string, key backend.StoreKey, kind backend.StoreKind) (string, 
 			return "", fmt.Errorf("store key: %w", err)
 		}
 		return config.HostStoreConfigDir(home, owner, hash, storeKey), nil
+	default:
+		return "", fmt.Errorf("unknown store kind %q", kind)
 	}
 }
 

--- a/internal/backend/hoststore/hoststore_test.go
+++ b/internal/backend/hoststore/hoststore_test.go
@@ -29,6 +29,7 @@ func TestDirMapsEachKindToItsHostDirectory(t *testing.T) {
 		{"config default", backend.StoreKey{Owner: "codex", ProjectHash: "abc123abc123"}, backend.StoreKindConfig, config.HostStoreConfigDir(home, "codex", "abc123abc123", "default")},
 		{"config suffix", backend.StoreKey{Owner: "codex", ProjectHash: "abc123abc123", Suffix: "wt2"}, backend.StoreKindConfig, config.HostStoreConfigDir(home, "codex", "abc123abc123", "wt2")},
 		{"env", backend.StoreKey{Owner: "codex", ProjectHash: "abc123abc123"}, backend.StoreKindEnv, config.HostStoreEnvDir(home, "codex", "abc123abc123")},
+		{"feature state", backend.StoreKey{Owner: "state-probe", ProjectHash: "abc123abc123"}, backend.StoreKindFeatureState, config.HostStoreFeatureStateDir(home, "abc123abc123", "state-probe")},
 		{"auth default identity", backend.StoreKey{Owner: "codex"}, backend.StoreKindAuth, config.HostStoreAuthDir(home, "codex", "")},
 		{"auth named identity (--auth-name)", backend.StoreKey{Owner: "codex", Suffix: "personal"}, backend.StoreKindAuth, config.HostStoreAuthDir(home, "codex", "personal")},
 		{"feature auth", backend.StoreKey{Owner: "playwright"}, backend.StoreKindFeatureAuth, config.HostStoreFeatureAuthDir(home, "playwright")},
@@ -50,6 +51,12 @@ func TestDirIncompleteKeyIsEmpty(t *testing.T) {
 	if got := Dir(home, backend.StoreKey{ProjectHash: "abc123abc123"}, backend.StoreKindConfig); got != "" {
 		t.Fatalf("Dir() with missing owner = %q, want empty", got)
 	}
+	if got := Dir(home, backend.StoreKey{Owner: "state-probe"}, backend.StoreKindFeatureState); got != "" {
+		t.Fatalf("Dir() feature state with missing project hash = %q, want empty", got)
+	}
+	if got := Dir(home, backend.StoreKey{Owner: "codex", ProjectHash: "abc123abc123"}, backend.StoreKind("unknown")); got != "" {
+		t.Fatalf("Dir() with unknown kind = %q, want empty", got)
+	}
 }
 
 func TestDirRejectsMaliciousKeySegments(t *testing.T) {
@@ -64,6 +71,7 @@ func TestDirRejectsMaliciousKeySegments(t *testing.T) {
 		{"hash traversal", backend.StoreKey{Owner: "codex", ProjectHash: ".."}, backend.StoreKindConfig},
 		{"suffix traversal", backend.StoreKey{Owner: "codex", ProjectHash: "abc123abc123", Suffix: "../evil"}, backend.StoreKindConfig},
 		{"auth owner traversal", backend.StoreKey{Owner: "../evil"}, backend.StoreKindAuth},
+		{"feature state hash traversal", backend.StoreKey{Owner: "state-probe", ProjectHash: ".."}, backend.StoreKindFeatureState},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/backend/qemu/prepare.go
+++ b/internal/backend/qemu/prepare.go
@@ -29,7 +29,7 @@ func (b *Backend) PrepareStores(ctx context.Context, prep backend.StorePrep) (ba
 		}
 	}
 	if prep.Auth != nil {
-		if err := b.storage.Ensure(ctx, prep.Auth.Key, backend.StoreKindAuth, ""); err != nil {
+		if err := b.storage.Ensure(ctx, prep.Auth.Key, prep.Auth.Kind, ""); err != nil {
 			logx.Warnf("Failed to prepare %s shared auth store: %v", util.TitleCase(prep.Auth.Key.Owner), err)
 		}
 	}
@@ -46,9 +46,9 @@ func (b *Backend) PrepareStores(ctx context.Context, prep backend.StorePrep) (ba
 			state.PersistedEnvAvailable = false
 		}
 	}
-	for _, feature := range prep.Features {
-		if err := b.storage.Ensure(ctx, feature.Key, backend.StoreKindFeatureAuth, ""); err != nil {
-			logx.Warnf("Failed to prepare %s feature auth store: %v", util.TitleCase(feature.Key.Owner), err)
+	for _, store := range prep.FeatureStores {
+		if err := b.storage.Ensure(ctx, store.Key, store.Kind, ""); err != nil {
+			logx.Warnf("Failed to prepare %s %s: %v", util.TitleCase(store.Key.Owner), store.Kind.FeatureStoreLabel(), err)
 		}
 	}
 	if prep.Config != nil && len(prep.ResetAuthFiles) > 0 {

--- a/internal/backend/qemu/prepare.go
+++ b/internal/backend/qemu/prepare.go
@@ -29,7 +29,7 @@ func (b *Backend) PrepareStores(ctx context.Context, prep backend.StorePrep) (ba
 		}
 	}
 	if prep.Auth != nil {
-		if err := b.storage.Ensure(ctx, prep.Auth.Key, prep.Auth.Kind, ""); err != nil {
+		if err := b.storage.Ensure(ctx, prep.Auth.Key, backend.StoreKindAuth, ""); err != nil {
 			logx.Warnf("Failed to prepare %s shared auth store: %v", util.TitleCase(prep.Auth.Key.Owner), err)
 		}
 	}

--- a/internal/backend/qemu/storage_test.go
+++ b/internal/backend/qemu/storage_test.go
@@ -75,6 +75,21 @@ func TestMountSourceResolvesSharedStoreDirs(t *testing.T) {
 	}
 }
 
+func TestPrepareStoresUsesSharedAuthStoreKind(t *testing.T) {
+	home := t.TempDir()
+	b := New(Options{Host: model.Host{Home: home}})
+	key := backend.StoreKey{Owner: "claude"}
+
+	if _, err := b.PrepareStores(context.Background(), backend.StorePrep{
+		Auth: &backend.StorePrepEntry{Key: key},
+	}); err != nil {
+		t.Fatalf("PrepareStores(auth): %v", err)
+	}
+	if _, err := os.Stat(config.HostStoreAuthDir(home, key.Owner, "")); err != nil {
+		t.Fatalf("shared auth store not created: %v", err)
+	}
+}
+
 func TestPrepareStoresCreatesFeatureStateStore(t *testing.T) {
 	home := t.TempDir()
 	b := New(Options{Host: model.Host{Home: home}})

--- a/internal/backend/qemu/storage_test.go
+++ b/internal/backend/qemu/storage_test.go
@@ -45,7 +45,7 @@ func TestStoreManagerReadWriteRemove(t *testing.T) {
 
 // TestMountSourceResolvesSharedStoreDirs pins qemu store mounts to the shared
 // host-store layout, so qemu guests keep reading and writing the exact same
-// auth/config/env directories as Docker sessions of the same tool/project.
+// auth/config/env/feature-state directories as Docker sessions.
 func TestMountSourceResolvesSharedStoreDirs(t *testing.T) {
 	home := t.TempDir()
 	store := newStoreManager(model.Host{Home: home})
@@ -65,17 +65,46 @@ func TestMountSourceResolvesSharedStoreDirs(t *testing.T) {
 	if want := config.HostStoreConfigDir(home, "claude", "abc123def456", "default"); configDir != want {
 		t.Fatalf("config mount source = %q, want shared store dir %q", configDir, want)
 	}
+
+	stateDir, err := store.MountSource(backend.StoreKey{Owner: "state-probe", ProjectHash: "abc123def456"}, backend.StoreKindFeatureState)
+	if err != nil {
+		t.Fatalf("MountSource(feature state): %v", err)
+	}
+	if want := config.HostStoreFeatureStateDir(home, "abc123def456", "state-probe"); stateDir != want {
+		t.Fatalf("feature-state mount source = %q, want shared store dir %q", stateDir, want)
+	}
+}
+
+func TestPrepareStoresCreatesFeatureStateStore(t *testing.T) {
+	home := t.TempDir()
+	b := New(Options{Host: model.Host{Home: home}})
+	key := backend.StoreKey{Owner: "state-probe", ProjectHash: "abc123def456"}
+
+	if _, err := b.PrepareStores(context.Background(), backend.StorePrep{
+		FeatureStores: []backend.StorePrepEntry{{Kind: backend.StoreKindFeatureState, Key: key}},
+	}); err != nil {
+		t.Fatalf("PrepareStores(feature state): %v", err)
+	}
+	if _, err := os.Stat(config.HostStoreFeatureStateDir(home, key.ProjectHash, key.Owner)); err != nil {
+		t.Fatalf("feature state store not created: %v", err)
+	}
 }
 
 func TestWithStoreLockUsesSharedPerStoreLockFiles(t *testing.T) {
 	home := t.TempDir()
 	store := newStoreManager(model.Host{Home: home})
-	key := backend.StoreKey{Owner: "tool"}
 	ctx := context.Background()
-
-	for _, kind := range []backend.StoreKind{backend.StoreKindAuth, backend.StoreKindFeatureAuth} {
-		if err := store.WithStoreLock(ctx, key, kind, func() error { return nil }); err != nil {
-			t.Fatalf("WithStoreLock(%s): %v", kind, err)
+	stores := []struct {
+		kind backend.StoreKind
+		key  backend.StoreKey
+	}{
+		{kind: backend.StoreKindAuth, key: backend.StoreKey{Owner: "tool"}},
+		{kind: backend.StoreKindFeatureAuth, key: backend.StoreKey{Owner: "feature"}},
+		{kind: backend.StoreKindFeatureState, key: backend.StoreKey{Owner: "feature", ProjectHash: "abc123def456"}},
+	}
+	for _, storeRef := range stores {
+		if err := store.WithStoreLock(ctx, storeRef.key, storeRef.kind, func() error { return nil }); err != nil {
+			t.Fatalf("WithStoreLock(%s): %v", storeRef.kind, err)
 		}
 	}
 
@@ -86,7 +115,7 @@ func TestWithStoreLockUsesSharedPerStoreLockFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read locks dir: %v", err)
 	}
-	if len(entries) != 2 {
+	if len(entries) != len(stores) {
 		t.Fatalf("locks dir entries = %d, want one per store kind", len(entries))
 	}
 }

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -90,11 +90,24 @@ type Mount struct {
 type StoreKind string
 
 const (
-	StoreKindConfig      StoreKind = "config"
-	StoreKindAuth        StoreKind = "auth"
-	StoreKindFeatureAuth StoreKind = "feature-auth"
-	StoreKindEnv         StoreKind = "env"
+	StoreKindConfig       StoreKind = "config"
+	StoreKindAuth         StoreKind = "auth"
+	StoreKindFeatureAuth  StoreKind = "feature-auth"
+	StoreKindFeatureState StoreKind = "feature-state"
+	StoreKindEnv          StoreKind = "env"
 )
+
+// FeatureStoreLabel returns the user-facing label for a feature-owned store.
+func (kind StoreKind) FeatureStoreLabel() string {
+	switch kind {
+	case StoreKindFeatureAuth:
+		return "feature auth store"
+	case StoreKindFeatureState:
+		return "feature state store"
+	default:
+		return "feature store"
+	}
+}
 
 type StoreKey struct {
 	Owner       string
@@ -126,10 +139,10 @@ type StoreRef struct {
 // prepare them before the session starts. The caller decides policy (which
 // stores exist, reset flags, preserve lists); the backend owns the mechanics.
 type StorePrep struct {
-	Config   *ConfigStorePrep
-	Auth     *StorePrepEntry // shared tool auth store
-	Env      *EnvStorePrep
-	Features []StorePrepEntry // feature auth stores
+	Config        *ConfigStorePrep
+	Auth          *StorePrepEntry // shared tool auth store
+	Env           *EnvStorePrep
+	FeatureStores []StorePrepEntry
 
 	// ResetAuthFiles lists store-relative auth files to delete from the config
 	// store and (when present) the shared auth store before the session starts.
@@ -156,7 +169,8 @@ type ConfigOverlaySpec struct {
 }
 
 type StorePrepEntry struct {
-	Key StoreKey
+	Kind StoreKind
+	Key  StoreKey
 }
 
 type EnvStorePrep struct {

--- a/internal/backend/types_test.go
+++ b/internal/backend/types_test.go
@@ -9,6 +9,22 @@ package backend
 
 import "testing"
 
+func TestFeatureStoreLabel(t *testing.T) {
+	tests := []struct {
+		kind StoreKind
+		want string
+	}{
+		{kind: StoreKindFeatureAuth, want: "feature auth store"},
+		{kind: StoreKindFeatureState, want: "feature state store"},
+		{kind: StoreKindConfig, want: "feature store"},
+	}
+	for _, tt := range tests {
+		if got := tt.kind.FeatureStoreLabel(); got != tt.want {
+			t.Errorf("StoreKind(%q).FeatureStoreLabel() = %q, want %q", tt.kind, got, tt.want)
+		}
+	}
+}
+
 func TestValidateFailsClosedForRestrictedNetwork(t *testing.T) {
 	req := Request{Network: NetworkPolicy{Mode: NetworkModeRestricted}}
 	if err := Validate(req, Capabilities{}); err == nil {

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -721,8 +721,10 @@ func cleanupCommand(res *Result) *cobra.Command {
 					res.Options.CleanupKeepAuth = true
 				case "memory":
 					res.Options.CleanupKeepMemory = true
+				case "feature-state":
+					res.Options.CleanupKeepFeatureState = true
 				default:
-					return fmt.Errorf("unknown --keep value %q (valid: cache,history,auth,memory)", token)
+					return fmt.Errorf("unknown --keep value %q (valid: cache,history,auth,memory,feature-state)", token)
 				}
 			}
 			return nil
@@ -731,7 +733,7 @@ func cleanupCommand(res *Result) *cobra.Command {
 	addOptionFlagsByName(cmd.Flags(), &res.Options, &res.Sources, "tool")
 	cmd.Flags().BoolVar(&res.Options.CleanupAll, "all", false, "Remove stores and caches for all projects")
 	cmd.Flags().BoolVar(&res.Options.CleanupEphemeral, "ephemeral", false, "Remove stopped containers and ephemeral session stores")
-	cmd.Flags().StringSlice("keep", nil, "Keep stores of the listed kinds: cache,history,auth,memory (memory has no selective effect with --all)")
+	cmd.Flags().StringSlice("keep", nil, "Keep stores of the listed kinds: cache,history,auth,memory,feature-state (memory has no selective effect with --all)")
 	cmd.Flags().BoolVar(&res.Options.CleanupBuildCache, "build-cache", false, "Prune Docker build cache (requires confirmation)")
 	cmd.Flags().BoolVar(&res.Options.CleanupDryRun, "dry-run", false, "Show what would be removed")
 	return cmd

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -99,7 +99,7 @@ func TestParseShellAdmin(t *testing.T) {
 
 func TestParseCleanupFlags(t *testing.T) {
 	defaults := config.DefaultOptions()
-	res, err := Parse([]string{"cleanup", "--all", "--keep", "memory", "--tool", "codex"}, defaults)
+	res, err := Parse([]string{"cleanup", "--all", "--keep", "memory,feature-state", "--tool", "codex"}, defaults)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -111,6 +111,9 @@ func TestParseCleanupFlags(t *testing.T) {
 	}
 	if !res.Options.CleanupKeepMemory {
 		t.Fatal("expected cleanup keep-memory true")
+	}
+	if !res.Options.CleanupKeepFeatureState {
+		t.Fatal("expected cleanup keep-feature-state true")
 	}
 	if res.Options.Tool != "codex" {
 		t.Fatalf("expected tool codex, got %s", res.Options.Tool)

--- a/internal/config/extension.go
+++ b/internal/config/extension.go
@@ -98,6 +98,9 @@ func ListTools(paths model.Paths) ([]string, error) {
 
 	var tools []string
 	for _, name := range names {
+		if name == projectFeatureStateDirName {
+			continue
+		}
 		if hasSpecFile(paths, name, KindSandbox) {
 			tools = append(tools, name)
 		}

--- a/internal/config/extension_overlay_test.go
+++ b/internal/config/extension_overlay_test.go
@@ -132,6 +132,22 @@ func TestListToolsMergesAndDeduplicates(t *testing.T) {
 	}
 }
 
+func TestListToolsExcludesReservedFeatureStateName(t *testing.T) {
+	tmp := t.TempDir()
+	toolsDir := filepath.Join(tmp, "extensions", "tools")
+	writeTestFile(t, filepath.Join(toolsDir, "codex", SpecFilename), `{"schemaVersion":"1","kind":"sandbox","name":"codex"}`)
+	writeTestFile(t, filepath.Join(toolsDir, projectFeatureStateDirName, SpecFilename), `{"schemaVersion":"1","kind":"sandbox","name":"features"}`)
+
+	got, err := ListTools(model.Paths{ToolsDir: toolsDir})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	want := []string{"codex"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListTools=%v want=%v", got, want)
+	}
+}
+
 func TestListFeaturesMergesAndDeduplicates(t *testing.T) {
 	tmp := t.TempDir()
 	builtinFeatures := filepath.Join(tmp, "extensions", "features")

--- a/internal/config/host_paths.go
+++ b/internal/config/host_paths.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	enclaveDirName         = "." + model.AppName
-	configFilename         = "config.json"
-	networkPolicyFilename  = "network.jsonc"
-	recentProjectsFilename = "recent-projects.json"
+	enclaveDirName             = "." + model.AppName
+	configFilename             = "config.json"
+	networkPolicyFilename      = "network.jsonc"
+	recentProjectsFilename     = "recent-projects.json"
+	projectFeatureStateDirName = "features"
 )
 
 func HostLocksDir(home string) string {
@@ -173,6 +174,18 @@ func HostStoreConfigDir(home string, tool string, projectHash string, key string
 // for a project.
 func HostStoreEnvDir(home string, tool string, projectHash string) string {
 	return filepath.Join(HostProjectToolDir(home, projectHash, tool), "env")
+}
+
+// HostStoreFeatureStateRootDir is the project-scoped root for feature-owned
+// state shared by every tool running in that project.
+func HostStoreFeatureStateRootDir(home string, projectHash string) string {
+	return filepath.Join(HostProjectDir(home, projectHash), projectFeatureStateDirName)
+}
+
+// HostStoreFeatureStateDir is the host directory backing one feature's
+// project-scoped state store.
+func HostStoreFeatureStateDir(home string, projectHash string, feature string) string {
+	return filepath.Join(HostStoreFeatureStateRootDir(home, projectHash), feature, "state")
 }
 
 // HostStoreAuthRootDir is the host directory holding every tool's shared auth

--- a/internal/config/host_paths_test.go
+++ b/internal/config/host_paths_test.go
@@ -78,6 +78,9 @@ func TestHostPaths(t *testing.T) {
 	if got, want := HostStoreEnvDir(home, tool, projectHash), filepath.Join(stateRoot, "projects", projectHash, tool, "env"); got != want {
 		t.Fatalf("HostStoreEnvDir() = %q, want %q", got, want)
 	}
+	if got, want := HostStoreFeatureStateDir(home, projectHash, "myfeature"), filepath.Join(stateRoot, "projects", projectHash, "features", "myfeature", "state"); got != want {
+		t.Fatalf("HostStoreFeatureStateDir() = %q, want %q", got, want)
+	}
 	if got, want := HostStoreAuthDir(home, tool, ""), filepath.Join(stateRoot, "tools", tool, "auth", "default"); got != want {
 		t.Fatalf("HostStoreAuthDir() = %q, want %q", got, want)
 	}

--- a/internal/config/spec.go
+++ b/internal/config/spec.go
@@ -53,9 +53,10 @@ type specDocument struct {
 	DefaultEnabled     *bool    `json:"defaultEnabled,omitempty"`  // mixin-only
 	DefaultIncluded    *bool    `json:"defaultIncluded,omitempty"` // tool-only
 
-	// mixin enclave-native auth (features that carry credentials, e.g. github-cli)
+	// Enclave-native mixin fields.
 	ConfigDir string   `json:"configDir,omitempty"`
 	AuthFiles []string `json:"authFiles,omitempty"`
+	State     bool     `json:"state,omitempty"`
 }
 
 type specSandbox struct {

--- a/internal/config/spec_loader.go
+++ b/internal/config/spec_loader.go
@@ -49,6 +49,12 @@ func LoadSpec(paths model.Paths, name string, kind string) (specDocument, error)
 	if doc.Name != name {
 		return specDocument{}, fmt.Errorf("%s name must be %q", specPath, name)
 	}
+	if kind == KindSandbox && name == projectFeatureStateDirName {
+		return specDocument{}, fmt.Errorf("%s name %q is reserved for project-scoped feature state", specPath, name)
+	}
+	if kind == KindSandbox && doc.State {
+		return specDocument{}, fmt.Errorf("%s state is supported for mixin extensions only", specPath)
+	}
 	if err := validateStartupCommands(doc, specPath); err != nil {
 		return specDocument{}, err
 	}

--- a/internal/config/spec_loader_test.go
+++ b/internal/config/spec_loader_test.go
@@ -91,6 +91,9 @@ func TestLoadFeatureExtensionFromSpec(t *testing.T) {
 	if !ext.DefaultEnabled {
 		t.Fatalf("expected default DefaultEnabled=true for mixin, got %+v", ext)
 	}
+	if !ext.FeatureState {
+		t.Fatalf("expected state opt-in to map onto feature, got %+v", ext)
+	}
 }
 
 func TestListToolsIncludesSpecOnlyTools(t *testing.T) {
@@ -153,9 +156,26 @@ func TestLoadSpecRejectsNameInDocument(t *testing.T) {
 	}
 }
 
-// TestLoadSpecMissingFileRoutesElsewhere confirms that resolving a spec of a
-// kind whose root does not contain the extension returns not-found (the
-// previous "kind mismatch" test only ever hit this path).
+func TestLoadSpecRejectsReservedFeatureStateToolName(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "tools", projectFeatureStateDirName, SpecFilename),
+		"schemaVersion: \"1\"\nkind: sandbox\nname: "+projectFeatureStateDirName+"\n")
+	paths := model.Paths{ToolsDir: filepath.Join(dir, "tools"), FeaturesDir: filepath.Join(dir, "features")}
+	if _, err := LoadSpec(paths, projectFeatureStateDirName, KindSandbox); err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("expected reserved-name error, got %v", err)
+	}
+}
+
+func TestLoadSpecRejectsStateOnSandbox(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "tools", "demo", SpecFilename),
+		"schemaVersion: \"1\"\nkind: sandbox\nname: demo\nstate: true\n")
+	paths := model.Paths{ToolsDir: filepath.Join(dir, "tools"), FeaturesDir: filepath.Join(dir, "features")}
+	if _, err := LoadSpec(paths, "demo", KindSandbox); err == nil || !strings.Contains(err.Error(), "mixin") {
+		t.Fatalf("expected mixin-only state error, got %v", err)
+	}
+}
+
 func TestLoadSpecRejectsUnknownKeys(t *testing.T) {
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, "tools", "demo", SpecFilename),
@@ -242,6 +262,9 @@ func TestLoadSpecRejectsWhitespaceEntrypointArgv(t *testing.T) {
 	}
 }
 
+// TestLoadSpecMissingFileRoutesElsewhere confirms that resolving a spec of a
+// kind whose root does not contain the extension returns not-found (the
+// previous "kind mismatch" test only ever hit this path).
 func TestLoadSpecMissingFileRoutesElsewhere(t *testing.T) {
 	paths := testPathsWithExtensions(t, "testdata/spec")
 	// "demo" only exists under tools/; KindMixin resolves under features/.

--- a/internal/config/spec_map.go
+++ b/internal/config/spec_map.go
@@ -293,14 +293,15 @@ func specToProfile(doc specDocument) model.Profile {
 // kind-specific defaults via applyExtensionDefaults.
 func specToExtension(doc specDocument) (model.Extension, extensionManifestState) {
 	ext := model.Extension{
-		Name:        doc.Name,
-		Description: doc.Description,
-		AptPackages: doc.AptPackages,
-		NeedsRoot:   doc.NeedsRoot,
-		ConfigDir:   doc.ConfigDir,
-		AuthFiles:   doc.AuthFiles,
-		Secrets:     buildSecrets(doc),
-		Ports:       buildPorts(doc),
+		Name:         doc.Name,
+		Description:  doc.Description,
+		AptPackages:  doc.AptPackages,
+		NeedsRoot:    doc.NeedsRoot,
+		ConfigDir:    doc.ConfigDir,
+		AuthFiles:    doc.AuthFiles,
+		FeatureState: doc.State,
+		Secrets:      buildSecrets(doc),
+		Ports:        buildPorts(doc),
 	}
 	if doc.Network != nil {
 		ext.AllowedDomains = doc.Network.AllowedDomains

--- a/internal/config/spec_map_test.go
+++ b/internal/config/spec_map_test.go
@@ -243,6 +243,7 @@ needsRoot: true
 priority: 50
 configDir: .config/gh
 authFiles: [hosts.yml, config.yml]
+state: true
 credentials:
   sources:
     github-token: { env: [GH_TOKEN, GITHUB_TOKEN] }
@@ -254,7 +255,7 @@ network:
 	if ext.Type != model.ExtensionKindMixin || ext.Name != "github-cli" {
 		t.Fatalf("kind->type wrong: %+v", ext)
 	}
-	if !ext.NeedsRoot || ext.ConfigDir != ".config/gh" || len(ext.AuthFiles) != 2 {
+	if !ext.NeedsRoot || ext.ConfigDir != ".config/gh" || len(ext.AuthFiles) != 2 || !ext.FeatureState {
 		t.Fatalf("mixin fields wrong: %+v", ext)
 	}
 	if !state.PrioritySet || ext.Priority != 50 {

--- a/internal/config/testdata/spec/features/demo-mixin/spec.yaml
+++ b/internal/config/testdata/spec/features/demo-mixin/spec.yaml
@@ -2,3 +2,4 @@ schemaVersion: "1"
 kind: mixin
 name: demo-mixin
 description: Minimal spec.yaml mixin fixture for LoadFeatureExtension tests.
+state: true

--- a/internal/model/env.go
+++ b/internal/model/env.go
@@ -33,6 +33,8 @@ const (
 	EnvNetworkLogMode           = EnvPrefix + "NETWORK_LOG_MODE"
 	EnvGatewayConfigDir         = EnvPrefix + "GATEWAY_CONFIG_DIR"
 	EnvFeatureAuthMap           = EnvPrefix + "FEATURE_AUTH_MAP"
+	EnvFeatureStateRoot         = EnvPrefix + "FEATURE_STATE_ROOT"
+	EnvFeatureStateDir          = EnvPrefix + "FEATURE_STATE_DIR"
 	EnvYolo                     = EnvPrefix + "YOLO"
 	EnvPlaywrightMCP            = EnvPrefix + "PLAYWRIGHT_MCP"
 	EnvSecretReleaseFile        = EnvPrefix + "SECRET_RELEASE_FILE"

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -76,14 +76,15 @@ type BuildOptions struct {
 }
 
 type CleanupOptions struct {
-	CleanupAll        bool
-	CleanupEphemeral  bool
-	CleanupKeepCache  bool
-	CleanupKeepHist   bool
-	CleanupKeepMemory bool
-	CleanupKeepAuth   bool
-	CleanupBuildCache bool
-	CleanupDryRun     bool
+	CleanupAll              bool
+	CleanupEphemeral        bool
+	CleanupKeepCache        bool
+	CleanupKeepHist         bool
+	CleanupKeepMemory       bool
+	CleanupKeepAuth         bool
+	CleanupKeepFeatureState bool
+	CleanupBuildCache       bool
+	CleanupDryRun           bool
 }
 
 // ImgOptions carries arguments for the host-side `img import` command.
@@ -368,6 +369,7 @@ type Extension struct {
 	Priority            int                     `json:"priority,omitempty"`
 	ConfigDir           string                  `json:"config_dir,omitempty"`
 	AuthFiles           []string                `json:"auth_files,omitempty"`
+	FeatureState        bool                    `json:"feature_state,omitempty"`
 	Secrets             map[string]SecretConfig `json:"secrets,omitempty"`
 	// AllowedDomains/DeniedDomains/EnvVariables/ProxyManaged mirror the
 	// same-named Profile fields for mixins: populated from a mixin spec.yaml's
@@ -435,13 +437,14 @@ const (
 	// AppID is the reverse-DNS application identifier. It names the app-specific
 	// host directories on platforms that follow that convention (macOS
 	// Library/Application Support and Library/Caches).
-	AppID                   = "org.eclipse." + AppName
-	Version                 = "1.0.0"
-	HostnamePrefix          = AppName + "-"
-	ContainerUser           = "agent"
-	ContainerHome           = "/home/" + ContainerUser
-	ContainerAuthDir        = "." + AppName + "-auth"
-	ContainerFeatureAuthDir = "." + AppName + "-feature-auth"
+	AppID                    = "org.eclipse." + AppName
+	Version                  = "1.0.0"
+	HostnamePrefix           = AppName + "-"
+	ContainerUser            = "agent"
+	ContainerHome            = "/home/" + ContainerUser
+	ContainerAuthDir         = "." + AppName + "-auth"
+	ContainerFeatureAuthDir  = "." + AppName + "-feature-auth"
+	ContainerFeatureStateDir = "." + AppName + "-feature-state"
 	// UserCommandsContainerDir is the fixed, home-layout-neutral path where the
 	// host session command tree is mounted read-only inside the container.
 	UserCommandsContainerDir = "/opt/" + AppName + "/commands"

--- a/internal/runtime/auth_mount_test.go
+++ b/internal/runtime/auth_mount_test.go
@@ -81,3 +81,26 @@ func TestAddAuthMountOmitsSecurestorageDirEnvWhenUnset(t *testing.T) {
 		t.Fatalf("did not expect CLAUDE_SECURESTORAGE_CONFIG_DIR for codex")
 	}
 }
+
+func TestAddFeatureStateMountsUsesNeutralRoot(t *testing.T) {
+	t.Parallel()
+
+	r := &Runtime{
+		containerHome: "/home/agent",
+		features:      []model.Extension{{Name: "state-probe"}, {Name: "stateless"}},
+	}
+	store := backend.StoreRef{
+		Kind: backend.StoreKindFeatureState,
+		Key:  backend.StoreKey{Owner: "state-probe", ProjectHash: "abc123def456"},
+	}
+	acc := newMountAccumulator(nil, nil)
+	r.addFeatureStateMounts(acc, map[string]backend.StoreRef{"state-probe": store})
+
+	mountRoot := "/home/agent/" + model.ContainerFeatureStateDir
+	if !hasStore(acc.Stores(), backend.StoreKindFeatureState, "state-probe", mountRoot+"/state-probe") {
+		t.Fatalf("expected feature state mounted below %s", mountRoot)
+	}
+	if got, ok := lookupEnv(acc.Env(), model.EnvFeatureStateRoot); !ok || got != mountRoot {
+		t.Fatalf("%s = %q (present=%v), want %q", model.EnvFeatureStateRoot, got, ok, mountRoot)
+	}
+}

--- a/internal/runtime/entrypoint_auth_test.go
+++ b/internal/runtime/entrypoint_auth_test.go
@@ -12,6 +12,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"enclave/internal/model"
 )
 
 func TestEntrypointClaudeCredentialsNewerConfigUpdatesSharedAndLinks(t *testing.T) {
@@ -96,6 +98,43 @@ func runEntrypointAuth(t *testing.T, home string, configDir string, authDir stri
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, string(out))
 	}
+}
+
+func TestEntrypointScopesFeatureStateDirToOwningFeature(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "project")
+	featuresDir := filepath.Join(home, "features")
+	stateRoot := filepath.Join(home, model.ContainerFeatureStateDir)
+	stateDir := filepath.Join(stateRoot, "stateful")
+	for _, dir := range []string{projectDir, stateDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	probe := `printf '%s' "${` + model.EnvFeatureStateDir + `:-unset}"`
+	writeFile(t, filepath.Join(featuresDir, "stateful", "feature-entrypoint.d", "setup.sh"), probe+` > "$HOME/stateful.out"`)
+	writeFile(t, filepath.Join(featuresDir, "stateless", "feature-entrypoint.d", "setup.sh"), probe+` > "$HOME/stateless.out"`)
+
+	entrypointPath := filepath.Join("..", "..", "entrypoint.sh")
+	cmd := exec.Command("bash", entrypointPath, "bash", "-c", probe+` > "$HOME/final.out"`)
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + home,
+		"PROJECT_DIR=" + projectDir,
+		"TOOL=claude",
+		"ENCLAVE_TOOLS_DIR=" + filepath.Join("..", "..", "extensions", "tools"),
+		"ENCLAVE_FEATURES_DIR=" + featuresDir,
+		"ENCLAVE_FEATURE_STATE_ROOT=" + stateRoot,
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, string(out))
+	}
+
+	assertFileContent(t, filepath.Join(home, "stateful.out"), stateDir)
+	assertFileContent(t, filepath.Join(home, "stateless.out"), "unset")
+	assertFileContent(t, filepath.Join(home, "final.out"), "unset")
 }
 
 func assertSymlinkTarget(t *testing.T, path string, want string) {

--- a/internal/runtime/ports_test.go
+++ b/internal/runtime/ports_test.go
@@ -226,8 +226,8 @@ func TestApplyFeaturePortsPublishesEnabledFeatureDeclarations(t *testing.T) {
 	r := &Runtime{
 		profile: model.Profile{Name: "claude"},
 		features: []model.Extension{
-			{Name: "diffity", Ports: []model.PortConfig{
-				{Container: 5391, HostAllocation: model.HostAllocationAuto, Publish: true, Label: "Diffity"},
+			{Name: "preview", Ports: []model.PortConfig{
+				{Container: 5391, HostAllocation: model.HostAllocationAuto, Publish: true, Label: "Preview"},
 			}},
 			{Name: "fixed", Ports: []model.PortConfig{
 				{Container: 8080, Publish: true, Label: "Fixed"},
@@ -254,8 +254,8 @@ func TestApplyFeaturePortsUserMappingWins(t *testing.T) {
 		run:     model.RunOptions{Ports: []string{"127.0.0.1:6000:5391"}},
 		profile: model.Profile{Name: "claude"},
 		features: []model.Extension{
-			{Name: "diffity", Ports: []model.PortConfig{
-				{Container: 5391, HostAllocation: model.HostAllocationAuto, Publish: true, Label: "Diffity"},
+			{Name: "preview", Ports: []model.PortConfig{
+				{Container: 5391, HostAllocation: model.HostAllocationAuto, Publish: true, Label: "Preview"},
 			}},
 		},
 	}
@@ -290,13 +290,13 @@ func TestDeclaredPortConfigsCombinesProfileAndFeatures(t *testing.T) {
 			Ports: []model.PortConfig{{Container: 3000, Publish: true, Label: "Theia IDE"}},
 		},
 		features: []model.Extension{
-			{Name: "diffity", Ports: []model.PortConfig{
-				{Container: 5391, HostAllocation: model.HostAllocationAuto, Publish: true, Label: "Diffity"},
+			{Name: "preview", Ports: []model.PortConfig{
+				{Container: 5391, HostAllocation: model.HostAllocationAuto, Publish: true, Label: "Preview"},
 			}},
 		},
 	}
 	got := r.declaredPortConfigs()
-	if len(got) != 2 || got[0].Label != "Theia IDE" || got[1].Label != "Diffity" {
+	if len(got) != 2 || got[0].Label != "Theia IDE" || got[1].Label != "Preview" {
 		t.Fatalf("declaredPortConfigs = %+v", got)
 	}
 }
@@ -305,11 +305,11 @@ func TestLogDeclaredPortAvailabilityAutoPortWithoutBackendFallsBack(t *testing.T
 	r := &Runtime{
 		profile: model.Profile{Name: "claude"},
 		features: []model.Extension{
-			{Name: "diffity", Ports: []model.PortConfig{{
+			{Name: "preview", Ports: []model.PortConfig{{
 				Container:      5391,
 				HostAllocation: model.HostAllocationAuto,
 				Publish:        true,
-				Label:          "Diffity",
+				Label:          "Preview",
 				OpenURL:        "http://localhost:{host_port}",
 			}}},
 		},

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -340,7 +340,8 @@ func (r *Runtime) prepareVolumes(containerName string, baseContainerName string,
 
 	r.addConfigMount(mountArgs, stores.Config)
 	r.addAuthMount(mountArgs, stores.Auth)
-	r.addFeatureAuthMounts(mountArgs, stores.Features)
+	r.addFeatureAuthMounts(mountArgs, stores.FeatureAuth)
+	r.addFeatureStateMounts(mountArgs, stores.FeatureState)
 	r.addEnvStore(mountArgs, stores.Env)
 
 	authState, secretMapping, err := newAuthManager(r).Prepare(mountArgs.EnvPtr(), stores)
@@ -1460,6 +1461,27 @@ func (r *Runtime) addFeatureAuthMounts(mounts *mountAccumulator, featureStores m
 	}
 	if len(entries) > 0 {
 		mounts.AddEnv(model.EnvFeatureAuthMap, strings.Join(entries, "|"))
+	}
+}
+
+func (r *Runtime) addFeatureStateMounts(mounts *mountAccumulator, featureStores map[string]backend.StoreRef) {
+	if len(featureStores) == 0 {
+		return
+	}
+	mountRoot := r.containerHome + "/" + model.ContainerFeatureStateDir
+	mounted := false
+	for _, feat := range r.features {
+		store, ok := featureStores[feat.Name]
+		if !ok {
+			continue
+		}
+		mountPath := mountRoot + "/" + feat.Name
+		mounts.AddStore(backend.PersistentStore{Kind: store.Kind, Key: store.Key, ContainerPath: mountPath})
+		mounted = true
+		logx.Infof("%s feature state mounted", util.TitleCase(feat.Name))
+	}
+	if mounted {
+		mounts.AddEnv(model.EnvFeatureStateRoot, mountRoot)
 	}
 }
 

--- a/internal/runtime/volume_manager.go
+++ b/internal/runtime/volume_manager.go
@@ -22,10 +22,11 @@ import (
 // uses. It replaces the volume-name-carrying model.VolumeState: the runtime
 // only tracks store identity; the backend resolves names.
 type storeSet struct {
-	Config   *backend.StoreRef
-	Auth     *backend.StoreRef
-	Env      *backend.StoreRef
-	Features map[string]backend.StoreRef
+	Config       *backend.StoreRef
+	Auth         *backend.StoreRef
+	Env          *backend.StoreRef
+	FeatureAuth  map[string]backend.StoreRef
+	FeatureState map[string]backend.StoreRef
 
 	PersistedEnvAvailable bool
 }
@@ -75,7 +76,7 @@ func (m volumeManager) BuildPrep(volumeSuffix string) (backend.StorePrep, storeS
 	if m.shouldCreateSharedAuthVolume() {
 		// Suffix selects the named auth identity; an empty suffix selects default.
 		key := backend.StoreKey{Owner: m.profile.Name, Suffix: m.auth.AuthName}
-		prep.Auth = &backend.StorePrepEntry{Key: key}
+		prep.Auth = &backend.StorePrepEntry{Kind: backend.StoreKindAuth, Key: key}
 		stores.Auth = &backend.StoreRef{Kind: backend.StoreKindAuth, Key: key}
 	}
 
@@ -86,19 +87,25 @@ func (m volumeManager) BuildPrep(volumeSuffix string) (backend.StorePrep, storeS
 	}
 
 	for _, feat := range m.features {
-		if !m.shouldCreateFeatureAuthVolume(feat) {
-			continue
+		if m.shouldCreateFeatureAuthVolume(feat) {
+			authFiles, err := backend.ValidateAuthFilePaths(feat.AuthFiles)
+			if err == nil && len(authFiles) > 0 {
+				key := backend.StoreKey{Owner: feat.Name}
+				prep.FeatureStores = append(prep.FeatureStores, backend.StorePrepEntry{Kind: backend.StoreKindFeatureAuth, Key: key})
+				if stores.FeatureAuth == nil {
+					stores.FeatureAuth = map[string]backend.StoreRef{}
+				}
+				stores.FeatureAuth[feat.Name] = backend.StoreRef{Kind: backend.StoreKindFeatureAuth, Key: key}
+			}
 		}
-		authFiles, err := backend.ValidateAuthFilePaths(feat.AuthFiles)
-		if err != nil || len(authFiles) == 0 {
-			continue
+		if m.shouldCreateFeatureStateVolume(feat) {
+			key := backend.StoreKey{Owner: feat.Name, ProjectHash: m.project.Hash}
+			prep.FeatureStores = append(prep.FeatureStores, backend.StorePrepEntry{Kind: backend.StoreKindFeatureState, Key: key})
+			if stores.FeatureState == nil {
+				stores.FeatureState = map[string]backend.StoreRef{}
+			}
+			stores.FeatureState[feat.Name] = backend.StoreRef{Kind: backend.StoreKindFeatureState, Key: key}
 		}
-		key := backend.StoreKey{Owner: feat.Name}
-		prep.Features = append(prep.Features, backend.StorePrepEntry{Key: key})
-		if stores.Features == nil {
-			stores.Features = map[string]backend.StoreRef{}
-		}
-		stores.Features[feat.Name] = backend.StoreRef{Kind: backend.StoreKindFeatureAuth, Key: key}
 	}
 
 	if m.shouldResetAuthFiles() {
@@ -127,7 +134,7 @@ func (m volumeManager) authSyncSpec(stores storeSet) *backend.AuthSyncSpec {
 		}
 	}
 	for _, feat := range m.features {
-		if _, ok := stores.Features[feat.Name]; !ok {
+		if _, ok := stores.FeatureAuth[feat.Name]; !ok {
 			continue
 		}
 		authFiles, err := backend.ValidateAuthFilePaths(feat.AuthFiles)
@@ -195,6 +202,10 @@ func (m volumeManager) shouldCreateFeatureAuthVolume(ext model.Extension) bool {
 		return false
 	}
 	return true
+}
+
+func (m volumeManager) shouldCreateFeatureStateVolume(ext model.Extension) bool {
+	return ext.FeatureState && m.run.Persist
 }
 
 func (m volumeManager) shouldCreateEnvVolume() bool {

--- a/internal/runtime/volume_manager_test.go
+++ b/internal/runtime/volume_manager_test.go
@@ -10,6 +10,7 @@ package runtime
 import (
 	"testing"
 
+	"enclave/internal/backend"
 	"enclave/internal/model"
 )
 
@@ -63,5 +64,108 @@ func TestConfigVolumeRelativeDirsSkipsRootLevelFiles(t *testing.T) {
 
 	if got := m.configVolumeRelativeDirs(); len(got) != 0 {
 		t.Fatalf("configVolumeRelativeDirs() = %v, want no nested directories", got)
+	}
+}
+
+func TestBuildPrepFeatureStateGate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		persist   bool
+		state     bool
+		authScope string
+		want      bool
+	}{
+		{name: "persistent shared auth", persist: true, state: true, authScope: model.AuthScopeShared, want: true},
+		{name: "persistent project auth", persist: true, state: true, authScope: model.AuthScopeProject, want: true},
+		{name: "ephemeral", persist: false, state: true, authScope: model.AuthScopeShared, want: false},
+		{name: "not opted in", persist: true, state: false, authScope: model.AuthScopeShared, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Runtime{
+				profile:  model.Profile{Name: "claude", ConfigDir: ".claude"},
+				project:  model.Project{Hash: "abc123def456"},
+				run:      model.RunOptions{Persist: tt.persist},
+				auth:     model.AuthOptions{AuthScope: tt.authScope},
+				features: []model.Extension{{Name: "state-probe", FeatureState: tt.state}},
+			}
+
+			prep, stores := newVolumeManager(r).BuildPrep("session-specific")
+			state, ok := stores.FeatureState["state-probe"]
+			if ok != tt.want {
+				t.Fatalf("feature state present = %v, want %v", ok, tt.want)
+			}
+			var prepState *backend.StorePrepEntry
+			for i := range prep.FeatureStores {
+				if prep.FeatureStores[i].Kind == backend.StoreKindFeatureState {
+					prepState = &prep.FeatureStores[i]
+				}
+			}
+			if (prepState != nil) != tt.want {
+				t.Fatalf("feature-state prep present = %v, want %v", prepState != nil, tt.want)
+			}
+			if !tt.want {
+				return
+			}
+			wantKey := backend.StoreKey{Owner: "state-probe", ProjectHash: "abc123def456"}
+			if state.Kind != backend.StoreKindFeatureState || state.Key != wantKey {
+				t.Fatalf("feature state = %+v, want kind=%q key=%+v", state, backend.StoreKindFeatureState, wantKey)
+			}
+			if prepState.Key != wantKey {
+				t.Fatalf("feature-state prep key = %+v, want %+v", prepState.Key, wantKey)
+			}
+		})
+	}
+}
+
+func TestBuildPrepFeatureStateKeyIsToolIndependent(t *testing.T) {
+	t.Parallel()
+
+	build := func(tool string) backend.StoreRef {
+		r := &Runtime{
+			profile:  model.Profile{Name: tool},
+			project:  model.Project{Hash: "abc123def456"},
+			run:      model.RunOptions{Persist: true},
+			features: []model.Extension{{Name: "state-probe", FeatureState: true}},
+		}
+		_, stores := newVolumeManager(r).BuildPrep("")
+		return stores.FeatureState["state-probe"]
+	}
+
+	claude := build("claude")
+	codex := build("codex")
+	if claude != codex {
+		t.Fatalf("feature state differs by tool: claude=%+v codex=%+v", claude, codex)
+	}
+}
+
+func TestBuildPrepAllowsFeatureAuthAndStateTogether(t *testing.T) {
+	t.Parallel()
+
+	r := &Runtime{
+		profile: model.Profile{Name: "claude", ConfigDir: ".claude"},
+		project: model.Project{Hash: "abc123def456"},
+		run:     model.RunOptions{Persist: true},
+		auth:    model.AuthOptions{AuthScope: model.AuthScopeShared},
+		features: []model.Extension{{
+			Name:         "github-cli",
+			ConfigDir:    ".config/gh",
+			AuthFiles:    []string{"hosts.yml"},
+			FeatureState: true,
+		}},
+	}
+
+	prep, stores := newVolumeManager(r).BuildPrep("")
+	if _, ok := stores.FeatureAuth["github-cli"]; !ok {
+		t.Fatal("feature auth store missing")
+	}
+	if _, ok := stores.FeatureState["github-cli"]; !ok {
+		t.Fatal("feature state store missing")
+	}
+	if len(prep.FeatureStores) != 2 {
+		t.Fatalf("feature prep entries = %d, want auth and state", len(prep.FeatureStores))
 	}
 }

--- a/runtime-assets/microvm/alpine/build-bundle.sh
+++ b/runtime-assets/microvm/alpine/build-bundle.sh
@@ -114,6 +114,7 @@ cp /src/runtime-assets/auth-reconcile.sh "$root/usr/local/share/enclave/auth-rec
 cp /src/runtime-assets/net.sh "$root/usr/local/share/enclave/net.sh"
 cp /src/runtime-assets/kit-init.sh "$root/usr/local/share/enclave/kit-init.sh"
 chmod 0755 "$root/usr/local/bin/entrypoint.sh" "$root/usr/local/share/enclave/auth-reconcile.sh" "$root/usr/local/share/enclave/net.sh"
+chmod 0644 "$root/usr/local/share/enclave/kit-init.sh"
 
 if [ -d /src/docs ]; then cp -a /src/docs "$root/usr/share/doc/enclave/docs"; fi
 


### PR DESCRIPTION

#### What it does

Adds an opt-in state store for features that need to keep project data across sessions and tools. A mixin can declare `state: true`; in persistent sessions Enclave creates `~/.local/state/enclave/projects/<hash>/features/<feature>/state/` and mounts it at `~/.enclave-feature-state/<feature>/`.

While sourcing that feature's setup scripts, the entrypoint exposes the mount as `ENCLAVE_FEATURE_STATE_DIR`. It unsets the variable before sourcing the next feature and before starting the agent. Ephemeral sessions do not create or mount feature state.

Feature state is represented in both backend store layers, although current QEMU sessions disable mixins and do not mount it. It is independent of auth scope and remains separate from feature auth. `enclave cleanup` removes it with the rest of the project data unless `--keep feature-state` is set, including during `cleanup --all`.

Mixin validation rejects `state` on sandbox specs. The sandbox extension name `features` is now reserved because it would collide with the project feature-state namespace. The image build also makes `kit-init.sh` world-readable, so startup does not depend on the checkout's umask.

#### How to test

Current QEMU sessions disable mixins, so this manual test uses Docker. It creates a temporary `state-probe` extension that records which tools start with its state store mounted.

Run the setup commands from the repository root. `enclave shell` is interactive; run the checks below at the container prompt.

```bash
repo="$PWD"
make build
enclave_bin="$repo/bin/enclave"
test_root="$(mktemp -d)"
project_dir="$test_root/project"

export XDG_CONFIG_HOME="$test_root/config"
export XDG_STATE_HOME="$test_root/state"

probe_dir="$XDG_CONFIG_HOME/enclave/extensions/features/state-probe"
mkdir -p "$probe_dir/feature-entrypoint.d" "$project_dir"
cat >"$probe_dir/spec.yaml" <<'YAML'
schemaVersion: "1"
kind: mixin
name: state-probe
displayName: State Probe
description: Manual feature-state probe
defaultEnabled: false
state: true
YAML
cat >"$probe_dir/feature-entrypoint.d/setup.sh" <<'SH'
if [ -n "${ENCLAVE_FEATURE_STATE_DIR:-}" ]; then
    printf '%s\n' "${TOOL:-unknown}" >> "$ENCLAVE_FEATURE_STATE_DIR/runs"
fi
SH

cd "$project_dir"
"$enclave_bin" shell --tool claude --features state-probe --rebuild
```

Inside the Claude shell:

```bash
cat "$HOME/.enclave-feature-state/state-probe/runs"  # claude
printf '%s\n' "${ENCLAVE_FEATURE_STATE_DIR-unset}"   # unset
exit
```

Start the same extension with Codex:

```bash
"$enclave_bin" shell --tool codex --features state-probe --rebuild
```

Inside the Codex shell, the shared file should contain both tool names:

```bash
cat "$HOME/.enclave-feature-state/state-probe/runs"
# claude
# codex
exit
```

Back on the host, clean up and run the automated checks:

```bash
cd "$repo"
rm -rf "$test_root"
unset XDG_CONFIG_HOME XDG_STATE_HOME
make test
make lint
```

The unit tests cover stateless and ephemeral sessions, cleanup retention, and both backend store layers.

#### Follow-ups

None.

#### Breaking changes

The sandbox extension name `features` is now reserved.

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).