### PR TITLE
fix: resolve tool extension config assets from the user extension tree

### DIFF
--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -236,7 +236,7 @@ additional files beyond `spec.yaml`.
 | File | Purpose |
 |------|---------|
 | `spec.yaml` | Extension spec: `kind: sandbox`, `sandbox.*` metadata, `network`, `credentials`, `providers`, `ports` |
-| `gateway-allowlist.conf` | dnsmasq config for network isolation |
+| `gateway-allowlist.conf` | dnsmasq config for network isolation. Resolved from the user extension tree ahead of the built-in one; a tool that ships none falls back to the broader `base.conf` |
 | `install.sh` | Installation script run during Docker build |
 
 ### Optional Files
@@ -244,6 +244,7 @@ additional files beyond `spec.yaml`.
 | File | Purpose |
 |------|---------|
 | `templates/` | Settings templates copied to `/usr/local/share/enclave/templates/` |
+| `config-base/` | Seed files for the tool's config store, overlaid into the generated config source before the host and per-project layers |
 | `check-update.sh` | Optional prebuild hook that returns a stable upstream fingerprint for automatic update probes |
 | `entrypoint.d/*.sh` | Scripts sourced at container startup (only for matching tool) |
 | `go/` | Go code for custom hooks/handlers (compiled into binary) |
@@ -306,9 +307,15 @@ tool metadata. `sandbox.entrypoint.run` is the shared sbx-style command to
 launch the tool.
 
 When using `templates/`, set `sandbox.configDir`, `sandbox.settingsFile`
-(aggregated name like `<tool>-settings.json`), and `sandbox.settingsTarget`
-(path under `configDir`). Runtime composes the built-in template into the
-generated tool config source before container startup.
+(aggregated name like `<tool>-settings.json`: the `<tool>-` prefix followed by
+the template's bare filename, path separators are rejected), and `sandbox.settingsTarget`
+(path under `configDir`). Runtime composes the template into the generated tool
+config source before container startup. The template and the optional
+`config-base/` directory are resolved from the built-in tree and from
+`~/.config/enclave/extensions/tools/<tool>/`, with the user extension tree
+winning per file, the same precedence the image build context applies. A
+user-global tool extension can therefore use `templates/` without being
+upstreamed.
 
 If a tool supports host config passthrough, declare a narrow reviewed
 `sandbox.passthroughPaths` allow-list. Host passthrough is fail closed: only
@@ -686,7 +693,7 @@ Hooks run in a fixed order during runtime auth preparation:
 - `internal/model/types.go`: `Extension` struct with `IsMixin()` and `IsSandbox()` methods
 - `internal/config/extension.go`: Extension loading and filtering functions
 - `internal/config/profile.go`: `ListProfiles()` returns only tool extensions
-- `internal/runtime/network_manager.go`: Loads DNS allowlists from `extensions/tools/{tool}/gateway-allowlist.conf`
+- `internal/runtime/network_manager.go`: Loads DNS allowlists from `extensions/tools/{tool}/gateway-allowlist.conf`, resolved from the user extension tree ahead of the built-in one
 
 ## Adding a New Tool Extension
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -68,6 +68,8 @@ Project overrides take precedence over global. These files replace the built-in 
 
 The built-in allowlists live in `runtime-assets/gateway-allowlists/` in the repo and are baked into the container image at build time.
 
+Without an override, the tool's own `gateway-allowlist.conf` applies. It is resolved from `~/.config/enclave/extensions/tools/<tool>/` first and from the built-in extension tree second, so a user-installed tool extension enforces the allowlist it ships. A tool that declares none falls back to `base.conf`, which allows more domains than a tool-specific allowlist.
+
 ## Port Direction: `-p` vs `--bridge-port`
 
 These two flags handle opposite directions of port forwarding:

--- a/internal/config/extension.go
+++ b/internal/config/extension.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"enclave/internal/model"
 	"enclave/internal/util"
@@ -19,17 +20,65 @@ import (
 
 // ResolveToolFile resolves a tool extension file path with user override support.
 func ResolveToolFile(paths model.Paths, toolName string, fileName string) (string, bool) {
-	if paths.UserToolsDir != "" {
-		candidate := filepath.Join(paths.UserToolsDir, toolName, fileName)
+	for _, candidate := range toolFileCandidates(paths, toolName, fileName) {
 		if util.FileExists(candidate) {
 			return candidate, true
 		}
 	}
-	candidate := filepath.Join(paths.ToolsDir, toolName, fileName)
-	if util.FileExists(candidate) {
-		return candidate, true
-	}
 	return "", false
+}
+
+// toolFileCandidates lists the paths ResolveToolFile searches, in its
+// precedence order: the user extension tree ahead of the built-in one.
+func toolFileCandidates(paths model.Paths, toolName string, fileName string) []string {
+	candidates := make([]string, 0, 2)
+	for _, toolsRoot := range []string{paths.UserToolsDir, paths.ToolsDir} {
+		if strings.TrimSpace(toolsRoot) == "" {
+			continue
+		}
+		candidates = append(candidates, filepath.Join(toolsRoot, toolName, fileName))
+	}
+	return candidates
+}
+
+// toolSettingsTemplateName returns the bare template filename a tool's
+// settings_file refers to. Consumers join that name onto a templates directory
+// on the host and inside the container, so a missing name or an embedded path
+// separator is rejected here rather than escaping the templates directory.
+// validateAndNormalizeProfile applies this at spec load, which is what lets the
+// other consumers use the raw settings_file.
+func toolSettingsTemplateName(toolName string, settingsFile string) (string, error) {
+	prefix := toolName + "-"
+	if !strings.HasPrefix(settingsFile, prefix) {
+		return "", fmt.Errorf("settings_file %q must start with %q", settingsFile, prefix)
+	}
+	templateName := strings.TrimPrefix(settingsFile, prefix)
+	if templateName == "" {
+		return "", fmt.Errorf("settings_file %q is missing a template name after %q", settingsFile, prefix)
+	}
+	if strings.ContainsAny(templateName, `/\`) {
+		return "", fmt.Errorf("settings_file %q must not contain a path separator", settingsFile)
+	}
+	return templateName, nil
+}
+
+// ResolveToolSettingsTemplate resolves the settings template named by a tool's
+// settings_file. The template lives under templates/ in the extension tree, and
+// a user-global extension is not staged into the built-in assets tree, so both
+// trees are searched. Runtime and `validate-extensions` share this so a spec
+// cannot validate but then fail at session start.
+func ResolveToolSettingsTemplate(paths model.Paths, toolName string, settingsFile string) (string, error) {
+	templateName, err := toolSettingsTemplateName(toolName, settingsFile)
+	if err != nil {
+		return "", err
+	}
+	relativePath := filepath.Join(model.TemplatesDir, templateName)
+	templatePath, ok := ResolveToolFile(paths, toolName, relativePath)
+	if !ok {
+		return "", fmt.Errorf("missing template %q, searched: %s",
+			templateName, strings.Join(toolFileCandidates(paths, toolName, relativePath), ", "))
+	}
+	return templatePath, nil
 }
 
 // ResolveFeatureFile resolves a feature extension file path with user override support.
@@ -50,12 +99,12 @@ func ResolveFeatureFile(paths model.Paths, featureName string, fileName string) 
 // ResolveToolDirs returns the built-in and user tool extension directories.
 func ResolveToolDirs(paths model.Paths, toolName string) (builtinDir string, userDir string) {
 	builtin := filepath.Join(paths.ToolsDir, toolName)
-	if isDir(builtin) {
+	if util.IsDir(builtin) {
 		builtinDir = builtin
 	}
 	if paths.UserToolsDir != "" {
 		candidate := filepath.Join(paths.UserToolsDir, toolName)
-		if isDir(candidate) {
+		if util.IsDir(candidate) {
 			userDir = candidate
 		}
 	}
@@ -65,16 +114,44 @@ func ResolveToolDirs(paths model.Paths, toolName string) (builtinDir string, use
 // ResolveFeatureDirs returns the built-in and user feature extension directories.
 func ResolveFeatureDirs(paths model.Paths, featureName string) (builtinDir string, userDir string) {
 	builtin := filepath.Join(paths.FeaturesDir, featureName)
-	if isDir(builtin) {
+	if util.IsDir(builtin) {
 		builtinDir = builtin
 	}
 	if paths.UserFeaturesDir != "" {
 		candidate := filepath.Join(paths.UserFeaturesDir, featureName)
-		if isDir(candidate) {
+		if util.IsDir(candidate) {
 			userDir = candidate
 		}
 	}
 	return builtinDir, userDir
+}
+
+// ResolveToolSubdirs returns the existing subdir directories of a tool
+// extension, built-in tree first so the user extension tree overlays it.
+func ResolveToolSubdirs(paths model.Paths, toolName string, subdir string) []string {
+	builtinDir, userDir := ResolveToolDirs(paths, toolName)
+	return existingSubdirs([]string{builtinDir, userDir}, subdir)
+}
+
+// ResolveFeatureSubdirs returns the existing subdir directories of a feature
+// extension, built-in tree first so the user extension tree overlays it.
+func ResolveFeatureSubdirs(paths model.Paths, featureName string, subdir string) []string {
+	builtinDir, userDir := ResolveFeatureDirs(paths, featureName)
+	return existingSubdirs([]string{builtinDir, userDir}, subdir)
+}
+
+func existingSubdirs(extensionDirs []string, subdir string) []string {
+	dirs := make([]string, 0, len(extensionDirs))
+	for _, extensionDir := range extensionDirs {
+		if extensionDir == "" {
+			continue
+		}
+		candidate := filepath.Join(extensionDir, subdir)
+		if util.IsDir(candidate) {
+			dirs = append(dirs, candidate)
+		}
+	}
+	return dirs
 }
 
 // LoadToolExtension loads a tool extension from its spec.yaml/spec.json
@@ -170,11 +247,6 @@ func appendExtensionNames(dir string, names map[string]struct{}) error {
 		names[entry.Name()] = struct{}{}
 	}
 	return nil
-}
-
-func isDir(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
 }
 
 // extensionManifestState records which optional extension-level fields were

--- a/internal/config/extension_overlay_test.go
+++ b/internal/config/extension_overlay_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"enclave/internal/model"
@@ -57,6 +58,51 @@ func TestResolveToolFileMissing(t *testing.T) {
 	}
 	if _, ok := ResolveToolFile(paths, "missing", SpecFilename); ok {
 		t.Fatal("expected missing file")
+	}
+}
+
+// A user-global tool extension keeps its settings template in
+// ~/.config/enclave/extensions/tools/<tool>/templates/, outside the built-in
+// assets tree the runtime used to search alone.
+func TestResolveToolSettingsTemplateFindsUserExtension(t *testing.T) {
+	tmp := t.TempDir()
+	paths := model.Paths{
+		ToolsDir:     filepath.Join(tmp, "extensions", "tools"),
+		UserToolsDir: filepath.Join(tmp, ".enclave", "extensions", "tools"),
+	}
+	templatePath := filepath.Join(paths.UserToolsDir, "usertool", model.TemplatesDir, "settings.json")
+	writeTestFile(t, templatePath, `{}`)
+
+	resolved, err := ResolveToolSettingsTemplate(paths, "usertool", "usertool-settings.json")
+	if err != nil {
+		t.Fatalf("ResolveToolSettingsTemplate returned error: %v", err)
+	}
+	if resolved != templatePath {
+		t.Fatalf("expected %s, got %s", templatePath, resolved)
+	}
+}
+
+func TestResolveToolSettingsTemplateRejectsInvalidSettingsFile(t *testing.T) {
+	tmp := t.TempDir()
+	paths := model.Paths{
+		ToolsDir:     filepath.Join(tmp, "extensions", "tools"),
+		UserToolsDir: filepath.Join(tmp, ".enclave", "extensions", "tools"),
+	}
+	writeTestFile(t, filepath.Join(tmp, "host-secret.txt"), "TOP SECRET")
+
+	cases := map[string]string{
+		"settings.json":                     "must start with",
+		"usertool-":                         "missing a template name",
+		"usertool-../../../host-secret.txt": "path separator",
+	}
+	for settingsFile, wantError := range cases {
+		_, err := ResolveToolSettingsTemplate(paths, "usertool", settingsFile)
+		if err == nil {
+			t.Fatalf("expected settings_file %q to be rejected", settingsFile)
+		}
+		if !strings.Contains(err.Error(), wantError) {
+			t.Fatalf("settings_file %q: expected error containing %q, got %v", settingsFile, wantError, err)
+		}
 	}
 }
 

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -67,6 +67,9 @@ func validateAndNormalizeProfile(profile *model.Profile) error {
 	if err := validateProfileSkillsPath(profile); err != nil {
 		return err
 	}
+	if err := validateAndNormalizeSettingsFile(profile); err != nil {
+		return err
+	}
 	if err := validateAndNormalizePorts(profile); err != nil {
 		return err
 	}
@@ -88,6 +91,20 @@ func validateAndNormalizeMemoryDir(profile *model.Profile) error {
 		profile.MemoryDir = cleaned
 	}
 	return nil
+}
+
+// validateAndNormalizeSettingsFile enforces the settings_file naming contract
+// at load, so every consumer can join the raw value onto a templates directory:
+// the config-source composition on the host and the container-side template
+// path handed to the entrypoint.
+func validateAndNormalizeSettingsFile(profile *model.Profile) error {
+	settingsFile := strings.TrimSpace(profile.SettingsFile)
+	profile.SettingsFile = settingsFile
+	if settingsFile == "" {
+		return nil
+	}
+	_, err := toolSettingsTemplateName(profile.Name, settingsFile)
+	return err
 }
 
 func validateProfileQEMUMemory(profile *model.Profile) error {

--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -93,6 +93,43 @@ func TestValidateAndNormalizeProfileValidatesSkillsPath(t *testing.T) {
 	}
 }
 
+// The settings_file contract is enforced at load so that every consumer can
+// join the raw value onto a templates directory, including the container-side
+// path the runtime hands to the entrypoint.
+func TestValidateAndNormalizeProfileValidatesSettingsFile(t *testing.T) {
+	tests := []struct {
+		name         string
+		settingsFile string
+		want         string
+		wantError    bool
+	}{
+		{name: "empty", settingsFile: "", want: ""},
+		{name: "trimmed", settingsFile: "  tool-settings.json  ", want: "tool-settings.json"},
+		{name: "missing prefix", settingsFile: "settings.json", wantError: true},
+		{name: "prefix only", settingsFile: "tool-", wantError: true},
+		{name: "slash traversal", settingsFile: "tool-../../etc/passwd", wantError: true},
+		{name: "backslash traversal", settingsFile: `tool-..\..\secrets`, wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := &model.Profile{Name: "tool", SettingsFile: tt.settingsFile}
+			err := validateAndNormalizeProfile(profile)
+			if tt.wantError {
+				if err == nil || !strings.Contains(err.Error(), "settings_file") {
+					t.Fatalf("expected settings_file validation error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+			if profile.SettingsFile != tt.want {
+				t.Fatalf("SettingsFile = %q, want %q", profile.SettingsFile, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadProfileReadsQEMUSettings(t *testing.T) {
 	paths := setupProfileTestPaths(t, `{
 		"name": "tool",

--- a/internal/config/project_marker.go
+++ b/internal/config/project_marker.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"enclave/internal/util"
 )
 
 const projectMarkerFilename = "project.json"
@@ -34,15 +36,10 @@ func WriteProjectMarkers(home string, projectHash string, realDir string) {
 	// The config-root overrides dir holds user-edited overrides. Writing the
 	// marker eagerly would leave an empty override dir for every project ever
 	// run, so only record it once the user has created overrides.
-	if overridesDir := HostProjectOverridesDir(home, projectHash); dirExists(overridesDir) {
+	if overridesDir := HostProjectOverridesDir(home, projectHash); util.IsDir(overridesDir) {
 		_ = writeProjectMarker(overridesDir, realDir)
 	}
 	_ = writeProjectMarker(HostProjectDir(home, projectHash), realDir)
-}
-
-func dirExists(dir string) bool {
-	info, err := os.Stat(dir)
-	return err == nil && info.IsDir()
 }
 
 func writeProjectMarker(dir string, realDir string) error {

--- a/internal/config/spec_loader.go
+++ b/internal/config/spec_loader.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"enclave/internal/model"
+	"enclave/internal/util"
 )
 
 // LoadSpec resolves and parses the spec.yaml (or spec.json) document for the
@@ -75,7 +76,7 @@ func LoadSpec(paths model.Paths, name string, kind string) (specDocument, error)
 // anything else is an unknown files/ subdir or a stray file and is flagged so a
 // misplaced payload is not silently ignored.
 func warnUnknownFilesEntries(filesDir string, name string, warn func(string)) {
-	if !isDir(filesDir) {
+	if !util.IsDir(filesDir) {
 		return
 	}
 	entries, err := os.ReadDir(filesDir)

--- a/internal/config/validate_extensions.go
+++ b/internal/config/validate_extensions.go
@@ -110,7 +110,7 @@ func validateUserToolExtensions(paths model.Paths, result *ExtensionValidation) 
 		builtinDir, _ := ResolveToolDirs(paths, name)
 		hasBuiltin := builtinDir != ""
 
-		if isDir(filepath.Join(userDir, "go")) {
+		if util.IsDir(filepath.Join(userDir, "go")) {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("tool %q: user go/ handlers are ignored (requires recompilation)", name))
 		}
 
@@ -182,18 +182,8 @@ func validateProfileSettings(paths model.Paths, toolName string, profile model.P
 		result.Errors = append(result.Errors, fmt.Sprintf("tool %q: settings_file set without settings_target", toolName))
 		return
 	}
-	prefix := toolName + "-"
-	if !strings.HasPrefix(settingsFile, prefix) {
-		result.Errors = append(result.Errors, fmt.Sprintf("tool %q: settings_file must start with %q", toolName, prefix))
-		return
-	}
-	templateName := strings.TrimPrefix(settingsFile, prefix)
-	if templateName == "" {
-		result.Errors = append(result.Errors, fmt.Sprintf("tool %q: settings_file missing template suffix", toolName))
-		return
-	}
-	if _, ok := ResolveToolFile(paths, toolName, filepath.Join(model.TemplatesDir, templateName)); !ok {
-		result.Errors = append(result.Errors, fmt.Sprintf("tool %q: missing template %q (checked merged templates)", toolName, templateName))
+	if _, err := ResolveToolSettingsTemplate(paths, toolName, settingsFile); err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("tool %q: %v", toolName, err))
 	}
 }
 
@@ -253,7 +243,7 @@ func validateUserFeatureExtensions(paths model.Paths, result *ExtensionValidatio
 		builtinDir, _ := ResolveFeatureDirs(paths, name)
 		hasBuiltin := builtinDir != ""
 
-		if isDir(filepath.Join(userDir, "go")) {
+		if util.IsDir(filepath.Join(userDir, "go")) {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("feature %q: user go/ handlers are ignored (requires recompilation)", name))
 		}
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -498,6 +498,7 @@ const (
 	TemplatesDir           = "templates"
 	HomeConfigDirName      = "home-config"
 	SkillsDirName          = "skills"
+	ConfigBaseDirName      = "config-base"
 	GeneratedSkillsDirName = "skills-generated"
 	GeneratedConfigDirName = "config-generated"
 )

--- a/internal/network/merge.go
+++ b/internal/network/merge.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"enclave/internal/config"
 	"enclave/internal/model"
 	"enclave/internal/util"
 )
@@ -219,17 +220,18 @@ func addToolDomains(toolDomains map[string][]string, tool string, domains []stri
 	}
 }
 
-// ResolveToolAllowlist returns the allowlist file for the given tool,
-// falling back to base.conf when the tool-specific allowlist is absent.
-func ResolveToolAllowlist(toolsDir string, allowlistsDir string, tool string) string {
+// ResolveToolAllowlist returns the allowlist file for the given tool, falling
+// back to base.conf when the tool declares none. The user extension tree is
+// searched ahead of the built-in one, so a user-global tool extension's
+// gateway-allowlist.conf applies instead of the broader base fallback.
+func ResolveToolAllowlist(paths model.Paths, tool string) string {
 	if tool == "" {
 		return ""
 	}
-	allowlist := filepath.Join(toolsDir, tool, model.GatewayAllowlistFilename)
-	if util.PathExists(allowlist) {
+	if allowlist, ok := config.ResolveToolFile(paths, tool, model.GatewayAllowlistFilename); ok {
 		return allowlist
 	}
-	fallback := filepath.Join(allowlistsDir, "base.conf")
+	fallback := filepath.Join(paths.AllowlistsDir, "base.conf")
 	if util.PathExists(fallback) {
 		return fallback
 	}

--- a/internal/network/merge_test.go
+++ b/internal/network/merge_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"enclave/internal/model"
 )
 
 func TestMergeDefaults(t *testing.T) {
@@ -222,5 +224,67 @@ func TestMergeToolDomains(t *testing.T) {
 	})
 	if len(ep.ToolDomains["claude"]) != 2 {
 		t.Fatalf("expected 2 tool domains after dedup, got %d: %v", len(ep.ToolDomains["claude"]), ep.ToolDomains["claude"])
+	}
+}
+
+// A user-global tool extension keeps its gateway-allowlist.conf in
+// ~/.config/enclave/extensions/tools/<tool>/, outside the content-hashed assets
+// tree. Without the user tree in the search, resolution silently fell through to
+// base.conf, which is broader than what the extension declared.
+func TestResolveToolAllowlistFindsUserExtension(t *testing.T) {
+	home := t.TempDir()
+	paths := model.Paths{
+		ToolsDir:      filepath.Join(home, "assets", "extensions", "tools"),
+		UserToolsDir:  filepath.Join(home, "config", "extensions", "tools"),
+		AllowlistsDir: filepath.Join(home, "assets", "runtime-assets", "gateway-allowlists"),
+	}
+	writeAllowlistFixture(t, filepath.Join(paths.AllowlistsDir, "base.conf"), "# base")
+	userAllowlist := filepath.Join(paths.UserToolsDir, "usertool", model.GatewayAllowlistFilename)
+	writeAllowlistFixture(t, userAllowlist, "# usertool")
+
+	if got := ResolveToolAllowlist(paths, "usertool"); got != userAllowlist {
+		t.Fatalf("expected the user extension allowlist %q, got %q", userAllowlist, got)
+	}
+}
+
+func TestResolveToolAllowlistPrefersUserExtensionOverBuiltIn(t *testing.T) {
+	home := t.TempDir()
+	paths := model.Paths{
+		ToolsDir:      filepath.Join(home, "assets", "extensions", "tools"),
+		UserToolsDir:  filepath.Join(home, "config", "extensions", "tools"),
+		AllowlistsDir: filepath.Join(home, "assets", "runtime-assets", "gateway-allowlists"),
+	}
+	writeAllowlistFixture(t, filepath.Join(paths.AllowlistsDir, "base.conf"), "# base")
+	writeAllowlistFixture(t, filepath.Join(paths.ToolsDir, "pi", model.GatewayAllowlistFilename), "# built-in")
+	userAllowlist := filepath.Join(paths.UserToolsDir, "pi", model.GatewayAllowlistFilename)
+	writeAllowlistFixture(t, userAllowlist, "# user")
+
+	if got := ResolveToolAllowlist(paths, "pi"); got != userAllowlist {
+		t.Fatalf("expected the user extension allowlist to win, got %q", got)
+	}
+}
+
+func TestResolveToolAllowlistFallsBackToBase(t *testing.T) {
+	home := t.TempDir()
+	paths := model.Paths{
+		ToolsDir:      filepath.Join(home, "assets", "extensions", "tools"),
+		UserToolsDir:  filepath.Join(home, "config", "extensions", "tools"),
+		AllowlistsDir: filepath.Join(home, "assets", "runtime-assets", "gateway-allowlists"),
+	}
+	base := filepath.Join(paths.AllowlistsDir, "base.conf")
+	writeAllowlistFixture(t, base, "# base")
+
+	if got := ResolveToolAllowlist(paths, "nosuchtool"); got != base {
+		t.Fatalf("expected the base fallback %q, got %q", base, got)
+	}
+}
+
+func writeAllowlistFixture(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/internal/policy/effective_resolver.go
+++ b/internal/policy/effective_resolver.go
@@ -84,7 +84,7 @@ func (r EffectiveResolver) Resolve(input ResolveInput) (ResolveResult, error) {
 		}
 	}
 
-	allowlistPath := network.ResolveToolAllowlist(r.paths.ToolsDir, r.paths.AllowlistsDir, tool)
+	allowlistPath := network.ResolveToolAllowlist(r.paths, tool)
 	allowlistPath = config.ResolveAllowlistPath(tool, r.home, projectHash, allowlistPath)
 
 	// Load from the tool's spec when the caller left either nil (see

--- a/internal/runtime/config_patch_test.go
+++ b/internal/runtime/config_patch_test.go
@@ -431,7 +431,10 @@ func writeRuntimeTestFile(t *testing.T, path string, content string) {
 
 func newTemplateOverrideRuntime(home string, profile model.Profile) *Runtime {
 	return &Runtime{
-		paths:         model.Paths{ToolsDir: filepath.Join(home, "extensions", "tools")},
+		paths: model.Paths{
+			ToolsDir:     filepath.Join(home, "extensions", "tools"),
+			UserToolsDir: filepath.Join(home, "user-extensions", "tools"),
+		},
 		host:          model.Host{Home: home},
 		project:       model.Project{Hash: "projhash"},
 		profile:       profile,
@@ -441,9 +444,22 @@ func newTemplateOverrideRuntime(home string, profile model.Profile) *Runtime {
 
 func writeBuiltInToolTemplate(t *testing.T, r *Runtime, content string) {
 	t.Helper()
+	writeToolTemplateIn(t, r, r.paths.ToolsDir, content)
+}
+
+// writeUserToolTemplate writes the settings template into the user extension
+// tree (~/.config/enclave/extensions/tools/<tool>/templates/), which is where a
+// user-global tool extension keeps it.
+func writeUserToolTemplate(t *testing.T, r *Runtime, content string) {
+	t.Helper()
+	writeToolTemplateIn(t, r, r.paths.UserToolsDir, content)
+}
+
+func writeToolTemplateIn(t *testing.T, r *Runtime, toolsRoot string, content string) {
+	t.Helper()
 	prefix := r.profile.Name + "-"
 	templateName := strings.TrimPrefix(r.profile.SettingsFile, prefix)
-	path := filepath.Join(r.paths.ToolsDir, r.profile.Name, "templates", templateName)
+	path := filepath.Join(toolsRoot, r.profile.Name, "templates", templateName)
 	writeRuntimeTestFile(t, path, content)
 }
 

--- a/internal/runtime/skills_mount.go
+++ b/internal/runtime/skills_mount.go
@@ -84,17 +84,7 @@ func (r *Runtime) addSkillMounts(mounts *mountAccumulator) error {
 }
 
 func (r *Runtime) extensionSkillSourceDirs() []string {
-	sourceDirs := make([]string, 0, 2)
-	for _, toolsRoot := range []string{r.paths.ToolsDir, r.paths.UserToolsDir} {
-		if toolsRoot == "" {
-			continue
-		}
-		skillsDir := filepath.Join(toolsRoot, r.profile.Name, model.SkillsDirName)
-		if info, err := os.Stat(skillsDir); err == nil && info.IsDir() {
-			sourceDirs = append(sourceDirs, skillsDir)
-		}
-	}
-	return sourceDirs
+	return config.ResolveToolSubdirs(r.paths, r.profile.Name, model.SkillsDirName)
 }
 
 // featureSkillSourceDirs returns skill directories shipped by enabled features
@@ -106,15 +96,7 @@ func (r *Runtime) extensionSkillSourceDirs() []string {
 func (r *Runtime) featureSkillSourceDirs() []string {
 	var dirs []string
 	for _, feature := range r.features {
-		for _, root := range []string{r.paths.FeaturesDir, r.paths.UserFeaturesDir} {
-			if root == "" {
-				continue
-			}
-			skillsDir := filepath.Join(root, feature.Name, model.SkillsDirName)
-			if info, err := os.Stat(skillsDir); err == nil && info.IsDir() {
-				dirs = append(dirs, skillsDir)
-			}
-		}
+		dirs = append(dirs, config.ResolveFeatureSubdirs(r.paths, feature.Name, model.SkillsDirName)...)
 	}
 	return dirs
 }

--- a/internal/runtime/tool_config_source.go
+++ b/internal/runtime/tool_config_source.go
@@ -121,7 +121,7 @@ func (r *Runtime) shouldMountToolConfigSource() bool {
 	if strings.EqualFold(strings.TrimSpace(r.run.HostConfig), model.HostConfigPassthrough) {
 		return true
 	}
-	if util.PathExists(filepath.Join(r.paths.ToolsDir, r.profile.Name, "config-base")) {
+	if len(r.extensionConfigBaseDirs()) > 0 {
 		return true
 	}
 	if util.DirHasFiles(config.HostToolConfigDir(r.host.Home, r.profile.Name)) {
@@ -144,7 +144,7 @@ func (r *Runtime) composeGeneratedConfigDir(targetDir string, globalConfigDir st
 	if err := clearDirectory(targetDir); err != nil {
 		return fmt.Errorf("clear generated config directory %q: %w", targetDir, err)
 	}
-	if err := r.applyBuiltInConfigLayer(targetDir); err != nil {
+	if err := r.applyExtensionConfigLayer(targetDir); err != nil {
 		return err
 	}
 	if err := r.applyHostConfigLayer(targetDir); err != nil {
@@ -162,11 +162,10 @@ func (r *Runtime) composeGeneratedConfigDir(targetDir string, globalConfigDir st
 	return r.applyConfigOverrideScope(targetDir, projectConfigDir, true)
 }
 
-func (r *Runtime) applyBuiltInConfigLayer(targetDir string) error {
-	baseDir := filepath.Join(r.paths.ToolsDir, r.profile.Name, "config-base")
-	if util.PathExists(baseDir) {
+func (r *Runtime) applyExtensionConfigLayer(targetDir string) error {
+	for _, baseDir := range r.extensionConfigBaseDirs() {
 		if err := overlayConfigSource(targetDir, baseDir, nil, nil, nil); err != nil {
-			return fmt.Errorf("overlay built-in config base from %q: %w", baseDir, err)
+			return fmt.Errorf("overlay extension config base from %q: %w", baseDir, err)
 		}
 	}
 
@@ -175,34 +174,27 @@ func (r *Runtime) applyBuiltInConfigLayer(targetDir string) error {
 		return fmt.Errorf("resolve settings target: %w", err)
 	}
 	if relativeSettingsPath != "" {
-		sourcePath, err := r.builtInSettingsTemplatePath()
+		sourcePath, err := config.ResolveToolSettingsTemplate(r.paths, r.profile.Name, r.profile.SettingsFile)
 		if err != nil {
 			return err
 		}
 		if err := copyConfigFile(sourcePath, filepath.Join(targetDir, relativeSettingsPath)); err != nil {
-			return fmt.Errorf("copy built-in settings template to %q: %w", relativeSettingsPath, err)
+			return fmt.Errorf("copy settings template to %q: %w", relativeSettingsPath, err)
 		}
 	}
-	if err := r.applyBuiltInSkillsLayer(targetDir); err != nil {
+	if err := r.applyExtensionSkillsLayer(targetDir); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r *Runtime) builtInSettingsTemplatePath() (string, error) {
-	prefix := r.profile.Name + "-"
-	if !strings.HasPrefix(r.profile.SettingsFile, prefix) {
-		return "", fmt.Errorf("settings_file %q must start with %q", r.profile.SettingsFile, prefix)
-	}
-	templateName := strings.TrimPrefix(r.profile.SettingsFile, prefix)
-	hostTemplatePath := filepath.Join(r.paths.ToolsDir, r.profile.Name, model.TemplatesDir, templateName)
-	if !util.PathExists(hostTemplatePath) {
-		return "", fmt.Errorf("built-in settings template missing at %s", hostTemplatePath)
-	}
-	return hostTemplatePath, nil
+// extensionConfigBaseDirs returns the existing config-base directories of the
+// tool extension, built-in tree first so the user extension tree overlays it.
+func (r *Runtime) extensionConfigBaseDirs() []string {
+	return config.ResolveToolSubdirs(r.paths, r.profile.Name, model.ConfigBaseDirName)
 }
 
-func (r *Runtime) applyBuiltInSkillsLayer(targetDir string) error {
+func (r *Runtime) applyExtensionSkillsLayer(targetDir string) error {
 	if strings.TrimSpace(r.profile.SkillsDir) == "" {
 		return nil
 	}

--- a/internal/runtime/tool_config_source_test.go
+++ b/internal/runtime/tool_config_source_test.go
@@ -84,6 +84,136 @@ func TestPrepareToolConfigSourceBuildsSettingsWhenConfigBaseExists(t *testing.T)
 	}
 }
 
+// A user-global tool extension keeps its settings template and config-base in
+// ~/.config/enclave/extensions/tools/<tool>/, which is never staged into the
+// content-hashed assets tree that ToolsDir points at. The built-in config layer
+// must therefore consult both trees, with the user tree winning per file, the
+// same precedence the image build context applies.
+func TestApplyExtensionConfigLayerUsesUserExtensionSettingsTemplate(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	r := newTemplateOverrideRuntime(home, model.Profile{
+		Name:           "usertool",
+		ConfigDir:      ".usertool",
+		SettingsFile:   "usertool-settings.json",
+		SettingsTarget: ".usertool/usertool.json",
+	})
+	writeUserToolTemplate(t, r, `{"source":"user-extension"}`)
+
+	targetDir := filepath.Join(home, "generated")
+	if err := r.applyExtensionConfigLayer(targetDir); err != nil {
+		t.Fatalf("applyExtensionConfigLayer returned error: %v", err)
+	}
+
+	settingsBytes, err := os.ReadFile(filepath.Join(targetDir, "usertool.json"))
+	if err != nil {
+		t.Fatalf("read generated settings: %v", err)
+	}
+	if string(settingsBytes) != `{"source":"user-extension"}` {
+		t.Fatalf("unexpected settings content: %s", string(settingsBytes))
+	}
+}
+
+func TestApplyExtensionConfigLayerPrefersUserExtensionSettingsTemplate(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	r := newTemplateOverrideRuntime(home, model.Profile{
+		Name:           "pi",
+		ConfigDir:      ".pi",
+		SettingsFile:   "pi-settings.json",
+		SettingsTarget: ".pi/agent/settings.json",
+	})
+	writeBuiltInToolTemplate(t, r, `{"source":"built-in"}`)
+	writeUserToolTemplate(t, r, `{"source":"user-extension"}`)
+
+	targetDir := filepath.Join(home, "generated")
+	if err := r.applyExtensionConfigLayer(targetDir); err != nil {
+		t.Fatalf("applyExtensionConfigLayer returned error: %v", err)
+	}
+
+	settingsBytes, err := os.ReadFile(filepath.Join(targetDir, "agent", "settings.json"))
+	if err != nil {
+		t.Fatalf("read generated settings: %v", err)
+	}
+	if string(settingsBytes) != `{"source":"user-extension"}` {
+		t.Fatalf("expected user extension template to win, got: %s", string(settingsBytes))
+	}
+}
+
+func TestApplyExtensionConfigLayerOverlaysConfigBaseFromBothTrees(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	r := newTemplateOverrideRuntime(home, model.Profile{
+		Name:      "usertool",
+		ConfigDir: ".usertool",
+	})
+	writeRuntimeTestFile(t, filepath.Join(r.paths.ToolsDir, "usertool", "config-base", "builtin.json"), `{"from":"built-in"}`)
+	writeRuntimeTestFile(t, filepath.Join(r.paths.ToolsDir, "usertool", "config-base", "shared.json"), `{"from":"built-in"}`)
+	writeRuntimeTestFile(t, filepath.Join(r.paths.UserToolsDir, "usertool", "config-base", "user.json"), `{"from":"user-extension"}`)
+	writeRuntimeTestFile(t, filepath.Join(r.paths.UserToolsDir, "usertool", "config-base", "shared.json"), `{"from":"user-extension"}`)
+
+	targetDir := filepath.Join(home, "generated")
+	if err := r.applyExtensionConfigLayer(targetDir); err != nil {
+		t.Fatalf("applyExtensionConfigLayer returned error: %v", err)
+	}
+
+	for _, name := range []string{"builtin.json", "user.json"} {
+		if _, err := os.Stat(filepath.Join(targetDir, name)); err != nil {
+			t.Fatalf("expected %s in the composed config base: %v", name, err)
+		}
+	}
+	sharedBytes, err := os.ReadFile(filepath.Join(targetDir, "shared.json"))
+	if err != nil {
+		t.Fatalf("read shared.json: %v", err)
+	}
+	if string(sharedBytes) != `{"from":"user-extension"}` {
+		t.Fatalf("expected user extension config base to win, got: %s", string(sharedBytes))
+	}
+}
+
+// settings_file is spec data, and the template name is joined onto templates/.
+// A name carrying path separators must not escape the extension tree and copy an
+// arbitrary host file into the container's config source.
+func TestApplyExtensionConfigLayerRejectsTraversingSettingsFile(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	writeRuntimeTestFile(t, filepath.Join(home, "host-secret.txt"), "TOP SECRET")
+
+	r := newTemplateOverrideRuntime(home, model.Profile{
+		Name:           "usertool",
+		ConfigDir:      ".usertool",
+		SettingsFile:   "usertool-../../../../host-secret.txt",
+		SettingsTarget: ".usertool/usertool.json",
+	})
+
+	targetDir := filepath.Join(home, "generated")
+	if err := r.applyExtensionConfigLayer(targetDir); err == nil {
+		t.Fatal("expected applyExtensionConfigLayer to fail rather than copy a host file")
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "usertool.json")); err == nil {
+		t.Fatal("expected no settings file to be written from a traversing settings_file")
+	}
+}
+
+func TestShouldMountToolConfigSourceDetectsUserExtensionConfigBase(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	r := newTemplateOverrideRuntime(home, model.Profile{
+		Name:      "usertool",
+		ConfigDir: ".usertool",
+	})
+	writeRuntimeTestFile(t, filepath.Join(r.paths.UserToolsDir, "usertool", "config-base", "user.json"), `{}`)
+
+	if !r.shouldMountToolConfigSource() {
+		t.Fatal("expected a user extension config-base to require the config source mount")
+	}
+}
+
 func TestPrepareToolConfigSourceComposesLayers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -308,6 +308,11 @@ func FileExists(path string) bool {
 	return err == nil && !info.IsDir()
 }
 
+func IsDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
 func Dedupe[T comparable](values []T) []T {
 	if len(values) == 0 {
 		return nil


### PR DESCRIPTION
## Problem

A tool extension installed under `~/.config/enclave/extensions/tools/<tool>/` could not use `sandbox.settingsFile`. Session start aborted with:

```
prepare config source for <tool>: built-in settings template missing at
~/.cache/enclave/assets/<hash>/extensions/tools/<tool>/templates/settings.json
```

The runtime resolved tool extension assets against `paths.ToolsDir` only. That path points into the content-hashed assets tree extracted from the embedded FS, whereas user extensions are merged into a temporary image build context and never staged there. Spec loading and validation already searched both trees, so `enclave validate-extensions` reported such a tool as valid while the runtime refused to start a session for it.

The gateway allowlist had the same defect and failed silently: a user extension's `gateway-allowlist.conf` was never found, so the session fell back to `base.conf`, which allows more domains than the extension declared.

## Fix

Resolve these through the existing `config.ResolveToolFile` and `ResolveToolDirs` helpers — user tree first for single files, built-in before user for directories — matching the per-file precedence the image build context already applies:

- the settings template
- `config-base/`, both in the overlay and in the mount decision
- `gateway-allowlist.conf`

Settings template resolution moves into `config.ResolveToolSettingsTemplate`, shared by the runtime and by `validate-extensions`, so the two cannot drift apart again.

`settings_file` is spec data joined onto a `templates/` directory both on the host and inside the container, so `validateAndNormalizeProfile` now enforces its naming contract at spec load: the value is trimmed, and an empty template name or an embedded path separator is rejected. Every consumer therefore sees a value it can join safely, including the container-side template path handed to the entrypoint.

The two-tree walk for extension subdirectories is now `config.ResolveToolSubdirs` / `ResolveFeatureSubdirs`; the tool config-base, tool skills, and feature skills lookups all go through it instead of hand-rolling the same `os.Stat`/`IsDir` loop. `config-base` detection requires a directory instead of any node.

`applyBuiltInConfigLayer` / `applyBuiltInSkillsLayer` are renamed to `applyExtensionConfigLayer` / `applyExtensionSkillsLayer`, since both now compose the built-in and the user extension tree.

## Tests

New coverage for user-tree resolution and precedence of the settings template, `config-base` overlay from both trees, the config-source mount decision, allowlist resolution (user tree, precedence, base fallback), and rejection of an invalid or traversing `settings_file` at profile load.

`make build`, `make test`, `make lint`, and `make check-license-headers` pass.
