### PR TITLE
feat: mark session-owned terminals with a background tint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,7 @@ supported under `tool_overrides.<tool>`.
 | `no_history` | Disable shell history |
 | `no_memory` | Disable per-project agent memory |
 | `session_monitor` | Run agents under the managed tmux session (enables `status` snapshots) |
+| `session_tint` | Terminal background color marking a session-owned terminal, as `#rrggbb` (unset: no tint) |
 | `base_image` | Docker base image override |
 | `devcontainer` | Derive base image from devcontainer.json |
 | `slim` | Build without features (tools only) |
@@ -99,6 +100,22 @@ on the host. Project config may strengthen the inherited mode from `follow` to
 the inherited mode are ignored. For a regular repository whose `.git`
 directory sits inside the project, the project mount mode governs and this
 option has no effect.
+
+`session_tint` marks the terminal that owns a session, so a sandboxed session
+is visually distinct from an ordinary shell. When set to an `#rrggbb` value,
+`run` (including `shell`, `continue`, and `resume`) and `attach` set the
+terminal background on start and reset it on exit. Inside tmux 3.3 or later only
+the session's pane is tinted; elsewhere the whole window is. Because only the
+background changes, pick a color that keeps your foreground text readable —
+enclave does not adjust it. Invalid values are reported and ignored.
+
+The tint is skipped when stdout is not a terminal and when `NO_COLOR` or
+`ENCLAVE_COLOR=never` is set; `ENCLAVE_COLOR=always` does not enable it, as the
+config key is the only switch. Because per-tool and per-project config layers
+apply, `tool_overrides.<tool>.session_tint` gives each tool its own color and a
+project config gives each project one. Agents that paint their own background
+can cover the tint. If enclave is killed with `SIGKILL` the reset never runs;
+clear a leftover tint with `printf '\e]111\a'`.
 
 **Example:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,19 +103,26 @@ option has no effect.
 
 `session_tint` marks the terminal that owns a session, so a sandboxed session
 is visually distinct from an ordinary shell. When set to an `#rrggbb` value,
-`run` (including `shell`, `continue`, and `resume`) and `attach` set the
-terminal background on start and reset it on exit. Inside tmux 3.3 or later only
-the session's pane is tinted; elsewhere the whole window is. Because only the
-background changes, pick a color that keeps your foreground text readable —
-enclave does not adjust it. Invalid values are reported and ignored.
+`run` (including `shell`, `continue`, and `resume`), `exec`, and `attach` set
+the terminal background on start and reset it on exit. Inside tmux 3.3 or later
+only the session's pane is tinted; elsewhere the whole window is. Because only
+the background changes, pick a color that keeps your foreground text readable —
+enclave does not adjust it. Invalid values are reported when the config file is
+read and ignored.
 
 The tint is skipped when stdout is not a terminal and when `NO_COLOR` or
 `ENCLAVE_COLOR=never` is set; `ENCLAVE_COLOR=always` does not enable it, as the
 config key is the only switch. Because per-tool and per-project config layers
 apply, `tool_overrides.<tool>.session_tint` gives each tool its own color and a
-project config gives each project one. Agents that paint their own background
-can cover the tint. If enclave is killed with `SIGKILL` the reset never runs;
-clear a leftover tint with `printf '\e]111\a'`.
+project config gives each project one; `attach` resolves the color for the tool
+and project of the session it attaches to, not for the current directory.
+Agents that paint their own background can cover the tint.
+
+The reset restores the terminal's configured default background, not whatever
+background was in effect before the session, so a color set at runtime (theme
+switchers, base16-style scripts) is dropped when the session ends. If enclave is
+killed with `SIGKILL` the reset never runs; clear a leftover tint with
+`printf '\e]111\a'`.
 
 **Example:**
 

--- a/internal/app/command_attach.go
+++ b/internal/app/command_attach.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"enclave/internal/backend"
+	"enclave/internal/config"
 	"enclave/internal/logx"
 	"enclave/internal/model"
 	"enclave/internal/termtint"
@@ -52,11 +53,33 @@ func runAttach(opts model.Options, projectDir string) int {
 		logx.Errorf("%v", err)
 		return 1
 	}
-	restoreTint := termtint.Begin(run.SessionTint)
+	restoreTint := termtint.Begin(attachSessionTint(session, run.SessionTint))
 	defer restoreTint()
 	if err := be.Attach(ctx, session.Ref, backend.AttachIO{DetachKeys: detachKeys}); err != nil {
 		logx.Errorf("attach: %v", err)
 		return 1
 	}
 	return 0
+}
+
+// attachSessionTint resolves session_tint for the session being attached rather
+// than for the ambient tool and cwd project, so attaching a codex session from
+// a shell whose default tool is claude paints the codex color. Warnings from
+// re-reading the config layers stay at debug level because the run path already
+// reports them. The fallback covers containers labeled by an older enclave that
+// recorded no tool or project dir.
+func attachSessionTint(session backend.Session, fallback string) string {
+	if session.Tool == "" || session.ProjectDir == "" {
+		return fallback
+	}
+	global, project, warnings, err := config.LoadDefaults(session.ProjectDir)
+	if err != nil {
+		logx.Debugf("resolve session_tint for %s: %v", session.Ref.Name, err)
+		return fallback
+	}
+	for _, warning := range warnings {
+		logx.Debugf("%s", warning)
+	}
+	opts, _, _ := config.ResolveOptionsForTool(model.Options{}, model.OptionSources{}, global, project, session.Tool)
+	return opts.SessionTint
 }

--- a/internal/app/command_attach.go
+++ b/internal/app/command_attach.go
@@ -14,6 +14,7 @@ import (
 	"enclave/internal/backend"
 	"enclave/internal/logx"
 	"enclave/internal/model"
+	"enclave/internal/termtint"
 )
 
 func runAttach(opts model.Options, projectDir string) int {
@@ -51,6 +52,8 @@ func runAttach(opts model.Options, projectDir string) int {
 		logx.Errorf("%v", err)
 		return 1
 	}
+	restoreTint := termtint.Begin(run.SessionTint)
+	defer restoreTint()
 	if err := be.Attach(ctx, session.Ref, backend.AttachIO{DetachKeys: detachKeys}); err != nil {
 		logx.Errorf("attach: %v", err)
 		return 1

--- a/internal/app/command_attach_test.go
+++ b/internal/app/command_attach_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"enclave/internal/backend"
+	"enclave/internal/config"
+)
+
+func writeGlobalToolTints(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	path, err := config.GlobalConfigPath()
+	if err != nil {
+		t.Fatalf("resolve global config path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir config root: %v", err)
+	}
+	payload := `{
+  "tool": "claude",
+  "tool_overrides": {
+    "claude": {"session_tint": "#111111"},
+    "codex": {"session_tint": "#222222"}
+  }
+}`
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+}
+
+// The ambient tool is claude, so a codex session must still resolve the codex
+// color rather than the default tool's.
+func TestAttachSessionTintFollowsSessionTool(t *testing.T) {
+	writeGlobalToolTints(t)
+	session := backend.Session{Tool: "codex", ProjectDir: t.TempDir()}
+
+	if got := attachSessionTint(session, "#111111"); got != "#222222" {
+		t.Fatalf("expected the codex tint, got %q", got)
+	}
+}
+
+func TestAttachSessionTintFallsBack(t *testing.T) {
+	writeGlobalToolTints(t)
+
+	cases := []struct {
+		name    string
+		session backend.Session
+	}{
+		{name: "unlabeled tool", session: backend.Session{ProjectDir: t.TempDir()}},
+		{name: "unlabeled project dir", session: backend.Session{Tool: "codex"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := attachSessionTint(tc.session, "#333333"); got != "#333333" {
+				t.Fatalf("expected the resolved fallback tint, got %q", got)
+			}
+		})
+	}
+}

--- a/internal/app/testdata/config_rows.golden
+++ b/internal/app/testdata/config_rows.golden
@@ -14,6 +14,7 @@ pass_env | default=""/false global=""/false project="[FOO,BAR]"/true toolOverrid
 allow_all_network | default="false"/true global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective="false"
 no_cache | default="false"/true global="true"/true project=""/false toolOverride=""/false cli=""/false | source=2 effective="true"
 session_monitor | default="false"/true global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective="false"
+session_tint | default=""/false global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective=""
 no_history | default="false"/true global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective="false"
 no_memory | default="false"/true global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective="false"
 image_inbox | default="false"/true global=""/false project=""/false toolOverride=""/false cli=""/false | source=0 effective="false"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -200,6 +200,7 @@ func readDefaults(path string) (Defaults, []string, error) {
 	warnings := validateTopLevelDefaults(path, doc, &defaults)
 	warnings = append(warnings, validateToolOverrides(path, doc, &defaults)...)
 	warnings = append(warnings, validatePassEnvNames(path, &defaults)...)
+	warnings = append(warnings, validateSessionTint(path, &defaults)...)
 	return defaults, warnings, nil
 }
 
@@ -302,6 +303,44 @@ func filterPassEnv(path string, toolName string, values []string, warnings []str
 		return nil, warnings
 	}
 	return kept, warnings
+}
+
+// validateSessionTint clears session_tint values (top level and per tool
+// override) that aren't #rrggbb colors, so the warning names the config file
+// that sets them and appears before a session takes over the screen.
+func validateSessionTint(path string, defaults *Defaults) []string {
+	if defaults == nil {
+		return nil
+	}
+
+	warnings := make([]string, 0)
+	if tint := strings.TrimSpace(defaults.SessionTint); tint != "" && !isValidTintColor(tint) {
+		warnings = append(warnings, fmt.Sprintf("Ignoring session_tint %q in %s: expected an #rrggbb color", tint, path))
+		defaults.SessionTint = ""
+	}
+
+	if len(defaults.ToolOverrides) == 0 {
+		return warnings
+	}
+
+	toolNames := make([]string, 0, len(defaults.ToolOverrides))
+	for name := range defaults.ToolOverrides {
+		toolNames = append(toolNames, name)
+	}
+	sort.Strings(toolNames)
+
+	for _, name := range toolNames {
+		override := defaults.ToolOverrides[name]
+		tint := strings.TrimSpace(override.SessionTint)
+		if tint == "" || isValidTintColor(tint) {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf("Ignoring tool_overrides.%s.session_tint %q in %s: expected an #rrggbb color", name, tint, path))
+		override.SessionTint = ""
+		defaults.ToolOverrides[name] = override
+	}
+
+	return warnings
 }
 
 func validateTopLevelDefaults(path string, doc map[string]json.RawMessage, defaults *Defaults) []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type Defaults struct {
 	NoHistory        *bool               `json:"no_history"`
 	NoMemory         *bool               `json:"no_memory"`
 	SessionMonitor   *bool               `json:"session_monitor"`
+	SessionTint      string              `json:"session_tint"`
 	ImageInbox       *bool               `json:"image_inbox"`
 	BaseImage        string              `json:"base_image"`
 	Devcontainer     *bool               `json:"devcontainer"`

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -40,6 +40,7 @@ func TestMergeDefaultsCoversAllFields(t *testing.T) {
 		NoHistory:        &trueVal,
 		NoMemory:         &trueVal,
 		SessionMonitor:   &trueVal,
+		SessionTint:      "#2a0f12",
 		ImageInbox:       &trueVal,
 		BaseImage:        "test-base-image",
 		Devcontainer:     &trueVal,

--- a/internal/config/options_cli.go
+++ b/internal/config/options_cli.go
@@ -348,6 +348,23 @@ func applyBridgePort(opts *model.Options, value string) error {
 	return nil
 }
 
+// isValidTintColor reports whether value is an #rrggbb color. termtint keeps its
+// own check as a guard before emitting the escape sequence; the format is
+// checked in both places because config must not depend on the terminal
+// packages (see internal/gateway/gateway_proxy_build_inputs.txt).
+func isValidTintColor(value string) bool {
+	if len(value) != 7 || value[0] != '#' {
+		return false
+	}
+	for _, r := range value[1:] {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 func isValidEnvKey(value string) bool {
 	if value == "" {
 		return false

--- a/internal/config/options_def.go
+++ b/internal/config/options_def.go
@@ -439,6 +439,16 @@ func OptionDefs() []OptionDef {
 			},
 		},
 		{
+			Name:          "session_tint",
+			Group:         OptionGroupRun,
+			Kind:          OptionKindString,
+			OptionField:   "SessionTint",
+			SourceField:   "SessionTint",
+			DefaultsField: "SessionTint",
+			Apply:         ApplyString,
+			TrimOnApply:   true,
+		},
+		{
 			Name:          "no_history",
 			Group:         OptionGroupRun,
 			Kind:          OptionKindBool,

--- a/internal/config/options_registry_gen.go
+++ b/internal/config/options_registry_gen.go
@@ -179,6 +179,16 @@ func OptionSpecs() []OptionSpec {
 			},
 		},
 		{
+			Name:  "session_tint",
+			Group: OptionGroupRun,
+			ApplyDefaultsWithSource: func(opts *model.Options, defaults Defaults, source model.OptionSource, sources *model.OptionSources) {
+				if canOverride(sources.SessionTint, source) && strings.TrimSpace(defaults.SessionTint) != "" {
+					opts.SessionTint = strings.TrimSpace(defaults.SessionTint)
+					sources.SessionTint = source
+				}
+			},
+		},
+		{
 			Name:  "no_history",
 			Group: OptionGroupRun,
 			ApplyDefaultsWithSource: func(opts *model.Options, defaults Defaults, source model.OptionSource, sources *model.OptionSources) {

--- a/internal/config/tool_overrides_test.go
+++ b/internal/config/tool_overrides_test.go
@@ -595,6 +595,48 @@ func TestReadDefaults_GlobalPassEnvDropsInvalidEntries(t *testing.T) {
 	}
 }
 
+func TestReadDefaults_SessionTintDropsInvalidValues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	payload := `{
+  "session_tint": "red",
+  "tool_overrides": {
+    "claude": {
+      "session_tint": "#2a0f12"
+    },
+    "codex": {
+      "session_tint": "#2a0"
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	defaults, warnings, err := readDefaults(path)
+	if err != nil {
+		t.Fatalf("readDefaults returned error: %v", err)
+	}
+	if defaults.SessionTint != "" {
+		t.Fatalf("expected invalid session_tint to be dropped, got %q", defaults.SessionTint)
+	}
+	if got := defaults.ToolOverrides["claude"].SessionTint; got != "#2a0f12" {
+		t.Fatalf("expected valid claude session_tint to remain, got %q", got)
+	}
+	if got := defaults.ToolOverrides["codex"].SessionTint; got != "" {
+		t.Fatalf("expected invalid codex session_tint to be dropped, got %q", got)
+	}
+	if !containsSubstring(warnings, "session_tint \"red\" in "+path) {
+		t.Fatalf("expected warning naming the config file, warnings=%v", warnings)
+	}
+	if !containsSubstring(warnings, "tool_overrides.codex.session_tint \"#2a0\"") {
+		t.Fatalf("expected tool override warning for codex, warnings=%v", warnings)
+	}
+	if containsSubstring(warnings, "claude") {
+		t.Fatalf("did not expect a warning for the valid claude value: %v", warnings)
+	}
+}
+
 func TestProjectOverrideGuardrails_StripsSensitiveFields(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/internal/logx/color.go
+++ b/internal/logx/color.go
@@ -34,14 +34,11 @@ var colorEnabled = ColorEnabledFor(os.Stderr)
 // callers that render to a stream other than the log stream. NO_COLOR wins
 // outright, then ENCLAVE_COLOR, and otherwise f has to be a terminal.
 func ColorEnabledFor(f *os.File) bool {
-	if os.Getenv("NO_COLOR") != "" {
+	if ColorSuppressedByEnv() {
 		return false
 	}
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(model.EnvColor))) {
-	case "always":
+	if strings.EqualFold(strings.TrimSpace(os.Getenv(model.EnvColor)), "always") {
 		return true
-	case "never":
-		return false
 	}
 	if f == nil {
 		return false
@@ -58,4 +55,15 @@ func Colorize(text string, color Color) string {
 
 func colorPrefix(label string, color Color) string {
 	return Colorize(label+": ", color)
+}
+
+// ColorSuppressedByEnv reports whether the environment explicitly disables
+// colored output, regardless of whether a terminal is attached. Consumers that
+// paint something other than log text (see internal/termtint) honor the same
+// opt-out without inheriting the terminal auto-detection of ColorEnabledFor.
+func ColorSuppressedByEnv() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(model.EnvColor)), "never")
 }

--- a/internal/model/option_sources_gen.go
+++ b/internal/model/option_sources_gen.go
@@ -41,6 +41,7 @@ type RunOptionSources struct {
 	ProjectMount     OptionSource
 	SessionMonitor   OptionSource
 	SessionName      OptionSource
+	SessionTint      OptionSource
 	Tool             OptionSource
 	WorktreeMetadata OptionSource
 	Yolo             OptionSource
@@ -103,6 +104,7 @@ func DefaultOptionSources() OptionSources {
 			ProjectMount:     SourceDefault,
 			SessionMonitor:   SourceDefault,
 			SessionName:      SourceDefault,
+			SessionTint:      SourceDefault,
 			Tool:             SourceDefault,
 			WorktreeMetadata: SourceDefault,
 			Yolo:             SourceDefault,
@@ -261,6 +263,9 @@ func MergeOptionSources(base OptionSources, override OptionSources) OptionSource
 	}
 	if override.SessionName != SourceUnset {
 		base.SessionName = override.SessionName
+	}
+	if override.SessionTint != SourceUnset {
+		base.SessionTint = override.SessionTint
 	}
 	if override.Slim != SourceUnset {
 		base.Slim = override.Slim

--- a/internal/model/option_sources_test.go
+++ b/internal/model/option_sources_test.go
@@ -43,6 +43,7 @@ func TestMergeOptionSourcesCoversAllFields(t *testing.T) {
 			AllowDomains:     SourceCLI,
 			BridgePorts:      SourceCLI,
 			SessionName:      SourceCLI,
+			SessionTint:      SourceCLI,
 			PlaywrightMCP:    SourceCLI,
 		},
 		AuthOptionSources: AuthOptionSources{

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -30,6 +30,7 @@ type RunOptions struct {
 	Admin             bool
 	ImageInbox        bool
 	SessionMonitor    bool
+	SessionTint       string
 	CmdArgs           []string
 	NoHistory         bool
 	NoMemory          bool

--- a/internal/runtime/exec.go
+++ b/internal/runtime/exec.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"enclave/internal/backend"
+	"enclave/internal/termtint"
 )
 
 func (r *Runtime) Exec() error {
@@ -42,6 +43,10 @@ func (r *Runtime) Exec() error {
 	if !ok {
 		return fmt.Errorf("backend %s does not support exec", be.Name())
 	}
+	// An exec occupies the terminal with an interactive TTY into the session, so
+	// it is marked like a session that owns the terminal from the start.
+	restoreTint := termtint.Begin(r.run.SessionTint)
+	defer restoreTint()
 	// The backend syncs session credentials after the exec completes, deriving
 	// the involved stores from the running container.
 	return execer.Exec(context.Background(), backend.SessionRef{Name: containerName}, backend.ExecRequest{Argv: cmdArgs, User: user, TTY: true}, backend.AttachIO{})

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -28,6 +28,7 @@ import (
 	"enclave/internal/mounts"
 	"enclave/internal/network"
 	"enclave/internal/policy"
+	"enclave/internal/termtint"
 	"enclave/internal/util"
 )
 
@@ -760,6 +761,8 @@ func (r *Runtime) runContainer(ctx *ExecutionContext) error {
 	if be == nil {
 		return fmt.Errorf("runtime backend is not configured")
 	}
+	restoreTint := termtint.Begin(r.run.SessionTint)
+	defer restoreTint()
 	_, err := be.Run(context.Background(), r.backendRequest(ctx, false, true), backend.AttachIO{TTY: true, OnStarted: func() { r.announcePublishedPorts(ctx.ContainerName) }})
 	return err
 }

--- a/internal/termtint/signal_unix.go
+++ b/internal/termtint/signal_unix.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package termtint
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// interruptSignals are the signals that would terminate a session before a
+// deferred restore can run.
+func interruptSignals() []os.Signal {
+	return []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP}
+}
+
+// reraise restores the signal's default disposition and re-sends it, so the
+// process dies exactly as it would have without the handler installed.
+func reraise(sig os.Signal) {
+	signal.Reset(sig)
+	unixSignal, ok := sig.(syscall.Signal)
+	if !ok {
+		return
+	}
+	_ = syscall.Kill(syscall.Getpid(), unixSignal)
+}

--- a/internal/termtint/signal_windows.go
+++ b/internal/termtint/signal_windows.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package termtint
+
+import "os"
+
+func interruptSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}
+
+// reraise cannot re-send a signal to the current process on Windows, so exit
+// with the conventional interrupted status once the tint is restored.
+func reraise(os.Signal) {
+	os.Exit(130)
+}

--- a/internal/termtint/termtint.go
+++ b/internal/termtint/termtint.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+// Package termtint marks a terminal that is currently owned by an enclave
+// session by setting its background color, so a sandboxed session is visually
+// distinct from an ordinary shell.
+package termtint
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"regexp"
+	"strings"
+	"sync"
+
+	"golang.org/x/term"
+
+	"enclave/internal/logx"
+)
+
+// OSC 11 sets the terminal background, OSC 111 resets it to the configured
+// default. tmux 3.3+ consumes both to style the pane rather than forwarding
+// them, so inside tmux only the session's pane is tinted.
+const (
+	setBackgroundFormat = "\x1b]11;%s\x07"
+	resetBackground     = "\x1b]111\x07"
+)
+
+var colorPattern = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
+
+// Indirection for tests: the real emit path requires a terminal on stdout.
+var (
+	out        io.Writer = os.Stdout
+	isTerminal           = func() bool {
+		return term.IsTerminal(int(os.Stdout.Fd())) // #nosec G115 -- file descriptor from Fd() fits in int on all supported platforms.
+	}
+)
+
+// Begin tints the terminal background and returns a function that restores it.
+// Callers should defer the returned function; it is safe to call more than
+// once. Begin is a no-op when color is empty, is not an #rrggbb value, when the
+// environment suppresses color, or when stdout is not a terminal.
+func Begin(color string) func() {
+	color = strings.TrimSpace(color)
+	if color == "" {
+		return func() {}
+	}
+	if !colorPattern.MatchString(color) {
+		logx.Warnf("Ignoring invalid session_tint %q: expected an #rrggbb color", color)
+		return func() {}
+	}
+	if logx.ColorSuppressedByEnv() || !isTerminal() {
+		return func() {}
+	}
+
+	_, _ = fmt.Fprintf(out, setBackgroundFormat, color)
+
+	var restoreOnce sync.Once
+	// A signal that kills enclave outright would leave the terminal tinted with
+	// no session behind it. A stale marker is worse than none, so restore before
+	// dying and then let the signal take its default effect.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, interruptSignals()...)
+	restore := func() {
+		restoreOnce.Do(func() {
+			signal.Stop(signals)
+			_, _ = fmt.Fprint(out, resetBackground)
+		})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case sig := <-signals:
+			restore()
+			reraise(sig)
+		case <-done:
+		}
+	}()
+
+	var stopOnce sync.Once
+	return func() {
+		stopOnce.Do(func() {
+			close(done)
+			restore()
+		})
+	}
+}

--- a/internal/termtint/termtint.go
+++ b/internal/termtint/termtint.go
@@ -44,15 +44,13 @@ var (
 
 // Begin tints the terminal background and returns a function that restores it.
 // Callers should defer the returned function; it is safe to call more than
-// once. Begin is a no-op when color is empty, is not an #rrggbb value, when the
-// environment suppresses color, or when stdout is not a terminal.
+// once. Begin is a no-op when color is empty or not an #rrggbb value, when the
+// environment suppresses color, or when stdout is not a terminal. Config
+// loading reports invalid values against the file that sets them; the format
+// check here guards the escape sequence against anything that slips past.
 func Begin(color string) func() {
 	color = strings.TrimSpace(color)
-	if color == "" {
-		return func() {}
-	}
 	if !colorPattern.MatchString(color) {
-		logx.Warnf("Ignoring invalid session_tint %q: expected an #rrggbb color", color)
 		return func() {}
 	}
 	if logx.ColorSuppressedByEnv() || !isTerminal() {

--- a/internal/termtint/termtint_test.go
+++ b/internal/termtint/termtint_test.go
@@ -83,13 +83,13 @@ func TestBeginSkips(t *testing.T) {
 // stays the single on/off switch.
 func TestColorAlwaysDoesNotForceTint(t *testing.T) {
 	t.Setenv("ENCLAVE_COLOR", "always")
-	buf := withTerminal(t, false)
+	buf := withTerminal(t, true)
 
-	restore := Begin("#2a0f12")
+	restore := Begin("")
 	restore()
 
 	if got := buf.String(); got != "" {
-		t.Fatalf("expected no output without a terminal, got %q", got)
+		t.Fatalf("expected no output without a configured color, got %q", got)
 	}
 }
 

--- a/internal/termtint/termtint_test.go
+++ b/internal/termtint/termtint_test.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package termtint
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// withTerminal points the package at a buffer and pretends stdout is a
+// terminal, restoring the real values afterwards.
+func withTerminal(t *testing.T, terminal bool) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prevOut, prevIsTerminal := out, isTerminal
+	out, isTerminal = buf, func() bool { return terminal }
+	t.Cleanup(func() { out, isTerminal = prevOut, prevIsTerminal })
+	return buf
+}
+
+func TestBeginTintsAndRestores(t *testing.T) {
+	buf := withTerminal(t, true)
+
+	restore := Begin("#2a0f12")
+	if got := buf.String(); got != "\x1b]11;#2a0f12\x07" {
+		t.Fatalf("unexpected tint sequence: %q", got)
+	}
+
+	buf.Reset()
+	restore()
+	if got := buf.String(); got != "\x1b]111\x07" {
+		t.Fatalf("unexpected restore sequence: %q", got)
+	}
+
+	buf.Reset()
+	restore()
+	if got := buf.String(); got != "" {
+		t.Fatalf("restore is not idempotent, second call wrote %q", got)
+	}
+}
+
+func TestBeginSkips(t *testing.T) {
+	cases := []struct {
+		name     string
+		color    string
+		terminal bool
+		env      map[string]string
+	}{
+		{name: "empty color", color: "", terminal: true},
+		{name: "blank color", color: "   ", terminal: true},
+		{name: "missing hash", color: "2a0f12", terminal: true},
+		{name: "short color", color: "#2a0", terminal: true},
+		{name: "named color", color: "red", terminal: true},
+		{name: "not a terminal", color: "#2a0f12", terminal: false},
+		{name: "NO_COLOR", color: "#2a0f12", terminal: true, env: map[string]string{"NO_COLOR": "1"}},
+		{name: "ENCLAVE_COLOR never", color: "#2a0f12", terminal: true, env: map[string]string{"ENCLAVE_COLOR": "never"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
+			buf := withTerminal(t, tc.terminal)
+
+			restore := Begin(tc.color)
+			restore()
+
+			if got := buf.String(); got != "" {
+				t.Fatalf("expected no output, got %q", got)
+			}
+		})
+	}
+}
+
+// ENCLAVE_COLOR=always may only veto a tint, never force one on: the config key
+// stays the single on/off switch.
+func TestColorAlwaysDoesNotForceTint(t *testing.T) {
+	t.Setenv("ENCLAVE_COLOR", "always")
+	buf := withTerminal(t, false)
+
+	restore := Begin("#2a0f12")
+	restore()
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("expected no output without a terminal, got %q", got)
+	}
+}
+
+func TestBeginAcceptsUppercaseHex(t *testing.T) {
+	buf := withTerminal(t, true)
+
+	restore := Begin("#2A0F12")
+	t.Cleanup(restore)
+
+	if !strings.Contains(buf.String(), "#2A0F12") {
+		t.Fatalf("expected uppercase color to be emitted, got %q", buf.String())
+	}
+}


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
A sandboxed session is indistinguishable from an ordinary shell once the agent paints over the scrollback, so it is easy to run host commands in a terminal that belongs to a session, or the reverse. The new session_tint config option takes an #rrggbb value; run and attach set the terminal background via OSC 11 on start and reset it via OSC 111 on exit. tmux 3.3 or later consumes both, so inside tmux only the session's pane is tinted.

The reset also runs on the interrupt signals, because a stale tint with no session behind it is a worse marker than none; the signal keeps its default effect afterwards. SIGKILL still leaks a tint, which the docs cover.

Only the config key enables the tint. NO_COLOR and ENCLAVE_COLOR=never suppress it, but ENCLAVE_COLOR=always does not turn it on, since a terminal background is not log text and should not follow log-color auto-detection. resolveColorEnabled grows a ColorSuppressedByEnv split for that reason.

Fixes #2
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Scratch config root, so the real config stays untouched:

```bash
mkdir -p /tmp/tint-test/config/enclave
echo '{"session_tint": "#2a0f12"}' > /tmp/tint-test/config/enclave/config.json
export XDG_CONFIG_HOME=/tmp/tint-test/config
./bin/enclave config --view source --json | grep -A3 session_tint
# -> "effective": "#2a0f12", "source": "global"
```

A scratch config root means an empty auth store, so a real session will ask for
a fresh tool login. For the session cases below it is less friction to put the
key in the real `~/.config/enclave/config.json` and remove it afterwards.

| # | Steps | Expected |
|---|---|---|
| 1 | `enclave shell`, then `exit` | tinted on start, restored on exit |
| 2 | `enclave -d`, then `enclave attach <name>`, detach with `ctrl-\` | launching terminal untinted; tinted while attached, restored on detach |
| 3 | `enclave shell`, then `kill -TERM $(pgrep -f 'enclave shell')` from another terminal | tint restored *and* enclave dies from the signal |
| 4 | `NO_COLOR=1 enclave shell` / `ENCLAVE_COLOR=never enclave shell` | no tint |
| 5 | config key removed, `ENCLAVE_COLOR=always enclave shell` | no tint — the config key is the only switch |
| 6 | `"session_tint": "red"` | `Ignoring invalid session_tint …` warning, no tint, session runs normally |

`SIGKILL` leaves the tint behind by design; clear it with `printf '\e]111\a'`.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
