### PR TITLE
fix: serve the website from the enclave.eclipse.dev root

### DIFF
--- a/.github/workflows/website-publish.yml
+++ b/.github/workflows/website-publish.yml
@@ -18,7 +18,7 @@ on:
       docs_base_url:
         description: "Docs base path (use /enclave-website/docs/ to test on the raw GitHub Pages URL)"
         type: string
-        default: "/enclave/docs/"
+        default: "/docs/"
 
 permissions:
   contents: read
@@ -44,7 +44,7 @@ jobs:
           node-version: "22.x"
       - name: Build site
         env:
-          DOCS_BASE_URL: ${{ inputs.docs_base_url || '/enclave/docs/' }}
+          DOCS_BASE_URL: ${{ inputs.docs_base_url || '/docs/' }}
         run: ./website/build.sh
       - name: Publish to enclave-website (gh-pages)
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
@@ -53,6 +53,9 @@ jobs:
           external_repository: eclipse-enclave/enclave-website
           publish_branch: gh-pages
           publish_dir: ./public
+          # The action replaces the published tree, so the custom domain's CNAME
+          # file has to be re-created on every deploy or the domain is unset.
+          cname: enclave.eclipse.dev
           user_name: "eclipse-enclave-bot"
           user_email: "enclave-bot@eclipse.org"
           commit_message: "deploy: ${{ github.sha }}"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 <h1 align="center">Enclave</h1>
 
+<p align="center">
+  <a href="https://enclave.eclipse.dev">enclave.eclipse.dev</a>
+</p>
+
 A Docker-based sandbox for running agentic coding tools — Claude, Codex, OpenCode, and others — in an isolated container while keeping your project files on the host. Network access is restricted to allowlisted domains by default, auth and history persist across sessions, and YOLO mode is on so agents can act without confirmation prompts.
 
 ## Requirements
@@ -237,7 +241,8 @@ in both `host/` and `session/`, the host command wins.
 | Extensions | [docs/extensions/README.md](docs/extensions/README.md) |
 | Security | [docs/security/README.md](docs/security/README.md) |
 
-Project resources: [Eclipse project page](https://projects.eclipse.org/projects/ecd.enclave),
+Project resources: [website](https://enclave.eclipse.dev),
+[Eclipse project page](https://projects.eclipse.org/projects/ecd.enclave),
 [contributing guide](CONTRIBUTING.md), [security policy](SECURITY.md),
 [code of conduct](CODE_OF_CONDUCT.md), [license](LICENSE.md), and
 [notices](NOTICE.md).

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
   <img src="docs/assets/appicon.png" alt="Enclave" width="128" height="128">
 </p>
 
-<h1 align="center">Enclave</h1>
-
-<p align="center">
-  <a href="https://enclave.eclipse.dev">enclave.eclipse.dev</a>
-</p>
+<h1 align="center">Eclipse Enclave</h1>
 
 A Docker-based sandbox for running agentic coding tools — Claude, Codex, OpenCode, and others — in an isolated container while keeping your project files on the host. Network access is restricted to allowlisted domains by default, auth and history persist across sessions, and YOLO mode is on so agents can act without confirmation prompts.
+
+<a href="https://enclave.eclipse.dev">Website</a> · <a href="https://enclave.eclipse.dev/docs/getting-started">Getting Started</a> · <a href="https://enclave.eclipse.dev/docs">Docs</a>
 
 ## Requirements
 

--- a/website/build.sh
+++ b/website/build.sh
@@ -11,7 +11,7 @@
 #   - Docusaurus docs under /docs (absolute baseUrl injected via DOCS_BASE_URL)
 #
 # DOCS_BASE_URL sets the docs base path, e.g.
-#   /enclave/docs/                                     (production)
+#   /docs/                                             (production, root domain)
 #   /enclave-website-previews/pr-previews/pr-42/docs/  (preview)
 set -euo pipefail
 

--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -26,10 +26,15 @@ The docs are served at `<site-root>/docs/`. The base path is controlled by the
 `docusaurus.config.js`. Set it at build time so the site works whether it is
 served at a domain root or a project subpath. No URLs are hardcoded.
 
-Production publishes with `/enclave/docs/`, matching the intended
-`eclipse.dev/enclave` path. A manual run of the *Deploy website* workflow can
-override this via its `docs_base_url` input, e.g. `/enclave-website/docs/` to
-verify a deployment on the raw `eclipse-enclave.github.io/enclave-website/` URL.
+Production serves the site at the root of https://enclave.eclipse.dev, so it
+publishes with the default `/docs/`. A manual run of the *Deploy website*
+workflow can override this via its `docs_base_url` input, e.g.
+`/enclave-website/docs/` to verify a deployment on the raw
+`eclipse-enclave.github.io/enclave-website/` URL.
+
+The custom domain lives in a `CNAME` file at the root of the published branch.
+The publish workflow re-creates it on every deploy (`cname:` input), because the
+deploy action replaces the published tree.
 
 Both website workflows push with the organization secret `DEPLOY_TOKEN`.
 

--- a/website/docs/docusaurus.config.js
+++ b/website/docs/docusaurus.config.js
@@ -16,14 +16,14 @@ import {themes as prismThemes} from 'prism-react-renderer';
 // --------------------------------------------------------------------------
 // Deployment base path.
 //
-// The docs are served under `<site-root>/docs/`. The site root itself moves
-// with the project (GitHub Pages URL today, eclipse.dev/eclipse-enclave later),
-// so this is the ONE place to adjust the base path. Nothing else hardcodes it.
+// The docs are served under `<site-root>/docs/`. Production serves the site at
+// the root of https://enclave.eclipse.dev, so the default '/docs/' is what
+// ships. This is the ONE place to adjust the base path; nothing else hardcodes
+// it.
 //
-// If the whole site is served under a project subpath (e.g.
-// eclipse-enclave.github.io/enclave/), set DOCS_BASE_URL to
-// '/<project>/docs/' at build time (e.g. via env in a future deploy step).
-// Default assumes a root deployment (custom domain / eclipse.dev forward).
+// If the whole site is served under a subpath (e.g. the PR previews under
+// eclipse-enclave.github.io/enclave-website-previews/pr-previews/pr-42/), set
+// DOCS_BASE_URL to '<subpath>/docs/' at build time.
 // --------------------------------------------------------------------------
 const baseUrl = process.env.DOCS_BASE_URL || '/docs/';
 
@@ -39,7 +39,7 @@ const config = {
 
   // `url` is only used for absolute-URL generation (sitemap, canonical tags).
   // It is not hardcoded into navigation. Update alongside the real domain.
-  url: 'https://eclipse.dev',
+  url: 'https://enclave.eclipse.dev',
   baseUrl,
 
   // 'warn' (not 'throw') because the docs live at /docs/ under a larger site and

--- a/website/docs/package-lock.json
+++ b/website/docs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "website-docs",
+  "name": "eclipse-enclave-docs",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "website-docs",
+      "name": "eclipse-enclave-docs",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.10.1",

--- a/website/index.html
+++ b/website/index.html
@@ -15,10 +15,15 @@
 <title>Eclipse Enclave: secure sandboxing for AI coding agents</title>
 <meta name="description" content="Eclipse Enclave runs AI coding agents inside isolated containers with a network policy you control. Full autonomy, safely contained.">
 <link rel="icon" type="image/png" href="assets/appicon.png">
+<link rel="canonical" href="https://enclave.eclipse.dev/">
 <meta property="og:title" content="Eclipse Enclave: secure sandboxing for AI coding agents">
 <meta property="og:description" content="Run AI coding agents at full autonomy inside isolated containers with network allowlists.">
 <meta property="og:type" content="website">
-<meta property="og:image" content="assets/appicon.png">
+<!-- Social crawlers require absolute URLs, so these are the only place the
+     production domain is hardcoded. Everything else uses relative links. -->
+<meta property="og:url" content="https://enclave.eclipse.dev/">
+<meta property="og:image" content="https://enclave.eclipse.dev/assets/appicon.png">
+<meta name="twitter:card" content="summary">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
#### What it does

The website is now hosted at https://enclave.eclipse.dev, so it is served from a
domain root rather than the planned `eclipse.dev/enclave` subpath. Production
builds still injected a `/enclave/docs/` base path, which broke the deployed
docs: pages referenced `/enclave/docs/assets/...` (404 today) while the files
themselves sit at `/docs/assets/...`, so no CSS or JS loaded.

- Production `DOCS_BASE_URL` and the `workflow_dispatch` default drop the
  `/enclave` prefix, so the docs build with the default `/docs/`.
- `docusaurus.config.js` sets `url: https://enclave.eclipse.dev` for correct
  sitemap and canonical URLs.
- The publish workflow now re-creates the `CNAME` file on every deploy. This is
  a latent trap unrelated to the base path: `actions-gh-pages` replaces the
  published tree, so the next deploy would have deleted the file the Pages
  settings UI created and unset the custom domain. Otterdog cannot manage this,
  as its repository resource has no custom-domain property.
- `index.html` gains `og:url`, a canonical link, and an absolute `og:image`. The
  relative `og:image` never worked for social crawlers; a stable domain is what
  was missing. These are the only place the production domain is hardcoded.
- README links the site under the title and in the project resources line.
- `package-lock.json` picks up a two-line rename: the lockfile `name` was still
  `website-docs` while `package.json` says `eclipse-enclave-docs`.

The preview workflow keeps its `/enclave-website-previews/pr-previews/pr-N/docs/`
base path, which is still correct for that host.

#### How to test

```bash
OUTPUT_DIR=/tmp/enclave-site ./website/build.sh
cd /tmp/enclave-site && python3 -m http.server 8000
```

Built pages should reference `/docs/assets/...`, and `sitemap.xml` should use
`https://enclave.eclipse.dev/docs/...`. I verified 200s on `/`, `/docs/`, all
three doc pages, the docs CSS bundle, and the marketing assets. `website/preview.sh`
covers the same ground. The only build warnings are the four intentional `../`
links from docs back to the marketing home, which is why `onBrokenLinks` is `warn`.

To confirm the current breakage before the fix lands:

```bash
curl -s https://enclave.eclipse.dev/docs/ | grep -oE 'href=/[^ >]*\.css'
# href=/enclave/docs/assets/css/styles.430d70dc.css  -> 404
```

#### Follow-ups

- The otterdog config in `.eclipsefdn` sets `homepage: https://www.eclipse.dev/enclave`
  for all three repos. That URL is now wrong and needs a separate PR there. -> https://github.com/eclipse-enclave/.eclipsefdn/pull/4

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).