### PR TITLE
docs: caution against giving agents SSH keys

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -177,10 +177,26 @@ This can also be set persistently in `config.json` via the `pass_env` key. See [
 
 ## SSH Keys
 
-Initialize isolated SSH keys for use inside containers:
+Giving an agent an SSH key is not recommended. The key lets the agent write to systems outside the sandbox, and Enclave cannot restrict how it is used. Let the agent commit in the container, review the diff, and push from the host instead.
+
+Use `ssh-init` only for sessions that must push without host intervention:
 
 ```bash
 enclave ssh-init
 ```
 
-Keys are generated at `~/.cache/enclave/ssh/` and mounted into the container read-only.
+`ssh-init` stores keys in Enclave's host cache: `~/.cache/enclave/ssh/` by default on Linux, `$XDG_CACHE_HOME/enclave/ssh/` when set, and `~/Library/Caches/org.eclipse.enclave/ssh/` on macOS.
+
+Docker mounts this directory read-only into every session, across all projects and tools. There is no per-session opt-out. Read-only access stops the agent from changing the key files, but it can still use the key for any operation allowed by the Git provider, including force pushes and branch deletion.
+
+The generated key has no passphrase and is usable as soon as it is mounted.
+
+Scope the key before you register it:
+
+- Prefer a deploy key limited to one repository. On GitHub, use repository Settings > Deploy keys; on GitLab, use repository Settings > Repository > Deploy keys. Enable write access only if needed.
+- For access to several repositories, use a dedicated machine account with minimal membership instead of a personal account.
+- To revoke access, delete the key at the provider, then delete the host cache directory listed above.
+
+You can replace the generated keys in the same directory. Do not use a key with broader access than the session needs.
+
+Commit and tag signing are disabled inside the container (see [Persistence](persistence.md#git)), so you cannot distinguish an agent's pushes from your own by their signatures.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -83,7 +83,7 @@ Mutation commands (`add-domain`, `remove-domain`, `set-mode`) apply the new poli
 |---------|-------------|
 | `enclave auth import --tool <tool>` | Copy host auth files into the auth store |
 | `enclave auth export --tool <tool>` | Copy auth store files back to the host |
-| `enclave ssh-init` | Initialize isolated SSH keys at `~/.cache/enclave/ssh/` |
+| `enclave ssh-init` | Initialize isolated SSH keys at `~/.cache/enclave/ssh/`. Not recommended: the key lets the agent push to your Git provider. See [SSH keys](auth.md#ssh-keys) |
 
 ### Images
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -103,7 +103,7 @@ Git commit and tag signing (`commit.gpgsign`, `tag.gpgsign`) are unconditionally
 
 ## SSH Keys
 
-See [Authentication & Secrets](auth.md#ssh-keys) for SSH key setup. The SSH directory is always mounted read-only.
+Giving an agent an SSH key is not recommended; see [Authentication & Secrets](auth.md#ssh-keys) for what the key grants and how to scope it. The SSH directory is always mounted read-only. That stops the agent from changing the key files; it does not limit what the key can do at your Git provider.
 
 ## Host Hardening
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -58,5 +58,9 @@ released by the gateway only for matching HTTPS hosts. This protects those
 environment values from direct exfiltration, but credential files and secrets
 without HTTP release can contain real values inside the tool config/auth store.
 
-See [Authentication and secrets](../auth.md) and the
-[restricted network request flow](../runtime/network-request-flow.md).
+Once configured, the SSH key is available to every Docker session, regardless
+of project or tool. SSH on port 22 bypasses the HTTP/TLS proxy, so a push does
+not appear in `network.log`, even with `--network-log=requests`. See
+[SSH keys](../auth.md#ssh-keys) for its access and how to scope or revoke it.
+
+See the [restricted network request flow](../runtime/network-request-flow.md).


### PR DESCRIPTION

#### What it does

Warns that `ssh-init` gives agents remote Git access and recommends pushing from
the host instead. Documents key scoping, revocation, signing limitations, and
the distinction between a read-only mount and the key's authority.

Docs-only; no behavior change.

#### How to test

Review the changed docs and verify their cross-links.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).