### PR TITLE
fix: resolve sessions by name in attach, stop, and theia

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,15 +44,29 @@ started as `--name "My Task"` is reachable as either `my-task` or `"My Task"`.
 The same holds for the `--name` filter of `ps`, `status`, and `stop`.
 
 Session names are resolved against the current project first (same worktree,
-then same project), then across all projects; they are not required to be
-unique, so when one matches several containers the candidates are listed and a
-container name must be passed instead. `--tool` narrows the candidates. Passing
-a container name or ID always resolves verbatim, independently of the working
-directory and `--tool`.
+then same project); they are not required to be unique, so when one matches
+several containers the candidates are listed and a container name must be passed
+instead. `--tool` narrows the candidates. Passing a container name or ID always
+resolves verbatim, independently of the working directory and `--tool`; an
+ambiguous container-ID prefix is reported like an ambiguous name.
+
+`attach` and `theia` widen the search to all projects when the current one has
+no match. `stop <name>` does not: removal is destructive and the auto-assigned
+names `1`, `2`, … collide across projects by construction, so another project's
+session has to be named by its container name or ID.
+
+`stop <name>` and `stop --name <name>` are different commands. The positional
+form removes the single session it resolves, whatever its tool and whether it is
+running or already stopped. `--name` filters the batch form instead: it removes
+every *background* session of the selected tool (`--tool`, default `claude`)
+whose session name matches. A `--name` that is blank or sanitizes to nothing
+matches no session rather than all of them.
 
 With no argument, `attach` picks the single detached session of the current
 project (a foreground session is entered with `exec` instead), and `theia` picks
-its single running container.
+the single running container of the current project. An argument that is present
+but blank (`enclave stop "$SESSION"` with an unset variable) is rejected instead
+of being treated as "no argument".
 
 ### Inspect
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -29,22 +29,30 @@ unchanged. See [windows.md](windows.md).
 | `enclave shell --admin` | Shell with limited sudo |
 | `enclave stop [name]` | Stop background containers, or one session by name |
 
-`enclave ps` prints one row per container with its `NAME` (container name) and `SESSION` (the `--name` session name, `-` for the project's default container); either can be passed to `attach`, `stop`, and `theia`. Flags: `--all` (include stopped containers, not just running ones), `--json` (emit a JSON array instead of the table). The flags compose (`ps --all --json`). Each JSON object has the fields `name`, `tool`, `projectDir` (absolute, resolved project path), `projectHash`, `worktree`, `status`, `createdAt` (RFC 3339, empty if unknown), `sessionName`, `background`, and `ports` (array of `{containerPort, hostPort, hostIP, protocol}` bindings).
+`enclave ps` prints one row per container with its `NAME` (container name) and `SESSION` (the `--name` session name, or the auto-assigned `1`, `2`, … for extra sessions; `-` for the project's default container); either can be passed to `attach`, `stop`, and `theia`. Flags: `--all` (include stopped containers, not just running ones), `--json` (emit a JSON array instead of the table). The flags compose (`ps --all --json`). Each JSON object has the fields `name`, `tool`, `projectDir` (absolute, resolved project path), `projectHash`, `worktree`, `status`, `createdAt` (RFC 3339, empty if unknown), `sessionName`, `background`, and `ports` (array of `{containerPort, hostPort, hostIP, protocol}` bindings).
 
 `status` reports sessions of the current project (like `exec`); `--all` widens it to every project. Flags: `--tool` and `--name` filter sessions; `--json` emits one machine-readable snapshot object per session (screen text and OSC title for external state detection). Each snapshot captures the trailing 24 screen rows. See [Session status snapshots](session-status.md).
 
-`enclave attach` flags: `--detach-keys <sequence>` overrides the key sequence for detaching from the session (default `ctrl-\`).
+`enclave attach` flags: `--detach-keys <sequence>` overrides the key sequence for detaching from the session (default `ctrl-\`); `--tool` disambiguates a session name used by more than one tool.
 
-`attach`, `stop <name>`, and `theia`/`theia-next` take either the container name
-from `enclave ps` or the session name passed to `--name` (`enclave --background
---name my-task` → `enclave attach my-task`). Session names are matched in their
-sanitized form (lowercased, non-alphanumerics collapsed to `-`, truncated to 32
-characters), so `--name "My Task"` is addressable as `my-task`. Names are
-resolved against the current project first, then against the whole host;
-`--tool` narrows the candidates. Session names are not required to be unique
-across projects — when one matches several containers, the candidates are listed
-and a container name must be passed instead. With no argument, `attach` and
-`theia` select the single running session of the current project.
+`attach`, `stop <name>`, and `theia`/`theia-next` accept the container name from
+`enclave ps`, a container ID, or the session name passed to `--name`
+(`enclave --background --name my-task` → `enclave attach my-task`). Session
+names are matched in sanitized form on both sides (lowercased,
+non-alphanumerics collapsed to `-`, truncated to 32 characters), so a session
+started as `--name "My Task"` is reachable as either `my-task` or `"My Task"`.
+The same holds for the `--name` filter of `ps`, `status`, and `stop`.
+
+Session names are resolved against the current project first (same worktree,
+then same project), then across all projects; they are not required to be
+unique, so when one matches several containers the candidates are listed and a
+container name must be passed instead. `--tool` narrows the candidates. Passing
+a container name or ID always resolves verbatim, independently of the working
+directory and `--tool`.
+
+With no argument, `attach` picks the single detached session of the current
+project (a foreground session is entered with `exec` instead), and `theia` picks
+its single running container.
 
 ### Inspect
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -41,7 +41,9 @@ unchanged. See [windows.md](windows.md).
 names are matched in sanitized form on both sides (lowercased,
 non-alphanumerics collapsed to `-`, truncated to 32 characters), so a session
 started as `--name "My Task"` is reachable as either `my-task` or `"My Task"`.
-The same holds for the `--name` filter of `ps`, `status`, and `stop`.
+The same holds for the `--name` filter of `ps`, `status`, and `stop`; a `--name`
+that is blank or sanitizes to nothing matches no session rather than all of
+them.
 
 Session names are resolved against the current project first (same worktree,
 then same project); they are not required to be unique, so when one matches
@@ -51,16 +53,17 @@ resolves verbatim, independently of the working directory and `--tool`; an
 ambiguous container-ID prefix is reported like an ambiguous name.
 
 `attach` and `theia` widen the search to all projects when the current one has
-no match. `stop <name>` does not: removal is destructive and the auto-assigned
-names `1`, `2`, … collide across projects by construction, so another project's
-session has to be named by its container name or ID.
+no match. `stop` never does, neither for `stop <name>` nor for `stop --name`:
+removal is destructive and the auto-assigned names `1`, `2`, … collide across
+projects by construction, so another project's session has to be named by its
+container name or ID.
 
-`stop <name>` and `stop --name <name>` are different commands. The positional
-form removes the single session it resolves, whatever its tool and whether it is
-running or already stopped. `--name` filters the batch form instead: it removes
-every *background* session of the selected tool (`--tool`, default `claude`)
-whose session name matches. A `--name` that is blank or sanitizes to nothing
-matches no session rather than all of them.
+`stop <name>` and `stop --name <name>` still select differently. The positional
+form removes exactly the one session it resolves, of any tool unless `--tool` is
+passed. `--name` filters the batch form instead: it removes every *background*
+session of the current project whose name matches, for the single tool that the
+options resolve to (so a profile or config `tool` applies as well). Both include
+containers that have already exited.
 
 With no argument, `attach` picks the single detached session of the current
 project (a foreground session is entered with `exec` instead), and `theia` picks

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,18 +22,29 @@ unchanged. See [windows.md](windows.md).
 | `enclave resume` | Session picker/list when supported (falls back to `continue`) |
 | `enclave ps` | List enclave containers (`--all` includes stopped, `--json` emits structured output) |
 | `enclave status` | Show terminal snapshots of running sessions |
-| `enclave attach <container>` | Attach to a named background session |
+| `enclave attach [name]` | Attach to a background session by session name or container name |
 | `enclave exec` | Attach to a running container |
 | `enclave exec --admin` | Attach with limited sudo (apt/dpkg) |
 | `enclave shell` | Open an interactive shell in the container |
 | `enclave shell --admin` | Shell with limited sudo |
-| `enclave stop` | Stop background containers |
+| `enclave stop [name]` | Stop background containers, or one session by name |
 
-`enclave ps` flags: `--all` (include stopped containers, not just running ones), `--json` (emit a JSON array instead of the table). The flags compose (`ps --all --json`). Each JSON object has the fields `name`, `tool`, `projectDir` (absolute, resolved project path), `projectHash`, `worktree`, `status`, `createdAt` (RFC 3339, empty if unknown), `sessionName`, `background`, and `ports` (array of `{containerPort, hostPort, hostIP, protocol}` bindings).
+`enclave ps` prints one row per container with its `NAME` (container name) and `SESSION` (the `--name` session name, `-` for the project's default container); either can be passed to `attach`, `stop`, and `theia`. Flags: `--all` (include stopped containers, not just running ones), `--json` (emit a JSON array instead of the table). The flags compose (`ps --all --json`). Each JSON object has the fields `name`, `tool`, `projectDir` (absolute, resolved project path), `projectHash`, `worktree`, `status`, `createdAt` (RFC 3339, empty if unknown), `sessionName`, `background`, and `ports` (array of `{containerPort, hostPort, hostIP, protocol}` bindings).
 
 `status` reports sessions of the current project (like `exec`); `--all` widens it to every project. Flags: `--tool` and `--name` filter sessions; `--json` emits one machine-readable snapshot object per session (screen text and OSC title for external state detection). Each snapshot captures the trailing 24 screen rows. See [Session status snapshots](session-status.md).
 
 `enclave attach` flags: `--detach-keys <sequence>` overrides the key sequence for detaching from the session (default `ctrl-\`).
+
+`attach`, `stop <name>`, and `theia`/`theia-next` take either the container name
+from `enclave ps` or the session name passed to `--name` (`enclave --background
+--name my-task` → `enclave attach my-task`). Session names are matched in their
+sanitized form (lowercased, non-alphanumerics collapsed to `-`, truncated to 32
+characters), so `--name "My Task"` is addressable as `my-task`. Names are
+resolved against the current project first, then against the whole host;
+`--tool` narrows the candidates. Session names are not required to be unique
+across projects — when one matches several containers, the candidates are listed
+and a container name must be passed instead. With no argument, `attach` and
+`theia` select the single running session of the current project.
 
 ### Inspect
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -7,12 +7,14 @@ By default, each `enclave` invocation starts or resumes a session for the curren
 ```bash
 enclave --name my-task           # Named persistent session
 enclave --background             # Detached background session
-enclave attach <container>       # Attach to a background session
+enclave attach my-task           # Attach by session name (or container name)
 enclave continue                 # Continue the latest session
 enclave resume                   # Session picker (falls back to continue)
 ```
 
 If a container name is already in use, a new session starts with a unique name. Use `exec` to attach to the default container name.
+
+Containers are named `enclave-<tool>-<project-hash>-<session>`, so the same session name can be used in several projects. `attach`, `stop <name>`, and `theia` resolve a session name within the current project first; when a name matches containers in more than one project, the candidates are listed and a full container name must be passed.
 
 ## Managing Running Containers
 
@@ -22,6 +24,7 @@ enclave exec --admin             # Attach with limited sudo (apt/dpkg)
 enclave shell                    # Interactive shell in container
 enclave shell --admin            # Shell with limited sudo
 enclave stop                     # Stop background containers
+enclave stop my-task             # Stop one session by name
 ```
 
 Sudo is disabled by default. The `--admin` flag grants limited package-management sudo (apt/dpkg only). Security settings are fixed at container start — `exec` attaches to the existing container as-is.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -14,7 +14,7 @@ enclave resume                   # Session picker (falls back to continue)
 
 If a container name is already in use, a new session starts with a unique name. Use `exec` to attach to the default container name.
 
-Containers are named `enclave-<tool>-<project-hash>-<session>`, so the same session name can be used in several projects. `attach`, `stop <name>`, and `theia` resolve a session name within the current project first; when a name matches containers in more than one project, the candidates are listed and a full container name must be passed.
+Containers are named `enclave-<tool>-<project-hash>-<session>`, so the same session name can be used in several projects. `attach`, `stop <name>`, and `theia` resolve a session name within the current project first; when a name matches containers in more than one project, the candidates are listed and a full container name must be passed. `attach` and `theia` also accept a name that only exists in another project; `stop` does not, since removing a container is destructive — pass its container name instead.
 
 ## Managing Running Containers
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -14,7 +14,7 @@ enclave resume                   # Session picker (falls back to continue)
 
 If a container name is already in use, a new session starts with a unique name. Use `exec` to attach to the default container name.
 
-Containers are named `enclave-<tool>-<project-hash>-<session>`, so the same session name can be used in several projects. `attach`, `stop <name>`, and `theia` resolve a session name within the current project first; when a name matches containers in more than one project, the candidates are listed and a full container name must be passed. `attach` and `theia` also accept a name that only exists in another project; `stop` does not, since removing a container is destructive — pass its container name instead.
+Containers are named `enclave-<tool>-<project-hash>-<session>`, so the same session name can be used in several projects. `attach`, `stop <name>`, and `theia` resolve a session name within the current project first; when a name matches containers in more than one project, the candidates are listed and a full container name must be passed. `attach` and `theia` also accept a name that only exists in another project; `stop` does not — neither by argument nor by `--name` — since removing a container is destructive: pass its container name instead.
 
 ## Managing Running Containers
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -102,11 +102,11 @@ func Run(args []string) int {
 	}
 
 	if parsed.Action == "stop" {
-		return runStop(parsed.Options.RunOptions)
+		return runStop(parsed.Options, projectDir)
 	}
 
 	if parsed.Action == "attach" {
-		return runAttach(parsed.Options.RunOptions)
+		return runAttach(parsed.Options, projectDir)
 	}
 
 	if parsed.Action == "review-target" {

--- a/internal/app/command_attach.go
+++ b/internal/app/command_attach.go
@@ -22,13 +22,15 @@ func runAttach(opts model.Options, projectDir string) int {
 	}
 
 	run := opts.RunOptions
-	requested := ""
-	if len(run.CmdArgs) > 0 {
-		requested = run.CmdArgs[0]
-	}
+	// The CLI puts the detach keys first, so that the optional session argument
+	// keeps its "not given" state.
 	detachKeys := model.DetachKeysDefault
-	if len(run.CmdArgs) > 1 && run.CmdArgs[1] != "" {
-		detachKeys = run.CmdArgs[1]
+	args := run.CmdArgs
+	if len(args) > 0 {
+		if keys := strings.TrimSpace(args[0]); keys != "" {
+			detachKeys = keys
+		}
+		args = args[1:]
 	}
 
 	be, err := selectBackend(opts, dockerBackendOptions(model.Host{}, model.Paths{}, model.BuildOptions{}, run))
@@ -38,12 +40,12 @@ func runAttach(opts model.Options, projectDir string) int {
 	}
 	ctx := context.Background()
 	session, err := resolveSessionTarget(ctx, be, sessionTargetQuery{
-		Requested: requested,
-		Tool:      sessionTargetTool(opts),
-		Project:   sessionTargetProject(projectDir),
+		Args:    args,
+		Tool:    sessionTargetTool(opts),
+		Project: sessionTargetProject(projectDir),
 		// Without a name, only detached sessions are picked: sharing the TTY of
 		// a foreground session means two terminals fighting over its stdin.
-		BackgroundOnly: strings.TrimSpace(requested) == "",
+		BackgroundOnly: len(args) == 0,
 	})
 	if err != nil {
 		logx.Errorf("%v", err)

--- a/internal/app/command_attach.go
+++ b/internal/app/command_attach.go
@@ -9,6 +9,7 @@ package app
 
 import (
 	"context"
+	"strings"
 
 	"enclave/internal/backend"
 	"enclave/internal/logx"
@@ -40,6 +41,9 @@ func runAttach(opts model.Options, projectDir string) int {
 		Requested: requested,
 		Tool:      sessionTargetTool(opts),
 		Project:   sessionTargetProject(projectDir),
+		// Without a name, only detached sessions are picked: sharing the TTY of
+		// a foreground session means two terminals fighting over its stdin.
+		BackgroundOnly: strings.TrimSpace(requested) == "",
 	})
 	if err != nil {
 		logx.Errorf("%v", err)

--- a/internal/app/command_attach.go
+++ b/internal/app/command_attach.go
@@ -15,23 +15,37 @@ import (
 	"enclave/internal/model"
 )
 
-func runAttach(run model.RunOptions) int {
+func runAttach(opts model.Options, projectDir string) int {
 	if code := requireDocker(); code != 0 {
 		return code
 	}
 
-	containerName := run.CmdArgs[0]
+	run := opts.RunOptions
+	requested := ""
+	if len(run.CmdArgs) > 0 {
+		requested = run.CmdArgs[0]
+	}
 	detachKeys := model.DetachKeysDefault
 	if len(run.CmdArgs) > 1 && run.CmdArgs[1] != "" {
 		detachKeys = run.CmdArgs[1]
 	}
 
-	be, err := selectBackend(model.Options{RunOptions: run}, dockerBackendOptions(model.Host{}, model.Paths{}, model.BuildOptions{}, run))
+	be, err := selectBackend(opts, dockerBackendOptions(model.Host{}, model.Paths{}, model.BuildOptions{}, run))
 	if err != nil {
 		logx.Errorf("%v", err)
 		return 1
 	}
-	if err := be.Attach(context.Background(), backend.SessionRef{Name: containerName}, backend.AttachIO{DetachKeys: detachKeys}); err != nil {
+	ctx := context.Background()
+	session, err := resolveSessionTarget(ctx, be, sessionTargetQuery{
+		Requested: requested,
+		Tool:      sessionTargetTool(opts),
+		Project:   sessionTargetProject(projectDir),
+	})
+	if err != nil {
+		logx.Errorf("%v", err)
+		return 1
+	}
+	if err := be.Attach(ctx, session.Ref, backend.AttachIO{DetachKeys: detachKeys}); err != nil {
 		logx.Errorf("attach: %v", err)
 		return 1
 	}

--- a/internal/app/command_ps.go
+++ b/internal/app/command_ps.go
@@ -133,9 +133,12 @@ func psToolFilter(opts model.Options) string {
 	return ""
 }
 
+// psSessionFilter returns the session-name filter in its canonical form: the
+// session label carries the sanitized name, so `--name "My Task"` and `--name
+// my-task` must select the same sessions.
 func psSessionFilter(opts model.Options) string {
 	if opts.Sources.SessionName == model.SourceCLI {
-		return strings.TrimSpace(opts.SessionName)
+		return model.SanitizeSessionName(opts.SessionName)
 	}
 	return ""
 }
@@ -302,6 +305,16 @@ func renderPSJSON(w io.Writer, sessions []backend.Session) error {
 	return enc.Encode(entries)
 }
 
+// sessionNameDisplay renders the SESSION column: the name accepted by
+// `attach`/`stop`/`theia`, or a dash for the project's default container, which
+// has no session name and is reached with `exec` instead.
+func sessionNameDisplay(sessionName string) string {
+	if trimmed := strings.TrimSpace(sessionName); trimmed != "" {
+		return trimmed
+	}
+	return "-"
+}
+
 func directoryDisplayName(worktreePath string, projectHash string) string {
 	if worktreePath != "" {
 		clean := filepath.Clean(worktreePath)
@@ -345,12 +358,13 @@ func formatPSUptime(createdAt time.Time, now time.Time) string {
 
 func renderPSTable(w io.Writer, rows []psRow) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "NAME\tTOOL\tDIR\tSTATUS\tUPTIME\tPORTS"); err != nil {
+	if _, err := fmt.Fprintln(tw, "NAME\tSESSION\tTOOL\tDIR\tSTATUS\tUPTIME\tPORTS"); err != nil {
 		return err
 	}
 	for _, row := range rows {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			row.Name,
+			sessionNameDisplay(row.SessionName),
 			row.Tool,
 			row.Directory,
 			row.Status,

--- a/internal/app/command_ps.go
+++ b/internal/app/command_ps.go
@@ -110,14 +110,22 @@ func listPSSessions(ctx context.Context, opts model.Options) ([]backend.Session,
 	if err != nil {
 		return nil, err
 	}
-	return be.List(ctx, psSessionFilterFor(opts))
+	sessions, err := be.List(ctx, psSessionFilterFor(opts))
+	if err != nil {
+		return nil, err
+	}
+	if name := psSessionFilter(opts); name != "" {
+		sessions = sessionsMatchingName(sessions, name)
+	}
+	return sessions, nil
 }
 
 // psSessionFilterFor builds the backend listing filter from the parsed ps
 // options. By default only running containers are listed; --all includes
-// stopped ones as well.
+// stopped ones as well. The session name is not part of it: names are matched
+// in sanitized form, which the backend cannot express as a label filter.
 func psSessionFilterFor(opts model.Options) backend.SessionFilter {
-	filter := backend.SessionFilter{Tool: psToolFilter(opts), SessionName: psSessionFilter(opts)}
+	filter := backend.SessionFilter{Tool: psToolFilter(opts)}
 	if opts.PSAll {
 		filter.All = true
 	} else {
@@ -133,12 +141,11 @@ func psToolFilter(opts model.Options) string {
 	return ""
 }
 
-// psSessionFilter returns the session-name filter in its canonical form: the
-// session label carries the sanitized name, so `--name "My Task"` and `--name
-// my-task` must select the same sessions.
+// psSessionFilter returns the raw `--name` value, if any. Matching sanitizes
+// it together with the recorded session names, so it is passed through here.
 func psSessionFilter(opts model.Options) string {
 	if opts.Sources.SessionName == model.SourceCLI {
-		return model.SanitizeSessionName(opts.SessionName)
+		return strings.TrimSpace(opts.SessionName)
 	}
 	return ""
 }

--- a/internal/app/command_ps.go
+++ b/internal/app/command_ps.go
@@ -114,7 +114,7 @@ func listPSSessions(ctx context.Context, opts model.Options) ([]backend.Session,
 	if err != nil {
 		return nil, err
 	}
-	if name := psSessionFilter(opts); name != "" {
+	if name, given := sessionNameFilter(opts); given {
 		sessions = sessionsMatchingName(sessions, name)
 	}
 	return sessions, nil
@@ -137,15 +137,6 @@ func psSessionFilterFor(opts model.Options) backend.SessionFilter {
 func psToolFilter(opts model.Options) string {
 	if opts.Sources.Tool == model.SourceCLI {
 		return strings.TrimSpace(opts.Tool)
-	}
-	return ""
-}
-
-// psSessionFilter returns the raw `--name` value, if any. Matching sanitizes
-// it together with the recorded session names, so it is passed through here.
-func psSessionFilter(opts model.Options) string {
-	if opts.Sources.SessionName == model.SourceCLI {
-		return strings.TrimSpace(opts.SessionName)
 	}
 	return ""
 }

--- a/internal/app/command_ps_test.go
+++ b/internal/app/command_ps_test.go
@@ -299,8 +299,41 @@ func TestRunPSPrintsTable(t *testing.T) {
 	if !strings.Contains(out, "http://localhost:3000") {
 		t.Fatalf("expected rendered open_url in output, got:\n%s", out)
 	}
-	if strings.Contains(out, "SESSION") {
-		t.Fatalf("did not expect session header in output, got:\n%s", out)
+	if !strings.Contains(out, "SESSION") {
+		t.Fatalf("expected session header in output, got:\n%s", out)
+	}
+}
+
+func TestRunPSShowsDashForSessionlessContainer(t *testing.T) {
+	psCheckDocker = func() error { return nil }
+	psNow = func() time.Time {
+		return time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC)
+	}
+	psSessionList = func(context.Context, model.Options) ([]backend.Session, error) {
+		return []backend.Session{{
+			Ref:         backend.SessionRef{Name: "enclave-codex-abc123abc123"},
+			Tool:        "codex",
+			ProjectHash: "abc123abc123",
+			Worktree:    "/tmp/project-alpha",
+			Status:      "running",
+		}}, nil
+	}
+	psDeclaredPorts = func(string) []model.PortConfig { return nil }
+	t.Cleanup(func() {
+		psCheckDocker = checkDocker
+		psSessionList = listPSSessions
+		psNow = time.Now
+		psDeclaredPorts = declaredPublishedPorts
+	})
+
+	out := captureStdout(t, func() {
+		if code := runPS(model.Options{}); code != 0 {
+			t.Fatalf("runPS() returned %d", code)
+		}
+	})
+
+	if !strings.Contains(out, "enclave-codex-abc123abc123  -") {
+		t.Fatalf("expected a dash in the session column, got:\n%s", out)
 	}
 }
 

--- a/internal/app/command_ps_test.go
+++ b/internal/app/command_ps_test.go
@@ -182,8 +182,8 @@ func TestPSToolAndSessionFiltersOnlyUseExplicitCLIState(t *testing.T) {
 	if got := psToolFilter(defaults); got != "" {
 		t.Fatalf("expected default tool not to filter, got %q", got)
 	}
-	if got := psSessionFilter(defaults); got != "" {
-		t.Fatalf("expected default session not to filter, got %q", got)
+	if name, given := sessionNameFilter(defaults); given || name != "" {
+		t.Fatalf("expected default session not to filter, got %q (given %v)", name, given)
 	}
 
 	explicit := model.Options{
@@ -196,8 +196,14 @@ func TestPSToolAndSessionFiltersOnlyUseExplicitCLIState(t *testing.T) {
 	if got := psToolFilter(explicit); got != "codex" {
 		t.Fatalf("expected explicit tool filter codex, got %q", got)
 	}
-	if got := psSessionFilter(explicit); got != "main" {
-		t.Fatalf("expected explicit session filter main, got %q", got)
+	if name, given := sessionNameFilter(explicit); !given || name != "main" {
+		t.Fatalf("expected explicit session filter main, got %q (given %v)", name, given)
+	}
+
+	blank := explicit
+	blank.SessionName = "  "
+	if name, given := sessionNameFilter(blank); !given || name != "" {
+		t.Fatalf("expected an explicitly blank --name to count as given, got %q (given %v)", name, given)
 	}
 }
 

--- a/internal/app/command_status.go
+++ b/internal/app/command_status.go
@@ -101,7 +101,7 @@ func runStatus(opts model.Options) int {
 		logx.Errorf("list sessions: %v", err)
 		return 1
 	}
-	if name := psSessionFilter(opts); name != "" {
+	if name, given := sessionNameFilter(opts); given {
 		sessions = sessionsMatchingName(sessions, name)
 	}
 

--- a/internal/app/command_status.go
+++ b/internal/app/command_status.go
@@ -95,12 +95,14 @@ func runStatus(opts model.Options) int {
 	sessions, err := be.List(ctx, backend.SessionFilter{
 		RunningOnly: true,
 		Tool:        psToolFilter(opts),
-		SessionName: psSessionFilter(opts),
 		ProjectHash: projectHash,
 	})
 	if err != nil {
 		logx.Errorf("list sessions: %v", err)
 		return 1
+	}
+	if name := psSessionFilter(opts); name != "" {
+		sessions = sessionsMatchingName(sessions, name)
 	}
 
 	snapshots := collectSnapshots(ctx, execer, sessions, model.DefaultStatusLines, statusNow)

--- a/internal/app/command_stop.go
+++ b/internal/app/command_stop.go
@@ -9,7 +9,6 @@ package app
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"enclave/internal/backend"
@@ -40,12 +39,22 @@ func runStop(opts model.Options, projectDir string) int {
 		return 1
 	}
 
-	if len(run.CmdArgs) > 0 && run.CmdArgs[0] != "" {
-		session, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
-			Requested:      run.CmdArgs[0],
-			Tool:           sessionTargetTool(opts),
-			Project:        sessionTargetProject(projectDir),
-			IncludeStopped: true,
+	return stopSessions(context.Background(), be, opts, projectDir)
+}
+
+// stopSessions removes the containers a `stop` invocation selects: the single
+// session named by the positional argument, or every background session of the
+// tool, narrowed by `--name` when that flag was given.
+func stopSessions(ctx context.Context, be backend.Backend, opts model.Options, projectDir string) int {
+	run := opts.RunOptions
+
+	if len(run.CmdArgs) > 0 {
+		session, err := resolveSessionTarget(ctx, be, sessionTargetQuery{
+			Args:               run.CmdArgs,
+			Tool:               sessionTargetTool(opts),
+			Project:            sessionTargetProject(projectDir),
+			IncludeStopped:     true,
+			ProjectScopedNames: true,
 		})
 		if err != nil {
 			logx.Errorf("%v", err)
@@ -56,14 +65,14 @@ func runStop(opts model.Options, projectDir string) int {
 	}
 
 	background := true
-	sessions, err := be.List(context.Background(), backend.SessionFilter{All: true, Background: &background, Tool: run.Tool})
+	sessions, err := be.List(ctx, backend.SessionFilter{All: true, Background: &background, Tool: run.Tool})
 	if err != nil {
 		logx.Errorf("Failed to list background sessions: %v", err)
 		return 1
 	}
 	// Sanitized matching happens here rather than as a label filter, so that a
 	// name which sanitizes to nothing stops nothing instead of everything.
-	if name := strings.TrimSpace(run.SessionName); name != "" {
+	if name, given := sessionNameFilter(opts); given {
 		sessions = sessionsMatchingName(sessions, name)
 	}
 

--- a/internal/app/command_stop.go
+++ b/internal/app/command_stop.go
@@ -9,6 +9,7 @@ package app
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"enclave/internal/backend"
@@ -55,10 +56,15 @@ func runStop(opts model.Options, projectDir string) int {
 	}
 
 	background := true
-	sessions, err := be.List(context.Background(), backend.SessionFilter{All: true, Background: &background, Tool: run.Tool, SessionName: model.SanitizeSessionName(run.SessionName)})
+	sessions, err := be.List(context.Background(), backend.SessionFilter{All: true, Background: &background, Tool: run.Tool})
 	if err != nil {
 		logx.Errorf("Failed to list background sessions: %v", err)
 		return 1
+	}
+	// Sanitized matching happens here rather than as a label filter, so that a
+	// name which sanitizes to nothing stops nothing instead of everything.
+	if name := strings.TrimSpace(run.SessionName); name != "" {
+		sessions = sessionsMatchingName(sessions, name)
 	}
 
 	if len(sessions) == 0 {

--- a/internal/app/command_stop.go
+++ b/internal/app/command_stop.go
@@ -44,7 +44,8 @@ func runStop(opts model.Options, projectDir string) int {
 
 // stopSessions removes the containers a `stop` invocation selects: the single
 // session named by the positional argument, or every background session of the
-// tool, narrowed by `--name` when that flag was given.
+// tool, narrowed to the current project's matching sessions when `--name` was
+// given.
 func stopSessions(ctx context.Context, be backend.Backend, opts model.Options, projectDir string) int {
 	run := opts.RunOptions
 
@@ -71,9 +72,12 @@ func stopSessions(ctx context.Context, be backend.Backend, opts model.Options, p
 		return 1
 	}
 	// Sanitized matching happens here rather than as a label filter, so that a
-	// name which sanitizes to nothing stops nothing instead of everything.
+	// name which sanitizes to nothing stops nothing instead of everything. Like
+	// the positional form, `--name` stays inside the current project: session
+	// names are project-relative and collide across projects.
 	if name, given := sessionNameFilter(opts); given {
-		sessions = sessionsMatchingName(sessions, name)
+		project := sessionTargetProject(projectDir)
+		sessions = sessionsMatchingName(projectHashSessions(sessions, project.Hash), name)
 	}
 
 	if len(sessions) == 0 {

--- a/internal/app/command_stop.go
+++ b/internal/app/command_stop.go
@@ -17,10 +17,12 @@ import (
 	"enclave/internal/model"
 )
 
-func runStop(run model.RunOptions) int {
+func runStop(opts model.Options, projectDir string) int {
 	if code := requireDocker(); code != 0 {
 		return code
 	}
+
+	run := opts.RunOptions
 
 	host, hostErr := resolveHost()
 	if hostErr != nil {
@@ -31,19 +33,29 @@ func runStop(run model.RunOptions) int {
 		logx.Warnf("Failed to resolve auth finalization assets: %v", pathsErr)
 	}
 
-	be, err := selectBackend(model.Options{RunOptions: run}, dockerBackendOptions(host, paths, model.BuildOptions{}, run))
+	be, err := selectBackend(opts, dockerBackendOptions(host, paths, model.BuildOptions{}, run))
 	if err != nil {
 		logx.Errorf("%v", err)
 		return 1
 	}
 
 	if len(run.CmdArgs) > 0 && run.CmdArgs[0] != "" {
-		stopContainer(be, run.CmdArgs[0])
+		session, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+			Requested:      run.CmdArgs[0],
+			Tool:           sessionTargetTool(opts),
+			Project:        sessionTargetProject(projectDir),
+			IncludeStopped: true,
+		})
+		if err != nil {
+			logx.Errorf("%v", err)
+			return 1
+		}
+		stopContainer(be, session.Ref.Name)
 		return 0
 	}
 
 	background := true
-	sessions, err := be.List(context.Background(), backend.SessionFilter{All: true, Background: &background, Tool: run.Tool, SessionName: run.SessionName})
+	sessions, err := be.List(context.Background(), backend.SessionFilter{All: true, Background: &background, Tool: run.Tool, SessionName: model.SanitizeSessionName(run.SessionName)})
 	if err != nil {
 		logx.Errorf("Failed to list background sessions: %v", err)
 		return 1

--- a/internal/app/command_stop_test.go
+++ b/internal/app/command_stop_test.go
@@ -40,6 +40,8 @@ type stopTestBackend struct {
 	stopOpts           backend.StopOptions
 	forceRemoveCalled  bool
 	strictRemoveCalled bool
+	sessions           []backend.Session
+	listFilter         backend.SessionFilter
 }
 
 func (b *stopTestBackend) Name() string { return "test" }
@@ -61,8 +63,9 @@ func (b *stopTestBackend) Run(context.Context, backend.Request, backend.AttachIO
 func (b *stopTestBackend) Start(context.Context, backend.Request) (backend.SessionRef, error) {
 	return backend.SessionRef{}, nil
 }
-func (b *stopTestBackend) List(context.Context, backend.SessionFilter) ([]backend.Session, error) {
-	return nil, nil
+func (b *stopTestBackend) List(_ context.Context, filter backend.SessionFilter) ([]backend.Session, error) {
+	b.listFilter = filter
+	return b.sessions, nil
 }
 func (b *stopTestBackend) Inspect(context.Context, backend.SessionRef) (*backend.Session, error) {
 	return nil, nil

--- a/internal/app/command_stop_test.go
+++ b/internal/app/command_stop_test.go
@@ -10,9 +10,11 @@ package app
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"enclave/internal/backend"
+	"enclave/internal/model"
 )
 
 func TestStopContainerFinalizesThenForceRemovesOnFinalizeError(t *testing.T) {
@@ -34,10 +36,75 @@ func TestStopContainerFinalizesThenForceRemovesOnFinalizeError(t *testing.T) {
 	}
 }
 
+func TestStopSessionsRequiresANameToStopSomething(t *testing.T) {
+	sessions := []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+		session("enclave-claude-aaaaaaaaaaaa-other", "other", "aaaaaaaaaaaa", "/repo/a"),
+	}
+	tests := []struct {
+		name     string
+		opts     model.Options
+		sessions []backend.Session
+		code     int
+		stopped  []string
+	}{
+		{
+			name:     "blank --name stops nothing",
+			opts:     stopOptionsWithName("   "),
+			sessions: sessions,
+		},
+		{
+			name:     "unsanitizable --name stops nothing",
+			opts:     stopOptionsWithName("???"),
+			sessions: sessions,
+		},
+		{
+			// The single session would be auto-selected if the blank argument were
+			// read as "no argument".
+			name:     "blank positional argument is rejected",
+			opts:     stopOptionsWithArg("   "),
+			sessions: sessions[:1],
+			code:     1,
+		},
+		{
+			name:     "no filter stops every background session",
+			opts:     model.Options{Sources: model.DefaultOptionSources()},
+			sessions: sessions,
+			stopped:  []string{sessions[0].Ref.Name, sessions[1].Ref.Name},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			be := &stopTestBackend{sessions: tt.sessions}
+			if code := stopSessions(context.Background(), be, tt.opts, ""); code != tt.code {
+				t.Fatalf("stopSessions() = %d, want %d", code, tt.code)
+			}
+			if !slices.Equal(be.stopped, tt.stopped) {
+				t.Fatalf("stopped %v, want %v", be.stopped, tt.stopped)
+			}
+		})
+	}
+}
+
+func stopOptionsWithName(sessionName string) model.Options {
+	opts := model.Options{Sources: model.DefaultOptionSources()}
+	opts.SessionName = sessionName
+	opts.Sources.SessionName = model.SourceCLI
+	return opts
+}
+
+func stopOptionsWithArg(arg string) model.Options {
+	opts := model.Options{Sources: model.DefaultOptionSources()}
+	opts.CmdArgs = []string{arg}
+	return opts
+}
+
 type stopTestBackend struct {
 	stopErr            error
 	stopCalled         bool
 	stopOpts           backend.StopOptions
+	stopped            []string
 	forceRemoveCalled  bool
 	strictRemoveCalled bool
 	sessions           []backend.Session
@@ -73,9 +140,10 @@ func (b *stopTestBackend) Inspect(context.Context, backend.SessionRef) (*backend
 func (b *stopTestBackend) Attach(context.Context, backend.SessionRef, backend.AttachIO) error {
 	return nil
 }
-func (b *stopTestBackend) Stop(_ context.Context, _ backend.SessionRef, opts backend.StopOptions) error {
+func (b *stopTestBackend) Stop(_ context.Context, ref backend.SessionRef, opts backend.StopOptions) error {
 	b.stopCalled = true
 	b.stopOpts = opts
+	b.stopped = append(b.stopped, ref.Name)
 	return b.stopErr
 }
 func (b *stopTestBackend) Remove(context.Context, backend.SessionRef) error {

--- a/internal/app/command_stop_test.go
+++ b/internal/app/command_stop_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"enclave/internal/backend"
+	"enclave/internal/config"
 	"enclave/internal/model"
 )
 
@@ -36,11 +37,16 @@ func TestStopContainerFinalizesThenForceRemovesOnFinalizeError(t *testing.T) {
 	}
 }
 
-func TestStopSessionsRequiresANameToStopSomething(t *testing.T) {
-	sessions := []backend.Session{
-		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
-		session("enclave-claude-aaaaaaaaaaaa-other", "other", "aaaaaaaaaaaa", "/repo/a"),
+func TestStopSessionsSelection(t *testing.T) {
+	projectDir := t.TempDir()
+	project, err := config.ResolveProjectFromDir(projectDir)
+	if err != nil {
+		t.Fatalf("ResolveProjectFromDir() error = %v", err)
 	}
+	mine := session("enclave-claude-"+project.Hash+"-my-task", "my-task", project.Hash, projectDir)
+	other := session("enclave-claude-"+project.Hash+"-other", "other", project.Hash, projectDir)
+	foreign := session("enclave-claude-bbbbbbbbbbbb-my-task", "my-task", "bbbbbbbbbbbb", "/repo/b")
+
 	tests := []struct {
 		name     string
 		opts     model.Options
@@ -49,35 +55,46 @@ func TestStopSessionsRequiresANameToStopSomething(t *testing.T) {
 		stopped  []string
 	}{
 		{
+			name:     "--name stops the matching session",
+			opts:     stopOptionsWithName("my-task"),
+			sessions: []backend.Session{mine, other},
+			stopped:  []string{mine.Ref.Name},
+		},
+		{
+			name:     "--name does not leave the project",
+			opts:     stopOptionsWithName("my-task"),
+			sessions: []backend.Session{foreign},
+		},
+		{
 			name:     "blank --name stops nothing",
 			opts:     stopOptionsWithName("   "),
-			sessions: sessions,
+			sessions: []backend.Session{mine, other},
 		},
 		{
 			name:     "unsanitizable --name stops nothing",
 			opts:     stopOptionsWithName("???"),
-			sessions: sessions,
+			sessions: []backend.Session{mine, other},
 		},
 		{
 			// The single session would be auto-selected if the blank argument were
 			// read as "no argument".
 			name:     "blank positional argument is rejected",
 			opts:     stopOptionsWithArg("   "),
-			sessions: sessions[:1],
+			sessions: []backend.Session{mine},
 			code:     1,
 		},
 		{
-			name:     "no filter stops every background session",
+			name:     "without --name every background session is stopped",
 			opts:     model.Options{Sources: model.DefaultOptionSources()},
-			sessions: sessions,
-			stopped:  []string{sessions[0].Ref.Name, sessions[1].Ref.Name},
+			sessions: []backend.Session{mine, foreign},
+			stopped:  []string{mine.Ref.Name, foreign.Ref.Name},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			be := &stopTestBackend{sessions: tt.sessions}
-			if code := stopSessions(context.Background(), be, tt.opts, ""); code != tt.code {
+			if code := stopSessions(context.Background(), be, tt.opts, projectDir); code != tt.code {
 				t.Fatalf("stopSessions() = %d, want %d", code, tt.code)
 			}
 			if !slices.Equal(be.stopped, tt.stopped) {

--- a/internal/app/command_theia.go
+++ b/internal/app/command_theia.go
@@ -9,11 +9,8 @@ package app
 
 import (
 	"context"
-	"fmt"
-	"sort"
 	"strings"
 
-	"enclave/internal/backend"
 	"enclave/internal/config"
 	"enclave/internal/logx"
 	"enclave/internal/model"
@@ -21,8 +18,8 @@ import (
 )
 
 // runTheia launches the host-installed Theia (or Theia-Next) IDE attached to
-// a running enclave container. The container name may be passed as the
-// single positional CLI argument; if omitted, the command auto-selects when
+// a running enclave container. The single positional CLI argument may be a
+// container name or a session name; if omitted, the command auto-selects when
 // exactly one managed container is running.
 func runTheia(variant theia.Variant, projectDir string, opts model.Options) int {
 	if !variant.Valid() {
@@ -47,11 +44,16 @@ func runTheia(variant theia.Variant, projectDir string, opts model.Options) int 
 		requested = strings.TrimSpace(opts.CmdArgs[0])
 	}
 
-	containerName, err := resolveTheiaContainer(ctx, be, requested)
+	session, err := resolveSessionTarget(ctx, be, sessionTargetQuery{
+		Requested: requested,
+		Tool:      sessionTargetTool(opts),
+		Project:   sessionTargetProject(projectDir),
+	})
 	if err != nil {
 		logx.Errorf("%v", err)
 		return 1
 	}
+	containerName := session.Ref.Name
 
 	home, err := config.ResolveHostHome()
 	if err != nil {
@@ -72,38 +74,4 @@ func runTheia(variant theia.Variant, projectDir string, opts model.Options) int 
 	}
 	logx.Infof("launched %s attached to %s (logs: %s)", variant, containerName, logPath)
 	return 0
-}
-
-func resolveTheiaContainer(ctx context.Context, be backend.Backend, requested string) (string, error) {
-	sessions, err := be.List(ctx, backend.SessionFilter{RunningOnly: true})
-	if err != nil {
-		return "", fmt.Errorf("list containers: %w", err)
-	}
-
-	names := make([]string, 0, len(sessions))
-	for _, s := range sessions {
-		if s.Ref.Name != "" {
-			names = append(names, s.Ref.Name)
-		}
-	}
-	sort.Strings(names)
-
-	if requested != "" {
-		for _, name := range names {
-			if name == requested {
-				return name, nil
-			}
-		}
-		return "", fmt.Errorf("no running enclave container named %q (use `enclave ps` to list)", requested)
-	}
-
-	switch len(names) {
-	case 0:
-		return "", fmt.Errorf("no running enclave containers (start one first)")
-	case 1:
-		return names[0], nil
-	default:
-		return "", fmt.Errorf("multiple running enclave containers; pass one explicitly:\n  %s",
-			strings.Join(names, "\n  "))
-	}
 }

--- a/internal/app/command_theia.go
+++ b/internal/app/command_theia.go
@@ -9,7 +9,6 @@ package app
 
 import (
 	"context"
-	"strings"
 
 	"enclave/internal/config"
 	"enclave/internal/logx"
@@ -39,15 +38,10 @@ func runTheia(variant theia.Variant, projectDir string, opts model.Options) int 
 		return 1
 	}
 
-	requested := ""
-	if len(opts.CmdArgs) > 0 {
-		requested = strings.TrimSpace(opts.CmdArgs[0])
-	}
-
 	session, err := resolveSessionTarget(ctx, be, sessionTargetQuery{
-		Requested: requested,
-		Tool:      sessionTargetTool(opts),
-		Project:   sessionTargetProject(projectDir),
+		Args:    opts.CmdArgs,
+		Tool:    sessionTargetTool(opts),
+		Project: sessionTargetProject(projectDir),
 	})
 	if err != nil {
 		logx.Errorf("%v", err)

--- a/internal/app/session_target.go
+++ b/internal/app/session_target.go
@@ -18,37 +18,48 @@ import (
 	"enclave/internal/model"
 )
 
+// containerIDMinPrefix is the shortest container-ID prefix accepted in place of
+// a name. Anything shorter is treated as a session name only, so that short
+// hex-looking session names keep working.
+const containerIDMinPrefix = 8
+
 // sessionTargetQuery describes how a positional container/session argument is
 // resolved to exactly one managed session.
 type sessionTargetQuery struct {
-	// Requested is the user-provided name: either a full container name or a
-	// session name as passed to `--name`. Empty means "auto-select".
+	// Requested is the user-provided name: a container name, a container ID, or
+	// a session name as passed to `--name`. Empty means "auto-select".
 	Requested string
-	// Tool restricts candidates to one tool. Only set it when the tool was
-	// chosen explicitly on the command line; the resolved default would
-	// otherwise hide sessions of other tools.
+	// Tool restricts session-name matches and auto-selection to one tool. Only
+	// set it when the tool was chosen explicitly on the command line; the
+	// resolved default would otherwise hide sessions of other tools.
 	Tool string
 	// Project is the project resolved from the working directory. Its sessions
-	// win over sessions of other projects that carry the same session name. A
-	// zero value disables the preference.
+	// win over sessions of other projects that carry the same session name, and
+	// auto-selection never leaves it. A zero value disables both.
 	Project model.Project
 	// IncludeStopped also considers stopped sessions (used by `stop`, which
 	// removes leftovers).
 	IncludeStopped bool
+	// BackgroundOnly restricts auto-selection to detached sessions, so that a
+	// bare `attach` cannot grab the TTY of a foreground session that a second
+	// terminal is already driving.
+	BackgroundOnly bool
 }
 
 // resolveSessionTarget resolves a positional container/session argument to one
-// running (or, with IncludeStopped, existing) session. A full container name
-// matches verbatim; anything else is treated as a session name and matched
-// against the sanitized session names of the candidates, preferring the
-// current project. Ambiguity is reported rather than guessed.
+// running (or, with IncludeStopped, existing) session. A container name or ID
+// matches verbatim; anything else is matched against the session names of the
+// candidates in sanitized form, preferring the current project. Ambiguity is
+// reported rather than guessed.
 func resolveSessionTarget(ctx context.Context, be backend.Backend, q sessionTargetQuery) (backend.Session, error) {
-	filter := backend.SessionFilter{Tool: strings.TrimSpace(q.Tool)}
+	filter := backend.SessionFilter{}
 	if q.IncludeStopped {
 		filter.All = true
 	} else {
 		filter.RunningOnly = true
 	}
+	// The tool is applied to the candidates below rather than to the listing:
+	// a container named or identified verbatim is resolved whatever its tool.
 	sessions, err := be.List(ctx, filter)
 	if err != nil {
 		return backend.Session{}, fmt.Errorf("list containers: %w", err)
@@ -56,7 +67,7 @@ func resolveSessionTarget(ctx context.Context, be backend.Backend, q sessionTarg
 
 	requested := strings.TrimSpace(q.Requested)
 	if requested == "" {
-		return selectSingleSession(scopeSessions(sessions, q.Project), sessions, "")
+		return autoSelectSession(sessions, q)
 	}
 
 	for _, session := range sessions {
@@ -70,19 +81,62 @@ func resolveSessionTarget(ctx context.Context, be backend.Backend, q sessionTarg
 		return backend.Session{}, fmt.Errorf("invalid session name %q", requested)
 	}
 	var matches []backend.Session
-	for _, session := range sessions {
+	for _, session := range sessionsForTool(sessions, q.Tool) {
 		if model.SanitizeSessionName(session.Name) == wanted {
 			matches = append(matches, session)
 		}
 	}
-	return selectSingleSession(scopeSessions(matches, q.Project), matches, requested)
+	if len(matches) == 0 {
+		if session, ok := sessionByContainerID(sessions, requested); ok {
+			return session, nil
+		}
+		return backend.Session{}, fmt.Errorf("no enclave session named %q (use `%s ps` to list sessions)", requested, model.AppName)
+	}
+	scoped, _ := projectSessions(matches, q.Project)
+	return selectSingleSession(scoped, requested)
 }
 
-// scopeSessions narrows candidates to the current project: sessions started
-// from the very same worktree first, then any session of the project. It
-// returns the input unchanged when nothing matches, so that a name pointing at
-// another project still resolves when it is unambiguous.
-func scopeSessions(sessions []backend.Session, project model.Project) []backend.Session {
+// autoSelectSession resolves the no-argument form. Unlike an explicit name it
+// never leaves the current project: picking up another project's agent because
+// this one has no session would be a surprising place to land.
+func autoSelectSession(sessions []backend.Session, q sessionTargetQuery) (backend.Session, error) {
+	candidates := sessionsForTool(sessions, q.Tool)
+	if q.BackgroundOnly {
+		var background []backend.Session
+		for _, session := range candidates {
+			if session.Background {
+				background = append(background, session)
+			}
+		}
+		candidates = background
+	}
+	if strings.TrimSpace(q.Project.Hash) != "" {
+		scoped, ok := projectSessions(candidates, q.Project)
+		if !ok {
+			scoped = nil
+		}
+		candidates = scoped
+	}
+	switch len(candidates) {
+	case 1:
+		return candidates[0], nil
+	case 0:
+		if q.BackgroundOnly {
+			return backend.Session{}, fmt.Errorf("no running background session for this project; name one explicitly (`%s ps`) or enter a foreground session with `%s exec`",
+				model.AppName, model.AppName)
+		}
+		return backend.Session{}, fmt.Errorf("no running enclave containers for this project (start one first)")
+	default:
+		return backend.Session{}, fmt.Errorf("multiple running enclave containers; pass one of these container names explicitly:\n  %s",
+			strings.Join(describeSessions(candidates), "\n  "))
+	}
+}
+
+// projectSessions narrows candidates to the current project: sessions started
+// from the very same worktree first, then any session of the project. ok
+// reports whether the project matched anything, so that callers can decide
+// between falling back to all candidates and reporting nothing.
+func projectSessions(sessions []backend.Session, project model.Project) (scoped []backend.Session, ok bool) {
 	worktree := strings.TrimSpace(project.Dir)
 	realDir := strings.TrimSpace(project.RealDir)
 	if worktree != "" || realDir != "" {
@@ -97,7 +151,7 @@ func scopeSessions(sessions []backend.Session, project model.Project) []backend.
 			}
 		}
 		if len(sameWorktree) > 0 {
-			return sameWorktree
+			return sameWorktree, true
 		}
 	}
 	if hash := strings.TrimSpace(project.Hash); hash != "" {
@@ -108,31 +162,65 @@ func scopeSessions(sessions []backend.Session, project model.Project) []backend.
 			}
 		}
 		if len(sameProject) > 0 {
-			return sameProject
+			return sameProject, true
 		}
 	}
-	return sessions
+	return sessions, false
 }
 
-// selectSingleSession picks the only candidate, or explains what to pass
-// instead. all is the unscoped candidate set, used to point at the sessions of
-// other projects that the scoping ruled out.
-func selectSingleSession(scoped []backend.Session, all []backend.Session, requested string) (backend.Session, error) {
-	switch len(scoped) {
-	case 1:
-		return scoped[0], nil
-	case 0:
-		if requested == "" {
-			return backend.Session{}, fmt.Errorf("no running enclave containers (start one first)")
+func sessionsForTool(sessions []backend.Session, tool string) []backend.Session {
+	tool = strings.TrimSpace(tool)
+	if tool == "" {
+		return sessions
+	}
+	var matches []backend.Session
+	for _, session := range sessions {
+		if strings.EqualFold(strings.TrimSpace(session.Tool), tool) {
+			matches = append(matches, session)
 		}
+	}
+	return matches
+}
+
+// sessionByContainerID resolves a container ID (or a prefix of one, as printed
+// by `docker ps`), which `attach` and `stop` accepted before names were
+// resolved. Session names win, so this only runs when none matched.
+func sessionByContainerID(sessions []backend.Session, requested string) (backend.Session, bool) {
+	if len(requested) < containerIDMinPrefix || !isHexString(requested) {
+		return backend.Session{}, false
+	}
+	for _, session := range sessions {
+		id := strings.TrimSpace(session.Ref.ID)
+		if id == "" {
+			continue
+		}
+		// Session IDs are truncated, so a full ID pasted from docker is a
+		// superstring of the one recorded here.
+		if strings.HasPrefix(id, requested) || strings.HasPrefix(requested, id) {
+			return session, true
+		}
+	}
+	return backend.Session{}, false
+}
+
+func isHexString(value string) bool {
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func selectSingleSession(matches []backend.Session, requested string) (backend.Session, error) {
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
 		return backend.Session{}, fmt.Errorf("no enclave session named %q (use `%s ps` to list sessions)", requested, model.AppName)
 	default:
-		subject := "multiple running enclave containers"
-		if requested != "" {
-			subject = fmt.Sprintf("session name %q matches multiple containers", requested)
-		}
-		return backend.Session{}, fmt.Errorf("%s; pass one of these container names explicitly:\n  %s",
-			subject, strings.Join(describeSessions(scoped), "\n  "))
+		return backend.Session{}, fmt.Errorf("session name %q matches multiple containers; pass one of these container names explicitly:\n  %s",
+			requested, strings.Join(describeSessions(matches), "\n  "))
 	}
 }
 
@@ -144,6 +232,24 @@ func describeSessions(sessions []backend.Session) []string {
 	}
 	sort.Strings(described)
 	return described
+}
+
+// sessionsMatchingName filters sessions by a user-provided `--name` value.
+// Both sides are sanitized, so `--name "My Task"` and `--name my-task` select
+// the same sessions regardless of the form recorded in the session label. A
+// name that sanitizes to nothing matches nothing, never everything.
+func sessionsMatchingName(sessions []backend.Session, requested string) []backend.Session {
+	wanted := model.SanitizeSessionName(requested)
+	if wanted == "" {
+		return nil
+	}
+	matches := make([]backend.Session, 0, len(sessions))
+	for _, session := range sessions {
+		if model.SanitizeSessionName(session.Name) == wanted {
+			matches = append(matches, session)
+		}
+	}
+	return matches
 }
 
 // sessionTargetTool returns the tool filter for session resolution: the tool

--- a/internal/app/session_target.go
+++ b/internal/app/session_target.go
@@ -23,12 +23,18 @@ import (
 // hex-looking session names keep working.
 const containerIDMinPrefix = 8
 
+// containerIDMaxLen is the length of a full container ID. Recorded IDs are
+// truncated, so a longer value is matched on its leading characters — but only
+// up to the length a real ID can have.
+const containerIDMaxLen = 64
+
 // sessionTargetQuery describes how a positional container/session argument is
 // resolved to exactly one managed session.
 type sessionTargetQuery struct {
-	// Requested is the user-provided name: a container name, a container ID, or
-	// a session name as passed to `--name`. Empty means "auto-select".
-	Requested string
+	// Args are the command's positional arguments. The first one selects the
+	// session: a container name, a container ID, or a session name as passed to
+	// `--name`. No argument at all means "auto-select".
+	Args []string
 	// Tool restricts session-name matches and auto-selection to one tool. Only
 	// set it when the tool was chosen explicitly on the command line; the
 	// resolved default would otherwise hide sessions of other tools.
@@ -40,6 +46,11 @@ type sessionTargetQuery struct {
 	// IncludeStopped also considers stopped sessions (used by `stop`, which
 	// removes leftovers).
 	IncludeStopped bool
+	// ProjectScopedNames rejects a session name that only matches outside the
+	// current project. `stop` sets it: removal is destructive and the
+	// auto-assigned names `1`, `2`, … collide across projects by construction,
+	// so another project's session needs its container name or ID.
+	ProjectScopedNames bool
 	// BackgroundOnly restricts auto-selection to detached sessions, so that a
 	// bare `attach` cannot grab the TTY of a foreground session that a second
 	// terminal is already driving.
@@ -49,9 +60,14 @@ type sessionTargetQuery struct {
 // resolveSessionTarget resolves a positional container/session argument to one
 // running (or, with IncludeStopped, existing) session. A container name or ID
 // matches verbatim; anything else is matched against the session names of the
-// candidates in sanitized form, preferring the current project. Ambiguity is
-// reported rather than guessed.
+// candidates in sanitized form, preferring (and with ProjectScopedNames
+// requiring) the current project. Ambiguity is reported rather than guessed.
 func resolveSessionTarget(ctx context.Context, be backend.Backend, q sessionTargetQuery) (backend.Session, error) {
+	requested, err := requestedSession(q.Args)
+	if err != nil {
+		return backend.Session{}, err
+	}
+
 	filter := backend.SessionFilter{}
 	if q.IncludeStopped {
 		filter.All = true
@@ -65,7 +81,6 @@ func resolveSessionTarget(ctx context.Context, be backend.Backend, q sessionTarg
 		return backend.Session{}, fmt.Errorf("list containers: %w", err)
 	}
 
-	requested := strings.TrimSpace(q.Requested)
 	if requested == "" {
 		return autoSelectSession(sessions, q)
 	}
@@ -87,13 +102,32 @@ func resolveSessionTarget(ctx context.Context, be backend.Backend, q sessionTarg
 		}
 	}
 	if len(matches) == 0 {
-		if session, ok := sessionByContainerID(sessions, requested); ok {
-			return session, nil
+		if byID := sessionsByContainerID(sessions, requested); len(byID) > 0 {
+			return selectSingleSession(byID, "container ID", requested)
 		}
 		return backend.Session{}, fmt.Errorf("no enclave session named %q (use `%s ps` to list sessions)", requested, model.AppName)
 	}
-	scoped, _ := projectSessions(matches, q.Project)
-	return selectSingleSession(scoped, requested)
+	scoped, inProject := projectSessions(matches, q.Project)
+	if q.ProjectScopedNames && !inProject {
+		return backend.Session{}, fmt.Errorf("no enclave session named %q in this project; pass a container name or ID from `%s ps` to reach a session of another project",
+			requested, model.AppName)
+	}
+	return selectSingleSession(scoped, "session name", requested)
+}
+
+// requestedSession picks the session argument out of a command's positional
+// arguments. An argument that is present but blank is rejected rather than
+// treated as "auto-select", so an unset variable in `enclave stop "$SESSION"`
+// cannot remove a session nobody named.
+func requestedSession(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", nil
+	}
+	requested := strings.TrimSpace(args[0])
+	if requested == "" {
+		return "", fmt.Errorf("empty session name; pass a session or container name from `%s ps`", model.AppName)
+	}
+	return requested, nil
 }
 
 // autoSelectSession resolves the no-argument form. Unlike an explicit name it
@@ -182,25 +216,28 @@ func sessionsForTool(sessions []backend.Session, tool string) []backend.Session 
 	return matches
 }
 
-// sessionByContainerID resolves a container ID (or a prefix of one, as printed
-// by `docker ps`), which `attach` and `stop` accepted before names were
-// resolved. Session names win, so this only runs when none matched.
-func sessionByContainerID(sessions []backend.Session, requested string) (backend.Session, bool) {
-	if len(requested) < containerIDMinPrefix || !isHexString(requested) {
-		return backend.Session{}, false
+// sessionsByContainerID collects the sessions matching a container ID (or a
+// prefix of one, as printed by `docker ps`), which `attach` and `stop` accepted
+// before names were resolved. Session names win, so this only runs when none
+// matched. All matches are returned so that an ambiguous prefix is reported
+// instead of resolved by listing order.
+func sessionsByContainerID(sessions []backend.Session, requested string) []backend.Session {
+	if len(requested) < containerIDMinPrefix || len(requested) > containerIDMaxLen || !isHexString(requested) {
+		return nil
 	}
+	var matches []backend.Session
 	for _, session := range sessions {
 		id := strings.TrimSpace(session.Ref.ID)
 		if id == "" {
 			continue
 		}
-		// Session IDs are truncated, so a full ID pasted from docker is a
-		// superstring of the one recorded here.
+		// Session IDs are truncated, so a full ID pasted from docker carries the
+		// one recorded here as its prefix.
 		if strings.HasPrefix(id, requested) || strings.HasPrefix(requested, id) {
-			return session, true
+			matches = append(matches, session)
 		}
 	}
-	return backend.Session{}, false
+	return matches
 }
 
 func isHexString(value string) bool {
@@ -212,15 +249,15 @@ func isHexString(value string) bool {
 	return value != ""
 }
 
-func selectSingleSession(matches []backend.Session, requested string) (backend.Session, error) {
+func selectSingleSession(matches []backend.Session, kind string, requested string) (backend.Session, error) {
 	switch len(matches) {
 	case 1:
 		return matches[0], nil
 	case 0:
 		return backend.Session{}, fmt.Errorf("no enclave session named %q (use `%s ps` to list sessions)", requested, model.AppName)
 	default:
-		return backend.Session{}, fmt.Errorf("session name %q matches multiple containers; pass one of these container names explicitly:\n  %s",
-			requested, strings.Join(describeSessions(matches), "\n  "))
+		return backend.Session{}, fmt.Errorf("%s %q matches multiple containers; pass one of these container names explicitly:\n  %s",
+			kind, requested, strings.Join(describeSessions(matches), "\n  "))
 	}
 }
 
@@ -250,6 +287,17 @@ func sessionsMatchingName(sessions []backend.Session, requested string) []backen
 		}
 	}
 	return matches
+}
+
+// sessionNameFilter returns the `--name` value of a listing or stop command.
+// given separates an omitted flag from an explicitly blank one: the latter has
+// to match nothing rather than everything. The value is passed through raw,
+// since matching sanitizes it together with the recorded session names.
+func sessionNameFilter(opts model.Options) (name string, given bool) {
+	if opts.Sources.SessionName != model.SourceCLI {
+		return "", false
+	}
+	return strings.TrimSpace(opts.SessionName), true
 }
 
 // sessionTargetTool returns the tool filter for session resolution: the tool

--- a/internal/app/session_target.go
+++ b/internal/app/session_target.go
@@ -23,10 +23,10 @@ import (
 // hex-looking session names keep working.
 const containerIDMinPrefix = 8
 
-// containerIDMaxLen is the length of a full container ID. Recorded IDs are
-// truncated, so a longer value is matched on its leading characters — but only
-// up to the length a real ID can have.
-const containerIDMaxLen = 64
+// containerIDFullLen is the length of a full container ID. Recorded IDs are
+// truncated, so only a value of exactly this length may extend one; anything
+// between is a prefix or nothing at all.
+const containerIDFullLen = 64
 
 // sessionTargetQuery describes how a positional container/session argument is
 // resolved to exactly one managed session.
@@ -49,7 +49,8 @@ type sessionTargetQuery struct {
 	// ProjectScopedNames rejects a session name that only matches outside the
 	// current project. `stop` sets it: removal is destructive and the
 	// auto-assigned names `1`, `2`, … collide across projects by construction,
-	// so another project's session needs its container name or ID.
+	// so another project's session needs its container name or ID. It requires
+	// Project to be set; without it no name resolves.
 	ProjectScopedNames bool
 	// BackgroundOnly restricts auto-selection to detached sessions, so that a
 	// bare `attach` cannot grab the TTY of a foreground session that a second
@@ -188,18 +189,27 @@ func projectSessions(sessions []backend.Session, project model.Project) (scoped 
 			return sameWorktree, true
 		}
 	}
-	if hash := strings.TrimSpace(project.Hash); hash != "" {
-		var sameProject []backend.Session
-		for _, session := range sessions {
-			if strings.TrimSpace(session.ProjectHash) == hash {
-				sameProject = append(sameProject, session)
-			}
-		}
-		if len(sameProject) > 0 {
-			return sameProject, true
-		}
+	if sameProject := projectHashSessions(sessions, project.Hash); len(sameProject) > 0 {
+		return sameProject, true
 	}
 	return sessions, false
+}
+
+// projectHashSessions narrows sessions to one project. An unresolvable project
+// (empty hash) matches nothing, never everything, so that a name-filtered
+// command cannot silently widen to the whole host.
+func projectHashSessions(sessions []backend.Session, hash string) []backend.Session {
+	hash = strings.TrimSpace(hash)
+	if hash == "" {
+		return nil
+	}
+	var matches []backend.Session
+	for _, session := range sessions {
+		if strings.TrimSpace(session.ProjectHash) == hash {
+			matches = append(matches, session)
+		}
+	}
+	return matches
 }
 
 func sessionsForTool(sessions []backend.Session, tool string) []backend.Session {
@@ -222,9 +232,10 @@ func sessionsForTool(sessions []backend.Session, tool string) []backend.Session 
 // matched. All matches are returned so that an ambiguous prefix is reported
 // instead of resolved by listing order.
 func sessionsByContainerID(sessions []backend.Session, requested string) []backend.Session {
-	if len(requested) < containerIDMinPrefix || len(requested) > containerIDMaxLen || !isHexString(requested) {
+	if len(requested) < containerIDMinPrefix || len(requested) > containerIDFullLen || !isHexString(requested) {
 		return nil
 	}
+	full := len(requested) == containerIDFullLen
 	var matches []backend.Session
 	for _, session := range sessions {
 		id := strings.TrimSpace(session.Ref.ID)
@@ -233,7 +244,7 @@ func sessionsByContainerID(sessions []backend.Session, requested string) []backe
 		}
 		// Session IDs are truncated, so a full ID pasted from docker carries the
 		// one recorded here as its prefix.
-		if strings.HasPrefix(id, requested) || strings.HasPrefix(requested, id) {
+		if strings.HasPrefix(id, requested) || (full && strings.HasPrefix(requested, id)) {
 			matches = append(matches, session)
 		}
 	}

--- a/internal/app/session_target.go
+++ b/internal/app/session_target.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"enclave/internal/backend"
+	"enclave/internal/config"
+	"enclave/internal/model"
+)
+
+// sessionTargetQuery describes how a positional container/session argument is
+// resolved to exactly one managed session.
+type sessionTargetQuery struct {
+	// Requested is the user-provided name: either a full container name or a
+	// session name as passed to `--name`. Empty means "auto-select".
+	Requested string
+	// Tool restricts candidates to one tool. Only set it when the tool was
+	// chosen explicitly on the command line; the resolved default would
+	// otherwise hide sessions of other tools.
+	Tool string
+	// Project is the project resolved from the working directory. Its sessions
+	// win over sessions of other projects that carry the same session name. A
+	// zero value disables the preference.
+	Project model.Project
+	// IncludeStopped also considers stopped sessions (used by `stop`, which
+	// removes leftovers).
+	IncludeStopped bool
+}
+
+// resolveSessionTarget resolves a positional container/session argument to one
+// running (or, with IncludeStopped, existing) session. A full container name
+// matches verbatim; anything else is treated as a session name and matched
+// against the sanitized session names of the candidates, preferring the
+// current project. Ambiguity is reported rather than guessed.
+func resolveSessionTarget(ctx context.Context, be backend.Backend, q sessionTargetQuery) (backend.Session, error) {
+	filter := backend.SessionFilter{Tool: strings.TrimSpace(q.Tool)}
+	if q.IncludeStopped {
+		filter.All = true
+	} else {
+		filter.RunningOnly = true
+	}
+	sessions, err := be.List(ctx, filter)
+	if err != nil {
+		return backend.Session{}, fmt.Errorf("list containers: %w", err)
+	}
+
+	requested := strings.TrimSpace(q.Requested)
+	if requested == "" {
+		return selectSingleSession(scopeSessions(sessions, q.Project), sessions, "")
+	}
+
+	for _, session := range sessions {
+		if session.Ref.Name == requested {
+			return session, nil
+		}
+	}
+
+	wanted := model.SanitizeSessionName(requested)
+	if wanted == "" {
+		return backend.Session{}, fmt.Errorf("invalid session name %q", requested)
+	}
+	var matches []backend.Session
+	for _, session := range sessions {
+		if model.SanitizeSessionName(session.Name) == wanted {
+			matches = append(matches, session)
+		}
+	}
+	return selectSingleSession(scopeSessions(matches, q.Project), matches, requested)
+}
+
+// scopeSessions narrows candidates to the current project: sessions started
+// from the very same worktree first, then any session of the project. It
+// returns the input unchanged when nothing matches, so that a name pointing at
+// another project still resolves when it is unambiguous.
+func scopeSessions(sessions []backend.Session, project model.Project) []backend.Session {
+	worktree := strings.TrimSpace(project.Dir)
+	realDir := strings.TrimSpace(project.RealDir)
+	if worktree != "" || realDir != "" {
+		var sameWorktree []backend.Session
+		for _, session := range sessions {
+			if worktree != "" && strings.TrimSpace(session.Worktree) == worktree {
+				sameWorktree = append(sameWorktree, session)
+				continue
+			}
+			if realDir != "" && strings.TrimSpace(session.ProjectDir) == realDir {
+				sameWorktree = append(sameWorktree, session)
+			}
+		}
+		if len(sameWorktree) > 0 {
+			return sameWorktree
+		}
+	}
+	if hash := strings.TrimSpace(project.Hash); hash != "" {
+		var sameProject []backend.Session
+		for _, session := range sessions {
+			if strings.TrimSpace(session.ProjectHash) == hash {
+				sameProject = append(sameProject, session)
+			}
+		}
+		if len(sameProject) > 0 {
+			return sameProject
+		}
+	}
+	return sessions
+}
+
+// selectSingleSession picks the only candidate, or explains what to pass
+// instead. all is the unscoped candidate set, used to point at the sessions of
+// other projects that the scoping ruled out.
+func selectSingleSession(scoped []backend.Session, all []backend.Session, requested string) (backend.Session, error) {
+	switch len(scoped) {
+	case 1:
+		return scoped[0], nil
+	case 0:
+		if requested == "" {
+			return backend.Session{}, fmt.Errorf("no running enclave containers (start one first)")
+		}
+		return backend.Session{}, fmt.Errorf("no enclave session named %q (use `%s ps` to list sessions)", requested, model.AppName)
+	default:
+		subject := "multiple running enclave containers"
+		if requested != "" {
+			subject = fmt.Sprintf("session name %q matches multiple containers", requested)
+		}
+		return backend.Session{}, fmt.Errorf("%s; pass one of these container names explicitly:\n  %s",
+			subject, strings.Join(describeSessions(scoped), "\n  "))
+	}
+}
+
+func describeSessions(sessions []backend.Session) []string {
+	described := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		described = append(described, fmt.Sprintf("%s (%s)", session.Ref.Name,
+			directoryDisplayName(session.Worktree, session.ProjectHash)))
+	}
+	sort.Strings(described)
+	return described
+}
+
+// sessionTargetTool returns the tool filter for session resolution: the tool
+// only counts when it was requested on the command line, since the resolved
+// default would otherwise exclude sessions of every other tool.
+func sessionTargetTool(opts model.Options) string {
+	if opts.Sources.Tool == model.SourceCLI {
+		return strings.TrimSpace(opts.Tool)
+	}
+	return ""
+}
+
+// sessionTargetProject resolves the project for scoping. Resolution failures
+// are not fatal: the caller then resolves names across all projects.
+func sessionTargetProject(projectDir string) model.Project {
+	if strings.TrimSpace(projectDir) == "" {
+		return model.Project{}
+	}
+	project, err := config.ResolveProjectFromDir(projectDir)
+	if err != nil {
+		return model.Project{}
+	}
+	return project
+}

--- a/internal/app/session_target_test.go
+++ b/internal/app/session_target_test.go
@@ -1,0 +1,171 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"enclave/internal/backend"
+	"enclave/internal/model"
+)
+
+func session(name string, sessionName string, hash string, dir string) backend.Session {
+	return backend.Session{
+		Ref:         backend.SessionRef{Name: name},
+		Tool:        "claude",
+		ProjectHash: hash,
+		Worktree:    dir,
+		ProjectDir:  dir,
+		Name:        sessionName,
+		Status:      "running",
+	}
+}
+
+func TestResolveSessionTargetAcceptsFullContainerName(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Requested: "enclave-claude-aaaaaaaaaaaa-my-task",
+	})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-claude-aaaaaaaaaaaa-my-task" {
+		t.Fatalf("resolved %q, want the container name it was given", got.Ref.Name)
+	}
+}
+
+func TestResolveSessionTargetResolvesSessionName(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "my-task"})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-claude-aaaaaaaaaaaa-my-task" {
+		t.Fatalf("resolved %q, want the container of session my-task", got.Ref.Name)
+	}
+}
+
+func TestResolveSessionTargetSanitizesRequestedName(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "My Task"})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-claude-aaaaaaaaaaaa-my-task" {
+		t.Fatalf("resolved %q, want the sanitized name to match", got.Ref.Name)
+	}
+}
+
+func TestResolveSessionTargetPrefersCurrentProject(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+		session("enclave-claude-bbbbbbbbbbbb-my-task", "my-task", "bbbbbbbbbbbb", "/repo/b"),
+	}}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Requested: "my-task",
+		Project:   model.Project{Hash: "bbbbbbbbbbbb", Dir: "/repo/b", RealDir: "/repo/b"},
+	})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-claude-bbbbbbbbbbbb-my-task" {
+		t.Fatalf("resolved %q, want the session of the current project", got.Ref.Name)
+	}
+}
+
+func TestResolveSessionTargetResolvesAcrossProjectsWhenUnambiguous(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Requested: "my-task",
+		Project:   model.Project{Hash: "bbbbbbbbbbbb", Dir: "/repo/b", RealDir: "/repo/b"},
+	})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-claude-aaaaaaaaaaaa-my-task" {
+		t.Fatalf("resolved %q, want the only session carrying the name", got.Ref.Name)
+	}
+}
+
+func TestResolveSessionTargetReportsAmbiguousSessionName(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+		session("enclave-claude-bbbbbbbbbbbb-my-task", "my-task", "bbbbbbbbbbbb", "/repo/b"),
+	}}
+
+	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "my-task"})
+	if err == nil {
+		t.Fatal("resolveSessionTarget() must not guess between projects")
+	}
+	for _, want := range []string{"enclave-claude-aaaaaaaaaaaa-my-task", "enclave-claude-bbbbbbbbbbbb-my-task"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not list candidate %q", err, want)
+		}
+	}
+}
+
+func TestResolveSessionTargetReportsUnknownName(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+
+	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "other"})
+	if err == nil || !strings.Contains(err.Error(), `"other"`) {
+		t.Fatalf("error = %v, want it to name the unknown session", err)
+	}
+}
+
+func TestResolveSessionTargetAutoSelectsWithinProject(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa", "", "aaaaaaaaaaaa", "/repo/a"),
+		session("enclave-claude-bbbbbbbbbbbb-my-task", "my-task", "bbbbbbbbbbbb", "/repo/b"),
+	}}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Project: model.Project{Hash: "aaaaaaaaaaaa", Dir: "/repo/a", RealDir: "/repo/a"},
+	})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-claude-aaaaaaaaaaaa" {
+		t.Fatalf("resolved %q, want the running session of the current project", got.Ref.Name)
+	}
+}
+
+func TestResolveSessionTargetListsOnlyRunningByDefault(t *testing.T) {
+	be := &stopTestBackend{}
+
+	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "my-task"}); err == nil {
+		t.Fatal("expected an error for an empty session list")
+	}
+	if !be.listFilter.RunningOnly || be.listFilter.All {
+		t.Fatalf("filter = %+v, want running sessions only", be.listFilter)
+	}
+
+	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "my-task", IncludeStopped: true}); err == nil {
+		t.Fatal("expected an error for an empty session list")
+	}
+	if !be.listFilter.All || be.listFilter.RunningOnly {
+		t.Fatalf("filter = %+v, want stopped sessions included", be.listFilter)
+	}
+}

--- a/internal/app/session_target_test.go
+++ b/internal/app/session_target_test.go
@@ -34,7 +34,7 @@ func TestResolveSessionTargetAcceptsFullContainerName(t *testing.T) {
 	}}
 
 	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
-		Requested: "enclave-claude-aaaaaaaaaaaa-my-task",
+		Args: []string{"enclave-claude-aaaaaaaaaaaa-my-task"},
 	})
 	if err != nil {
 		t.Fatalf("resolveSessionTarget() error = %v", err)
@@ -49,7 +49,7 @@ func TestResolveSessionTargetResolvesSessionName(t *testing.T) {
 		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
 	}}
 
-	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "my-task"})
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{"my-task"}})
 	if err != nil {
 		t.Fatalf("resolveSessionTarget() error = %v", err)
 	}
@@ -63,7 +63,7 @@ func TestResolveSessionTargetSanitizesRequestedName(t *testing.T) {
 		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
 	}}
 
-	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "My Task"})
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{"My Task"}})
 	if err != nil {
 		t.Fatalf("resolveSessionTarget() error = %v", err)
 	}
@@ -79,8 +79,8 @@ func TestResolveSessionTargetPrefersCurrentProject(t *testing.T) {
 	}}
 
 	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
-		Requested: "my-task",
-		Project:   model.Project{Hash: "bbbbbbbbbbbb", Dir: "/repo/b", RealDir: "/repo/b"},
+		Args:    []string{"my-task"},
+		Project: model.Project{Hash: "bbbbbbbbbbbb", Dir: "/repo/b", RealDir: "/repo/b"},
 	})
 	if err != nil {
 		t.Fatalf("resolveSessionTarget() error = %v", err)
@@ -96,8 +96,8 @@ func TestResolveSessionTargetResolvesAcrossProjectsWhenUnambiguous(t *testing.T)
 	}}
 
 	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
-		Requested: "my-task",
-		Project:   model.Project{Hash: "bbbbbbbbbbbb", Dir: "/repo/b", RealDir: "/repo/b"},
+		Args:    []string{"my-task"},
+		Project: model.Project{Hash: "bbbbbbbbbbbb", Dir: "/repo/b", RealDir: "/repo/b"},
 	})
 	if err != nil {
 		t.Fatalf("resolveSessionTarget() error = %v", err)
@@ -113,7 +113,7 @@ func TestResolveSessionTargetReportsAmbiguousSessionName(t *testing.T) {
 		session("enclave-claude-bbbbbbbbbbbb-my-task", "my-task", "bbbbbbbbbbbb", "/repo/b"),
 	}}
 
-	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "my-task"})
+	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{"my-task"}})
 	if err == nil {
 		t.Fatal("resolveSessionTarget() must not guess between projects")
 	}
@@ -129,9 +129,57 @@ func TestResolveSessionTargetReportsUnknownName(t *testing.T) {
 		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
 	}}
 
-	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "other"})
+	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{"other"}})
 	if err == nil || !strings.Contains(err.Error(), `"other"`) {
 		t.Fatalf("error = %v, want it to name the unknown session", err)
+	}
+}
+
+func TestResolveSessionTargetRejectsBlankArgument(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+	project := model.Project{Hash: "aaaaaaaaaaaa", Dir: "/repo/a", RealDir: "/repo/a"}
+
+	// `enclave stop "$SESSION"` with an unset variable must not fall through to
+	// auto-selection and remove the project's only session.
+	for _, args := range [][]string{{""}, {"   "}} {
+		if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+			Args:    args,
+			Project: project,
+		}); err == nil {
+			t.Fatalf("resolveSessionTarget(%q) must reject a blank argument", args)
+		}
+	}
+}
+
+func TestResolveSessionTargetProjectScopedNamesStayInProject(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-1", "1", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+
+	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Args:               []string{"1"},
+		Project:            model.Project{Hash: "bbbbbbbbbbbb", Dir: "/repo/b", RealDir: "/repo/b"},
+		ProjectScopedNames: true,
+	})
+	if err == nil {
+		t.Fatal("a project-scoped name must not resolve to another project's session")
+	}
+	if !strings.Contains(err.Error(), "another project") {
+		t.Fatalf("error %q does not point at the container-name escape hatch", err)
+	}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Args:               []string{"1"},
+		Project:            model.Project{Hash: "aaaaaaaaaaaa", Dir: "/repo/a", RealDir: "/repo/a"},
+		ProjectScopedNames: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-claude-aaaaaaaaaaaa-1" {
+		t.Fatalf("resolved %q, want the session of the current project", got.Ref.Name)
 	}
 }
 
@@ -198,7 +246,7 @@ func TestResolveSessionTargetResolvesContainerID(t *testing.T) {
 	be := &stopTestBackend{sessions: []backend.Session{target}}
 
 	for _, requested := range []string{"3f2b1c0d4e5f", "3f2b1c0d", "3f2b1c0d4e5f6a7b8c9d"} {
-		got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: requested})
+		got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{requested}})
 		if err != nil {
 			t.Fatalf("resolveSessionTarget(%q) error = %v", requested, err)
 		}
@@ -208,13 +256,42 @@ func TestResolveSessionTargetResolvesContainerID(t *testing.T) {
 	}
 }
 
+func TestResolveSessionTargetReportsAmbiguousContainerIDPrefix(t *testing.T) {
+	first := session("enclave-claude-aaaaaaaaaaaa-one", "one", "aaaaaaaaaaaa", "/repo/a")
+	first.Ref.ID = "3f2b1c0d4e5f"
+	second := session("enclave-claude-bbbbbbbbbbbb-two", "two", "bbbbbbbbbbbb", "/repo/b")
+	second.Ref.ID = "3f2b1c0daaaa"
+	be := &stopTestBackend{sessions: []backend.Session{first, second}}
+
+	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{"3f2b1c0d"}})
+	if err == nil {
+		t.Fatal("an ambiguous ID prefix must not be resolved by listing order")
+	}
+	for _, want := range []string{first.Ref.Name, second.Ref.Name} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not list candidate %q", err, want)
+		}
+	}
+}
+
+func TestResolveSessionTargetRejectsOverlongContainerID(t *testing.T) {
+	target := session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a")
+	target.Ref.ID = "3f2b1c0d4e5f"
+	be := &stopTestBackend{sessions: []backend.Session{target}}
+
+	requested := target.Ref.ID + strings.Repeat("a", containerIDMaxLen)
+	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{requested}}); err == nil {
+		t.Fatal("a value longer than a container ID must not match on its prefix")
+	}
+}
+
 func TestResolveSessionTargetPrefersSessionNameOverContainerID(t *testing.T) {
 	named := session("enclave-claude-aaaaaaaaaaaa-deadbeef", "deadbeef", "aaaaaaaaaaaa", "/repo/a")
 	other := session("enclave-claude-bbbbbbbbbbbb-other", "other", "bbbbbbbbbbbb", "/repo/b")
 	other.Ref.ID = "deadbeef1234"
 	be := &stopTestBackend{sessions: []backend.Session{named, other}}
 
-	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "deadbeef"})
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{"deadbeef"}})
 	if err != nil {
 		t.Fatalf("resolveSessionTarget() error = %v", err)
 	}
@@ -229,8 +306,8 @@ func TestResolveSessionTargetToolFilterKeepsExactContainerName(t *testing.T) {
 	}}
 
 	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
-		Requested: "enclave-codex-aaaaaaaaaaaa-my-task",
-		Tool:      "claude",
+		Args: []string{"enclave-codex-aaaaaaaaaaaa-my-task"},
+		Tool: "claude",
 	})
 	if err != nil {
 		t.Fatalf("resolveSessionTarget() error = %v", err)
@@ -259,16 +336,16 @@ func TestResolveSessionTargetToolNarrowsAmbiguousSessionName(t *testing.T) {
 	project := model.Project{Hash: "aaaaaaaaaaaa", Dir: "/repo/a", RealDir: "/repo/a"}
 
 	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
-		Requested: "my-task",
-		Project:   project,
+		Args:    []string{"my-task"},
+		Project: project,
 	}); err == nil {
 		t.Fatal("one name used by two tools in a project must be reported as ambiguous")
 	}
 
 	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
-		Requested: "my-task",
-		Tool:      "codex",
-		Project:   project,
+		Args:    []string{"my-task"},
+		Tool:    "codex",
+		Project: project,
 	})
 	if err != nil {
 		t.Fatalf("resolveSessionTarget() error = %v", err)
@@ -308,14 +385,14 @@ func TestSessionsMatchingNameIgnoresUnsanitizableName(t *testing.T) {
 func TestResolveSessionTargetListsOnlyRunningByDefault(t *testing.T) {
 	be := &stopTestBackend{}
 
-	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "my-task"}); err == nil {
+	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{"my-task"}}); err == nil {
 		t.Fatal("expected an error for an empty session list")
 	}
 	if !be.listFilter.RunningOnly || be.listFilter.All {
 		t.Fatalf("filter = %+v, want running sessions only", be.listFilter)
 	}
 
-	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "my-task", IncludeStopped: true}); err == nil {
+	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{"my-task"}, IncludeStopped: true}); err == nil {
 		t.Fatal("expected an error for an empty session list")
 	}
 	if !be.listFilter.All || be.listFilter.RunningOnly {

--- a/internal/app/session_target_test.go
+++ b/internal/app/session_target_test.go
@@ -152,6 +152,159 @@ func TestResolveSessionTargetAutoSelectsWithinProject(t *testing.T) {
 	}
 }
 
+func TestResolveSessionTargetAutoSelectStaysInProject(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+
+	_, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Project: model.Project{Hash: "bbbbbbbbbbbb", Dir: "/repo/b", RealDir: "/repo/b"},
+	})
+	if err == nil {
+		t.Fatal("auto-selection must not leave the current project")
+	}
+}
+
+func TestResolveSessionTargetAutoSelectSkipsForegroundSessions(t *testing.T) {
+	foreground := session("enclave-claude-aaaaaaaaaaaa", "", "aaaaaaaaaaaa", "/repo/a")
+	detached := session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a")
+	detached.Background = true
+	be := &stopTestBackend{sessions: []backend.Session{foreground, detached}}
+	project := model.Project{Hash: "aaaaaaaaaaaa", Dir: "/repo/a", RealDir: "/repo/a"}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Project:        project,
+		BackgroundOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != detached.Ref.Name {
+		t.Fatalf("resolved %q, want the detached session", got.Ref.Name)
+	}
+
+	be.sessions = []backend.Session{foreground}
+	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Project:        project,
+		BackgroundOnly: true,
+	}); err == nil {
+		t.Fatal("a foreground session must not be auto-selected")
+	}
+}
+
+func TestResolveSessionTargetResolvesContainerID(t *testing.T) {
+	target := session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a")
+	target.Ref.ID = "3f2b1c0d4e5f"
+	be := &stopTestBackend{sessions: []backend.Session{target}}
+
+	for _, requested := range []string{"3f2b1c0d4e5f", "3f2b1c0d", "3f2b1c0d4e5f6a7b8c9d"} {
+		got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: requested})
+		if err != nil {
+			t.Fatalf("resolveSessionTarget(%q) error = %v", requested, err)
+		}
+		if got.Ref.Name != target.Ref.Name {
+			t.Fatalf("resolveSessionTarget(%q) = %q, want the container with that ID", requested, got.Ref.Name)
+		}
+	}
+}
+
+func TestResolveSessionTargetPrefersSessionNameOverContainerID(t *testing.T) {
+	named := session("enclave-claude-aaaaaaaaaaaa-deadbeef", "deadbeef", "aaaaaaaaaaaa", "/repo/a")
+	other := session("enclave-claude-bbbbbbbbbbbb-other", "other", "bbbbbbbbbbbb", "/repo/b")
+	other.Ref.ID = "deadbeef1234"
+	be := &stopTestBackend{sessions: []backend.Session{named, other}}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Requested: "deadbeef"})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != named.Ref.Name {
+		t.Fatalf("resolved %q, want the session name to win over a container ID", got.Ref.Name)
+	}
+}
+
+func TestResolveSessionTargetToolFilterKeepsExactContainerName(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-codex-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+	}}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Requested: "enclave-codex-aaaaaaaaaaaa-my-task",
+		Tool:      "claude",
+	})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-codex-aaaaaaaaaaaa-my-task" {
+		t.Fatalf("resolved %q, want an exact container name to ignore the tool filter", got.Ref.Name)
+	}
+	if be.listFilter.Tool != "" {
+		t.Fatalf("listFilter.Tool = %q, want the tool applied to candidates, not the listing", be.listFilter.Tool)
+	}
+}
+
+func TestResolveSessionTargetToolNarrowsAmbiguousSessionName(t *testing.T) {
+	be := &stopTestBackend{sessions: []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+		{
+			Ref:         backend.SessionRef{Name: "enclave-codex-aaaaaaaaaaaa-my-task"},
+			Tool:        "codex",
+			ProjectHash: "aaaaaaaaaaaa",
+			Worktree:    "/repo/a",
+			ProjectDir:  "/repo/a",
+			Name:        "my-task",
+			Status:      "running",
+		},
+	}}
+	project := model.Project{Hash: "aaaaaaaaaaaa", Dir: "/repo/a", RealDir: "/repo/a"}
+
+	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Requested: "my-task",
+		Project:   project,
+	}); err == nil {
+		t.Fatal("one name used by two tools in a project must be reported as ambiguous")
+	}
+
+	got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{
+		Requested: "my-task",
+		Tool:      "codex",
+		Project:   project,
+	})
+	if err != nil {
+		t.Fatalf("resolveSessionTarget() error = %v", err)
+	}
+	if got.Ref.Name != "enclave-codex-aaaaaaaaaaaa-my-task" {
+		t.Fatalf("resolved %q, want --tool to pick the codex session", got.Ref.Name)
+	}
+}
+
+func TestSessionsMatchingNameSanitizesBothSides(t *testing.T) {
+	sessions := []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "My Task", "aaaaaaaaaaaa", "/repo/a"),
+		session("enclave-claude-aaaaaaaaaaaa-other", "other", "aaaaaaaaaaaa", "/repo/a"),
+	}
+
+	for _, requested := range []string{"My Task", "my-task"} {
+		matches := sessionsMatchingName(sessions, requested)
+		if len(matches) != 1 || matches[0].Name != "My Task" {
+			t.Fatalf("sessionsMatchingName(%q) = %v, want the session labeled with the raw name", requested, matches)
+		}
+	}
+}
+
+func TestSessionsMatchingNameIgnoresUnsanitizableName(t *testing.T) {
+	sessions := []backend.Session{
+		session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a"),
+		session("enclave-claude-aaaaaaaaaaaa", "", "aaaaaaaaaaaa", "/repo/a"),
+	}
+
+	// A name that sanitizes to nothing must match nothing: `stop --name "???"`
+	// must not turn into "stop everything".
+	if matches := sessionsMatchingName(sessions, "???"); len(matches) != 0 {
+		t.Fatalf("sessionsMatchingName(\"???\") = %v, want no matches", matches)
+	}
+}
+
 func TestResolveSessionTargetListsOnlyRunningByDefault(t *testing.T) {
 	be := &stopTestBackend{}
 

--- a/internal/app/session_target_test.go
+++ b/internal/app/session_target_test.go
@@ -245,7 +245,8 @@ func TestResolveSessionTargetResolvesContainerID(t *testing.T) {
 	target.Ref.ID = "3f2b1c0d4e5f"
 	be := &stopTestBackend{sessions: []backend.Session{target}}
 
-	for _, requested := range []string{"3f2b1c0d4e5f", "3f2b1c0d", "3f2b1c0d4e5f6a7b8c9d"} {
+	fullID := target.Ref.ID + strings.Repeat("a", containerIDFullLen-len(target.Ref.ID))
+	for _, requested := range []string{"3f2b1c0d4e5f", "3f2b1c0d", fullID} {
 		got, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{requested}})
 		if err != nil {
 			t.Fatalf("resolveSessionTarget(%q) error = %v", requested, err)
@@ -274,14 +275,17 @@ func TestResolveSessionTargetReportsAmbiguousContainerIDPrefix(t *testing.T) {
 	}
 }
 
-func TestResolveSessionTargetRejectsOverlongContainerID(t *testing.T) {
+func TestResolveSessionTargetRejectsPartialContainerIDExtension(t *testing.T) {
 	target := session("enclave-claude-aaaaaaaaaaaa-my-task", "my-task", "aaaaaaaaaaaa", "/repo/a")
 	target.Ref.ID = "3f2b1c0d4e5f"
 	be := &stopTestBackend{sessions: []backend.Session{target}}
 
-	requested := target.Ref.ID + strings.Repeat("a", containerIDMaxLen)
-	if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{requested}}); err == nil {
-		t.Fatal("a value longer than a container ID must not match on its prefix")
+	// Only a complete ID may extend the recorded (truncated) one; a value of
+	// some length in between cannot be verified against it.
+	for _, requested := range []string{target.Ref.ID + "aaaaaaaa", target.Ref.ID + strings.Repeat("a", containerIDFullLen)} {
+		if _, err := resolveSessionTarget(context.Background(), be, sessionTargetQuery{Args: []string{requested}}); err == nil {
+			t.Fatalf("resolveSessionTarget(%q) must not match on the recorded ID prefix", requested)
+		}
 	}
 }
 

--- a/internal/backend/docker/docker.go
+++ b/internal/backend/docker/docker.go
@@ -411,9 +411,6 @@ func sessionListFilterPairs(filter backend.SessionFilter) [][2]string {
 	if filter.ProjectHash != "" {
 		pairs = append(pairs, [2]string{"label", model.LabelHash + "=" + filter.ProjectHash})
 	}
-	if filter.SessionName != "" {
-		pairs = append(pairs, [2]string{"label", model.LabelSession + "=" + filter.SessionName})
-	}
 	if filter.Background != nil {
 		pairs = append(pairs, [2]string{"label", model.LabelBackground + "=" + strconv.FormatBool(*filter.Background)})
 	}

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -352,7 +352,6 @@ type SessionFilter struct {
 	RunningOnly bool
 	Tool        string
 	ProjectHash string
-	SessionName string
 	Background  *bool
 	NamePrefix  string
 	ExactName   string

--- a/internal/cli/attach_command.go
+++ b/internal/cli/attach_command.go
@@ -16,12 +16,16 @@ import (
 func attachCommand(res *Result) *cobra.Command {
 	var detachKeys string
 	cmd := &cobra.Command{
-		Use:   "attach <container-name>",
-		Short: "Attach to a running container",
-		Args:  cobra.ExactArgs(1),
+		Use:   "attach [container-or-session-name]",
+		Short: "Attach to a running session by container name or --name session name",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, cmdArgs []string) error {
 			res.Action = "attach"
-			res.Options.CmdArgs = append(res.Options.CmdArgs, cmdArgs[0], detachKeys)
+			target := ""
+			if len(cmdArgs) > 0 {
+				target = cmdArgs[0]
+			}
+			res.Options.CmdArgs = append(res.Options.CmdArgs, target, detachKeys)
 			return nil
 		},
 	}

--- a/internal/cli/attach_command.go
+++ b/internal/cli/attach_command.go
@@ -21,11 +21,9 @@ func attachCommand(res *Result) *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, cmdArgs []string) error {
 			res.Action = "attach"
-			target := ""
-			if len(cmdArgs) > 0 {
-				target = cmdArgs[0]
-			}
-			res.Options.CmdArgs = append(res.Options.CmdArgs, target, detachKeys)
+			// Detach keys first: an omitted session argument must stay
+			// distinguishable from an empty one, which is rejected.
+			res.Options.CmdArgs = append(append(res.Options.CmdArgs, detachKeys), cmdArgs...)
 			return nil
 		},
 	}

--- a/internal/cli/attach_command.go
+++ b/internal/cli/attach_command.go
@@ -30,5 +30,7 @@ func attachCommand(res *Result) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&detachKeys, "detach-keys", model.DetachKeysDefault, "Override the key sequence for detaching")
+	// --tool disambiguates a session name used by more than one tool.
+	addOptionFlagsByName(cmd.Flags(), &res.Options, &res.Sources, "tool")
 	return cmd
 }

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -176,6 +176,28 @@ func TestParsePS(t *testing.T) {
 	}
 }
 
+func TestParseAttachKeepsSessionArgumentOptional(t *testing.T) {
+	defaults := config.DefaultOptions()
+	tests := []struct {
+		args []string
+		want []string
+	}{
+		{args: []string{"attach"}, want: []string{model.DetachKeysDefault}},
+		{args: []string{"attach", "my-task"}, want: []string{model.DetachKeysDefault, "my-task"}},
+		{args: []string{"attach", "--detach-keys", "ctrl-p,ctrl-q"}, want: []string{"ctrl-p,ctrl-q"}},
+	}
+
+	for _, tt := range tests {
+		res, err := Parse(tt.args, defaults)
+		if err != nil {
+			t.Fatalf("parse %v failed: %v", tt.args, err)
+		}
+		if !reflect.DeepEqual(res.Options.CmdArgs, tt.want) {
+			t.Fatalf("parse %v: CmdArgs = %v, want %v", tt.args, res.Options.CmdArgs, tt.want)
+		}
+	}
+}
+
 func TestParseConfigFlags(t *testing.T) {
 	defaults := config.DefaultOptions()
 	res, err := Parse([]string{

--- a/internal/cli/stop_command.go
+++ b/internal/cli/stop_command.go
@@ -11,8 +11,8 @@ import "github.com/spf13/cobra"
 
 func stopCommand(res *Result) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "stop [container-name]",
-		Short: "Stop background containers",
+		Use:   "stop [container-or-session-name]",
+		Short: "Stop background containers, or one session by name",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, cmdArgs []string) error {
 			res.Action = "stop"

--- a/internal/cli/stop_command.go
+++ b/internal/cli/stop_command.go
@@ -19,8 +19,9 @@ With an argument, exactly the session it names is removed: a container name from
 ` + "`enclave ps`" + `, a container ID, or a session name of the current project.
 A session name of another project is not accepted here — pass its container name.
 
-Without an argument, every background container of the selected tool is removed;
---name narrows that to sessions with a matching name.`,
+Without an argument, every background container of the selected tool is removed,
+across all projects; --name narrows that to matching sessions of the current
+project.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, cmdArgs []string) error {
 			res.Action = "stop"

--- a/internal/cli/stop_command.go
+++ b/internal/cli/stop_command.go
@@ -13,7 +13,15 @@ func stopCommand(res *Result) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stop [container-or-session-name]",
 		Short: "Stop background containers, or one session by name",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Stop and remove enclave containers.
+
+With an argument, exactly the session it names is removed: a container name from
+` + "`enclave ps`" + `, a container ID, or a session name of the current project.
+A session name of another project is not accepted here — pass its container name.
+
+Without an argument, every background container of the selected tool is removed;
+--name narrows that to sessions with a matching name.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, cmdArgs []string) error {
 			res.Action = "stop"
 			res.Options.CmdArgs = append(res.Options.CmdArgs, cmdArgs...)

--- a/internal/cli/theia_command.go
+++ b/internal/cli/theia_command.go
@@ -14,7 +14,7 @@ import (
 )
 
 func theiaCommand(res *Result, variant string) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   variant + " [container-or-session-name]",
 		Short: fmt.Sprintf("Open %s attached to a running enclave container", variant),
 		Long: fmt.Sprintf(`Launch the %s desktop IDE attached to a running enclave container.
@@ -38,4 +38,7 @@ Roots honor $XDG_CONFIG_HOME on Linux (ignored on macOS).`, variant),
 			return nil
 		},
 	}
+	// --tool disambiguates a session name used by more than one tool.
+	addOptionFlagsByName(cmd.Flags(), &res.Options, &res.Sources, "tool")
+	return cmd
 }

--- a/internal/cli/theia_command.go
+++ b/internal/cli/theia_command.go
@@ -15,12 +15,13 @@ import (
 
 func theiaCommand(res *Result, variant string) *cobra.Command {
 	return &cobra.Command{
-		Use:   variant + " [container-name]",
+		Use:   variant + " [container-or-session-name]",
 		Short: fmt.Sprintf("Open %s attached to a running enclave container", variant),
 		Long: fmt.Sprintf(`Launch the %s desktop IDE attached to a running enclave container.
 
-If [container-name] is omitted, the single running enclave container is used.
-If multiple are running, names are listed and one must be passed explicitly.
+The argument is a container name from `+"`enclave ps`"+` or a session name passed
+to --name. If it is omitted, the single running container of the current project
+is used. If several match, names are listed and one must be passed explicitly.
 
 Preferences are merged from (highest wins):
   - ~/.config/enclave/projects/<hash>/config.json under {"theia":{"preferences":{...}}}

--- a/internal/model/session_name.go
+++ b/internal/model/session_name.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package model
+
+import (
+	"regexp"
+	"strings"
+)
+
+const sessionNameMaxLength = 32
+
+var sessionNameSeparators = regexp.MustCompile(`[^a-z0-9]+`)
+
+// SanitizeSessionName normalises a user-provided session name to the canonical
+// form used as the trailing segment of a managed container name, as the value
+// of LabelSession, and as the lookup key when a session is addressed by name.
+// Callers must compare sanitized values on both sides so that `--name "My
+// Task"` is addressable as `my-task` (and vice versa).
+func SanitizeSessionName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = sessionNameSeparators.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	if len(name) > sessionNameMaxLength {
+		name = name[:sessionNameMaxLength]
+		name = strings.TrimRight(name, "-")
+	}
+	return name
+}

--- a/internal/model/session_name_test.go
+++ b/internal/model/session_name_test.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package model
+
+import "testing"
+
+func TestSanitizeSessionName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"my-task", "my-task"},
+		{"  My Task  ", "my-task"},
+		{"feature/ABC-123", "feature-abc-123"},
+		{"--task--", "task"},
+		{"", ""},
+		{"///", ""},
+		{"a-very-long-session-name-that-exceeds-the-limit", "a-very-long-session-name-that-ex"},
+		{"trailing-separator-after-truncation-x", "trailing-separator-after-truncat"},
+	}
+	for _, tt := range tests {
+		if got := SanitizeSessionName(tt.in); got != tt.want {
+			t.Fatalf("SanitizeSessionName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -279,7 +279,7 @@ func (r *Runtime) logContainerStart(containerName string, baseContainerName stri
 		logx.Warnf("Container name %s is already in use; starting new session as %s", baseContainerName, containerName)
 	}
 	if r.run.Background {
-		logx.Successf("Starting background session %q for: %s", r.resolvedSessionName(), r.project.Name)
+		logx.Successf("Starting background session %q for: %s", r.friendlySessionName(), r.project.Name)
 		return
 	}
 	if r.run.Admin {
@@ -814,12 +814,12 @@ func (r *Runtime) containerEnv(ctx *ExecutionContext, interactive bool) []string
 	return env
 }
 
-// sessionDisplayName returns the session name recorded in the session label.
-// It is the sanitized form, so the label, the trailing container-name segment,
-// and the name users pass to `attach`/`stop` always agree.
+// sessionDisplayName returns the session name recorded in the session label:
+// the value the user supplied, so that consumers of the label keep seeing what
+// was typed. Lookups sanitize both sides instead of relying on the stored form.
 func (r *Runtime) sessionDisplayName(containerName string, background bool) string {
 	if background || r.run.SessionName != "" || containerName != r.baseContainerName() {
-		return r.resolvedSessionName()
+		return r.friendlySessionName()
 	}
 	return ""
 }
@@ -830,6 +830,15 @@ func (r *Runtime) baseContainerName() string {
 
 func (r *Runtime) containerName() string {
 	return r.baseContainerName() + "-" + r.resolvedSessionName()
+}
+
+// friendlySessionName returns the user-facing session name: the original
+// user-supplied value when set, otherwise the auto-generated name.
+func (r *Runtime) friendlySessionName() string {
+	if r.run.SessionName != "" {
+		return r.run.SessionName
+	}
+	return r.resolvedSessionName()
 }
 
 // resolvedSessionName returns the session name to use, computing and caching it

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -197,7 +197,7 @@ func (r *Runtime) prepareExecution() (*ExecutionContext, error) {
 		sessionContainerName := r.containerName()
 		if r.containerExists(sessionContainerName) {
 			if r.containerIsRunning(sessionContainerName) {
-				return nil, fmt.Errorf("session %s already running; stop it first with: %s stop %s", sessionContainerName, model.AppName, sessionContainerName)
+				return nil, fmt.Errorf("session %s already running; stop it first with: %s stop %s", sessionContainerName, model.AppName, r.resolvedSessionName())
 			}
 			logx.Infof("Removing stopped container: %s", sessionContainerName)
 			r.removeStoppedSession(sessionContainerName)
@@ -279,7 +279,7 @@ func (r *Runtime) logContainerStart(containerName string, baseContainerName stri
 		logx.Warnf("Container name %s is already in use; starting new session as %s", baseContainerName, containerName)
 	}
 	if r.run.Background {
-		logx.Successf("Starting background session %q for: %s", r.friendlySessionName(), r.project.Name)
+		logx.Successf("Starting background session %q for: %s", r.resolvedSessionName(), r.project.Name)
 		return
 	}
 	if r.run.Admin {
@@ -814,9 +814,12 @@ func (r *Runtime) containerEnv(ctx *ExecutionContext, interactive bool) []string
 	return env
 }
 
+// sessionDisplayName returns the session name recorded in the session label.
+// It is the sanitized form, so the label, the trailing container-name segment,
+// and the name users pass to `attach`/`stop` always agree.
 func (r *Runtime) sessionDisplayName(containerName string, background bool) string {
 	if background || r.run.SessionName != "" || containerName != r.baseContainerName() {
-		return r.friendlySessionName()
+		return r.resolvedSessionName()
 	}
 	return ""
 }
@@ -836,20 +839,11 @@ func (r *Runtime) resolvedSessionName() string {
 		return r.sessionName
 	}
 	if r.run.SessionName != "" {
-		r.sessionName = sanitizeSessionName(r.run.SessionName)
+		r.sessionName = model.SanitizeSessionName(r.run.SessionName)
 	} else {
 		r.sessionName = r.nextSessionName()
 	}
 	return r.sessionName
-}
-
-// friendlySessionName returns the user-facing session name: the original
-// user-supplied value when set, otherwise the auto-generated name.
-func (r *Runtime) friendlySessionName() string {
-	if r.run.SessionName != "" {
-		return r.run.SessionName
-	}
-	return r.resolvedSessionName()
 }
 
 func hostPortForContainerPort(ports []string, target string) (string, bool) {

--- a/internal/runtime/session_name.go
+++ b/internal/runtime/session_name.go
@@ -9,28 +9,12 @@ package runtime
 
 import (
 	"context"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"enclave/internal/backend"
 	"enclave/internal/model"
 )
-
-var nonAlphanumeric = regexp.MustCompile(`[^a-z0-9]+`)
-
-// sanitizeSessionName normalises a user-provided session name to a value safe
-// for use in Docker container names.
-func sanitizeSessionName(name string) string {
-	name = strings.ToLower(strings.TrimSpace(name))
-	name = nonAlphanumeric.ReplaceAllString(name, "-")
-	name = strings.Trim(name, "-")
-	if len(name) > 32 {
-		name = name[:32]
-		name = strings.TrimRight(name, "-")
-	}
-	return name
-}
 
 func isGatewaySidecar(name string) bool {
 	return strings.HasSuffix(name, model.GatewayContainerSuffix)

--- a/internal/runtime/session_name_test.go
+++ b/internal/runtime/session_name_test.go
@@ -14,6 +14,33 @@ import (
 	"enclave/internal/model"
 )
 
+func TestSessionDisplayNameMatchesContainerNameSuffix(t *testing.T) {
+	r := &Runtime{
+		profile: model.Profile{Name: "claude"},
+		project: model.Project{Hash: "abc123abc123"},
+		run:     model.RunOptions{Background: true, SessionName: "My Task"},
+	}
+
+	containerName := r.containerName()
+	if containerName != "enclave-claude-abc123abc123-my-task" {
+		t.Fatalf("containerName() = %q", containerName)
+	}
+	if got := r.sessionDisplayName(containerName, true); got != "my-task" {
+		t.Fatalf("sessionDisplayName() = %q, want the sanitized name recorded in the session label", got)
+	}
+}
+
+func TestSessionDisplayNameEmptyForDefaultForegroundContainer(t *testing.T) {
+	r := &Runtime{
+		profile: model.Profile{Name: "claude"},
+		project: model.Project{Hash: "abc123abc123"},
+	}
+
+	if got := r.sessionDisplayName(r.baseContainerName(), false); got != "" {
+		t.Fatalf("sessionDisplayName() = %q, want no session label", got)
+	}
+}
+
 func TestNextSessionNameStartsAtOneWhenDefaultContainerExists(t *testing.T) {
 	r := &Runtime{
 		profile: model.Profile{Name: "claude"},

--- a/internal/runtime/session_name_test.go
+++ b/internal/runtime/session_name_test.go
@@ -14,7 +14,7 @@ import (
 	"enclave/internal/model"
 )
 
-func TestSessionDisplayNameMatchesContainerNameSuffix(t *testing.T) {
+func TestSessionDisplayNameKeepsUserSuppliedName(t *testing.T) {
 	r := &Runtime{
 		profile: model.Profile{Name: "claude"},
 		project: model.Project{Hash: "abc123abc123"},
@@ -25,8 +25,8 @@ func TestSessionDisplayNameMatchesContainerNameSuffix(t *testing.T) {
 	if containerName != "enclave-claude-abc123abc123-my-task" {
 		t.Fatalf("containerName() = %q", containerName)
 	}
-	if got := r.sessionDisplayName(containerName, true); got != "my-task" {
-		t.Fatalf("sessionDisplayName() = %q, want the sanitized name recorded in the session label", got)
+	if got := r.sessionDisplayName(containerName, true); got != "My Task" {
+		t.Fatalf("sessionDisplayName() = %q, want the user-supplied name in the session label", got)
 	}
 }
 

--- a/website/docs/docs/cli.md
+++ b/website/docs/docs/cli.md
@@ -26,7 +26,7 @@ covers the core commands available today; it will grow as the surface stabilizes
 | `enclave continue` | Resume your previous session. |
 | `enclave ps` | List the sessions that are currently running. |
 | `enclave --background` | Start a session detached from your terminal. |
-| `enclave attach <container>` | Attach to a running session (default detach key: `Ctrl-\`). |
+| `enclave attach <name>` | Attach to a running session by session or container name (default detach key: `Ctrl-\`). |
 
 ## Start a session
 
@@ -100,7 +100,7 @@ enclave ps                      # find the running session's container name
 enclave attach <container>      # reattach to its TTY
 ```
 
-With a single running session in the project, plain `enclave attach` picks it.
+With a single detached session in the project, plain `enclave attach` picks it.
 
 Combine `--background` with `--name` when you want a stable, memorable name to
 reattach to:
@@ -112,7 +112,8 @@ enclave attach my-task
 
 Names are resolved within the current project first, so the same `--name` can be
 used in several projects. If a name matches sessions in more than one project,
-Enclave lists the candidate container names instead of guessing.
+Enclave lists the candidate container names instead of guessing; `--tool` also
+narrows them down.
 
 ### Detach without stopping the session
 

--- a/website/docs/docs/cli.md
+++ b/website/docs/docs/cli.md
@@ -85,7 +85,8 @@ choose one to inspect or resume.
 enclave ps
 ```
 
-The `NAME` column in the output is what you pass to `enclave attach`.
+Both the `NAME` (container) and `SESSION` (from `--name`) columns can be passed
+to `enclave attach`.
 
 ## Run in the background and reattach
 
@@ -99,13 +100,19 @@ enclave ps                      # find the running session's container name
 enclave attach <container>      # reattach to its TTY
 ```
 
-Combine `--background` with `--name` when you want a stable, memorable container
-name to reattach to:
+With a single running session in the project, plain `enclave attach` picks it.
+
+Combine `--background` with `--name` when you want a stable, memorable name to
+reattach to:
 
 ```bash
 enclave --background --name my-task
 enclave attach my-task
 ```
+
+Names are resolved within the current project first, so the same `--name` can be
+used in several projects. If a name matches sessions in more than one project,
+Enclave lists the candidate container names instead of guessing.
 
 ### Detach without stopping the session
 


### PR DESCRIPTION
## Why

Containers are named `enclave-<tool>-<project-hash>-<session>`, but `attach`, `stop <name>`, and `theia` passed their positional argument straight to Docker as an exact container name. The flow documented on the website — `enclave --background --name my-task` then `enclave attach my-task` — could therefore never work.

Global uniqueness of session names is deliberately *not* introduced: container names are already unique via the project hash, and reusing `--name review` across several repos is a normal parallel-agent workflow.

## What

- `attach`, `stop <name>`, and `theia`/`theia-next` share one resolver (`internal/app/session_target.go`). A full container name still matches verbatim; anything else is matched as a session name, preferring sessions from the same worktree, then the same project, then the whole host. When a name matches several containers, the candidates are listed instead of one being guessed. `--tool` narrows candidates when given on the CLI.
- `enclave attach` takes an optional argument: with a single running session in the project, bare `attach` picks it (matching `theia`).
- `stop <name>` also considers stopped containers, so a leftover can be cleared by name.
- Session-name normalization moved to `model.SanitizeSessionName`. The `enclave.session` label now stores the sanitized form, so it equals the trailing container-name segment; `ps --name` / `status --name` sanitize their filter input, which fixes `--name "My Task"` not matching `--name my-task`.
- `enclave ps` gained a `SESSION` column (`-` for a project's default container) so the addressable name is discoverable.
- The duplicate-session error now suggests `enclave stop my-task` rather than the full container name.
- Docs updated: `docs/cli-reference.md`, `docs/persistence.md`, `website/docs/docs/cli.md`, and the `attach`/`stop`/`theia` help text.

### Note for consumers

`ps --json` `sessionName` now reports the sanitized value (`my-task`, not `My Task`) for names that needed sanitizing. Field and shape are unchanged. Sessions started by an older build keep their raw label and still resolve, since matching sanitizes both sides.

## How to test

Unit coverage: `internal/app/session_target_test.go`, `internal/model/session_name_test.go`, `internal/runtime/session_name_test.go`, `internal/app/command_ps_test.go`. `make build`, `make test`, `make lint`, and `make check-license-headers` pass; the resolver has not been exercised against live containers.

Manual:

```bash
enclave --background --name my-task
enclave ps                 # NAME shows the container, SESSION shows my-task
enclave attach my-task     # attaches; Ctrl-\ to detach
enclave attach             # single running session in the project is picked
enclave stop my-task
```

Ambiguity and scoping:

```bash
# same name in two different projects
(cd ~/repo-a && enclave --background --name review)
(cd ~/repo-b && enclave --background --name review)
cd ~/repo-a && enclave attach review   # resolves to repo-a's session
cd /tmp && enclave attach review       # lists both candidate container names
```

Sanitization: `enclave --background --name "My Task"` is addressable as `enclave attach my-task`, and `enclave ps --name "My Task"` and `--name my-task` list the same row.