### PR TITLE
fix: leave the docs app when navigating to the website home

### DIFF
--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -32,6 +32,16 @@ workflow can override this via its `docs_base_url` input, e.g.
 `/enclave-website/docs/` to verify a deployment on the raw
 `eclipse-enclave.github.io/enclave-website/` URL.
 
+## Linking out of the docs app
+
+The docs are a single-page app that only owns the routes under its base path.
+Links to the marketing site (the "Home" entries in the navbar and footer) must
+be prefixed with `pathname://` and set `autoAddBaseUrl: false`, so Docusaurus
+emits a plain `<a>` and the browser performs a real page load. A bare path or a
+relative `../` is handled client-side, matches no docs route, and renders the
+docs 404 page instead. `onBrokenLinks` is set to `throw` to catch this at build
+time.
+
 The custom domain lives in a `CNAME` file at the root of the published branch.
 The publish workflow re-creates it on every deploy (`cname:` input), because the
 deploy action replaces the published tree.

--- a/website/docs/docusaurus.config.js
+++ b/website/docs/docusaurus.config.js
@@ -27,6 +27,16 @@ import {themes as prismThemes} from 'prism-react-renderer';
 // --------------------------------------------------------------------------
 const baseUrl = process.env.DOCS_BASE_URL || '/docs/';
 
+// The static marketing site lives one level above the docs base path.
+//
+// The `pathname://` prefix marks the link as "not part of this app", so
+// Docusaurus emits a plain <a> instead of a React Router link. Without it the
+// click is handled client-side, the site root does not match any docs route,
+// and the docs 404 page renders over the marketing home. `autoAddBaseUrl`
+// must be off or Docusaurus prepends the docs base path back onto the path.
+const siteRootHref = `pathname://${baseUrl.replace(/[^/]+\/$/, '')}`;
+const homeLinkProps = {autoAddBaseUrl: false, target: '_self', className: 'enclave-home-link'};
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Eclipse Enclave',
@@ -42,10 +52,9 @@ const config = {
   url: 'https://enclave.eclipse.dev',
   baseUrl,
 
-  // 'warn' (not 'throw') because the docs live at /docs/ under a larger site and
-  // intentionally link "up" to the marketing home via a relative `../` link,
-  // which sits outside Docusaurus's owned route tree.
-  onBrokenLinks: 'warn',
+  // Links that leave the docs route tree must use `pathname://` (see
+  // siteRootHref); anything else Docusaurus reports here is a genuine break.
+  onBrokenLinks: 'throw',
   markdown: {
     hooks: {
       onBrokenMarkdownLinks: 'warn',
@@ -100,11 +109,10 @@ const config = {
             label: 'Docs',
           },
           {
-            // Relative link back to the marketing site (one level above /docs/).
-            href: '../',
+            href: siteRootHref,
             label: 'Home',
             position: 'right',
-            target: '_self',
+            ...homeLinkProps,
           },
           {
             href: 'https://github.com/eclipse-enclave/enclave',
@@ -127,7 +135,7 @@ const config = {
           {
             title: 'Project',
             items: [
-              {label: 'Home', href: '../'},
+              {label: 'Home', href: siteRootHref, ...homeLinkProps},
               {label: 'Eclipse Project', href: 'https://projects.eclipse.org/projects/ecd.enclave'},
               {label: 'GitHub', href: 'https://github.com/eclipse-enclave/enclave'},
             ],

--- a/website/docs/src/css/custom.css
+++ b/website/docs/src/css/custom.css
@@ -372,6 +372,13 @@ div[class^='codeBlockContainer'],
   font-size: 0.85rem;
 }
 
+/* The "Home" links use `pathname://` so they leave the docs app with a real
+   page load. Docusaurus reads that as an external link and appends its
+   external-link icon, but the marketing home is part of the same site. */
+.enclave-home-link svg {
+  display: none;
+}
+
 /* ==========================================================================
    Signature modules — problem / solution boxes as framed enclosures.
    Precision crop-mark corners (top-left, bottom-right) evoke a bounded


### PR DESCRIPTION
## Problem

Clicking **Home** in the docs navbar or footer does not reach the marketing site.

| Clicked from | Lands on | Expected |
| --- | --- | --- |
| `/docs/` | `/` rendering the docs **Page Not Found** | marketing home |
| `/docs/getting-started/` | `/docs/` (docs index) | marketing home |

## Root cause

Both links used `href: '../'`. Docusaurus classifies any href without a protocol as internal and renders it as a React Router `<Link>`, so the click is handled inside the docs single-page app and never reaches the server:

- From `/docs/`, React Router pushes `/` into history. The site root matches no docs route, so the SPA renders its own 404 at `enclave.eclipse.dev/`. The server-side `/` was always fine, which is why the page looked broken only after clicking.
- From a nested page, React Router resolves `../` against the runtime pathname and lands on `/docs/`.

The build already reported this (`Broken link ... -> linking to ../`), but `onBrokenLinks: 'warn'` was set specifically to suppress it. This is not a regression from #55; the same mechanism broke the link under the old `/enclave/docs/` base path.

## Fix

- Derive the site root from `baseUrl` by stripping the last path segment, and prefix it with `pathname://`, the Docusaurus escape hatch for links outside its route tree. That emits a plain `<a>` and the browser performs a real page load. `autoAddBaseUrl: false` stops the docs base path being prepended back on.
- Set `onBrokenLinks: 'throw'` now that nothing legitimately links outside the route tree, so a recurrence fails the build.
- Hide the external-link icon Docusaurus appends to `pathname://` links, since the marketing home is same-site.
- Document the constraint in `website/docs/README.md`.

## Verification

Built both deployment shapes, served them through a GitHub-Pages-like static server, and drove headless Chrome to click the link.

| From | Before | After |
| --- | --- | --- |
| `/docs/` | `/` → Page Not Found | `/` → marketing home |
| `/docs/getting-started/` | `/docs/` → docs index | `/` → marketing home |
| `/docs/cli/` | `/docs/` → docs index | `/` → marketing home |
| footer link | `/docs/` → docs index | `/` → marketing home |
| preview subpath `/…/pr-42/docs/getting-started/` | n/a | `/…/pr-42/` → marketing home |

The icon is hidden in the desktop navbar, the mobile menu, and the footer. `display: none` also drops its "opens in new tab" label from the accessibility tree.