### PR TITLE
build: bump pinned agent Node runtime to 24.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # Base image: debian:trixie-slim (pinned) or ubuntu:24.04
 ARG BASE_IMAGE=debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba
 ARG DEVCONTAINER_BASE_IMAGE=0
-ARG AGENT_NODE_IMAGE=node:24-trixie-slim@sha256:036dfa7e82a1e867b09248440a2b6635b3f8de557f69e60bac923a10c6e696a8
+ARG AGENT_NODE_IMAGE=node:24-trixie-slim@sha256:0711b541c1c33a8a530ac4f0d391baa9a15b3d804695b1b24a47daa5fb60e74d
 FROM ${BASE_IMAGE} AS system
 ARG DEVCONTAINER_BASE_IMAGE
 USER root


### PR DESCRIPTION
#### What it does

Moves `ARG AGENT_NODE_IMAGE` in the `Dockerfile` from `node:24-trixie-slim@sha256:036dfa7e…` (Node v24.13.0) to `@sha256:0711b541…` (Node v24.19.0). The new pin is the OCI image-index digest, so it stays multi-arch (`linux/amd64` and `linux/arm64/v8`).

This pin is the floor for every Node-based agent CLI in the images, since their launchers are rewritten to `/opt/enclave/node/bin/node`. It had drifted roughly eight months, leaving it below the `>=24.15.0` minimum that some agent CLIs now declare on the 24.x line. That failure mode is quiet: npm only warns on an engine mismatch (`EBADENGINE`) and installs anyway, so it surfaces as a broken session rather than a build failure.

Nothing currently in-tree caps the major version, so there is no conflict either way: `@anthropic-ai/claude-code` is `>=22.0.0`, `@openai/codex` `>=16`, `@earendil-works/pi-coding-agent` `>=22.19.0`, `@anthropic-ai/sandbox-runtime` `>=20.11.0`, `@playwright/mcp` `>=18`, and `opencode-ai` declares no `engines`.

Staying on the 24.x line keeps the shared runtime on Active LTS (Krypton, EOL around May 2028) rather than moving to Node 26, which stays in its Current phase until November 2026. It is also a patch-level move within one major, so there is no ABI or API break for anything already installed, and it picks up six upstream patch releases.

Only the one line changed. `docs/tools.md` refers to `AGENT_NODE_IMAGE` by name without a version, and the `v24.18.0` / `v24.16.0` strings in `internal/runtime/entrypoint_node_version_test.go` are synthetic nvm fixtures for the `node-dev` feature, unrelated to this pin.

#### How to test

Confirm the new runtime lands where agent launchers point:

```bash
docker build --target tool-base -t enclave-node-pin-check:local .
docker run --rm enclave-node-pin-check:local /opt/enclave/node/bin/node --version
# v24.19.0
```

`tool-base` is the stage containing `FROM ${AGENT_NODE_IMAGE}`, both `COPY --from=agent-node-runtime` lines, and `install-agent-node-runtime.sh`, so it exercises the whole pin path. A full image build additionally installs every tool and feature without testing anything further about the pin.

`make build` and `make test` pass. `make lint` was not run locally: `lint-tools` fails on a missing `golangci-lint`, with `gosec` and `shellcheck` also unavailable in that environment. The license-header check and `go vet` pass. The diff is one Dockerfile line with no Go or shell code, so CI lint should be the deciding signal here.

#### Follow-ups

- Revisit the line choice after Node 26 enters LTS in November 2026.
- The pin has no automated staleness check, so it drifts silently until an agent CLI's engine floor rises past it. Worth considering a periodic probe alongside the existing `check-update.sh` mechanism.

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
