### PR TITLE
fix: make build the default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: MIT
 
 .PHONY: build cross-build install install-binary clean-legacy-assets uninstall clean clean-lint-cache test deb deb-quick rpm lint lint-changed lint-report fmt vet generate lint-tools check-go completions check-license-headers
+.DEFAULT_GOAL := build
 
 BIN_DIR ?= ./bin
 BINARY ?= enclave
@@ -21,6 +22,10 @@ LINT_GO_CACHE := $(LINT_TMP_DIR)/go-build
 LINT_GOLANGCI_CACHE := $(LINT_TMP_DIR)/golangci-lint-cache
 BASE_REF ?=
 
+build: check-go
+	mkdir -p $(BIN_DIR)
+	go build -o $(BIN_DIR)/$(BINARY) $(CMD_DIR)
+
 check-go:
 	@command -v go >/dev/null 2>&1 || { echo "Go is not installed. Install Go 1.24+ from https://go.dev/dl/"; exit 1; }
 	@GO_VER=$$(go version | awk '{split($$3, a, "."); print a[2]}'); \
@@ -28,10 +33,6 @@ check-go:
 		echo "Go 1.24+ is required (found $$(go version))"; \
 		exit 1; \
 	fi
-
-build: check-go
-	mkdir -p $(BIN_DIR)
-	go build -o $(BIN_DIR)/$(BINARY) $(CMD_DIR)
 
 completions:
 	mkdir -p $(COMPLETIONS_DIR)

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -12,7 +12,7 @@ Concise notes for contributors working on the enclave codebase.
 
 ## Common Commands
 
-Build the CLI:
+Build the CLI (plain `make` is equivalent to `make build`):
 
 ```bash
 make build


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Makes `build` the default Make target. Currently, plain `make` runs only the silent Go-version check and produces no binary or output, which is confusing. After this change, make behaves like make build.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

`make`

Verify that it runs the Go version check and builds bin/enclave, matching:

`make build`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
none

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
