### PR TITLE
fix: require a serviceAuth entry for every serviceDomains host

### DIFF
--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -146,6 +146,8 @@ the mounted host project directory and installs happen at `docker build` time:
 - `files/workspace/**` is copied into the project at container **start** and
   **never clobbers** an existing host file (warns and skips).
 - `commands.startup` running as root is **rejected loudly at load**.
+- `network.serviceDomains` mapping a host to a service that has no
+  `network.serviceAuth` entry is **rejected loudly at load** (see below).
 - `commands.install` (mixins only) is woven into the build; an `install.sh`
   sidecar wins if a feature ships both.
 
@@ -408,7 +410,12 @@ Secrets are split across two `spec.yaml` sections:
   `network.serviceAuth.<service-id>` (`headerName`, optional `valueFormat`)
   describe how the gateway injects that credential as an HTTP header when it
   proxies requests to those hosts. The service-id in `serviceAuth` and
-  `serviceDomains` is the same key used under `credentials.sources`.
+  `serviceDomains` is the same key used under `credentials.sources`. Every
+  service-id in `serviceDomains` must also have a `serviceAuth` entry; without
+  one the mapping is inert — the hosts never reach the allowlist and the
+  credential is injected as a raw env value — so the spec is rejected at load.
+  To make hosts reachable without injecting a credential, list them under
+  `network.allowedDomains` instead.
 
 The placeholder convention is Go `fmt`-style `%s`, not `{secret}`. An empty
 `valueFormat` means "inject the raw secret value" with no wrapping (see

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -146,8 +146,9 @@ the mounted host project directory and installs happen at `docker build` time:
 - `files/workspace/**` is copied into the project at container **start** and
   **never clobbers** an existing host file (warns and skips).
 - `commands.startup` running as root is **rejected loudly at load**.
-- `network.serviceDomains` mapping a host to a service that has no
-  `network.serviceAuth` entry is **rejected loudly at load** (see below).
+- the `network.serviceDomains` ↔ `network.serviceAuth` pairing must be complete
+  in both directions; an incomplete mapping is **rejected loudly at load**
+  (see below).
 - `commands.install` (mixins only) is woven into the build; an `install.sh`
   sidecar wins if a feature ships both.
 
@@ -415,7 +416,9 @@ Secrets are split across two `spec.yaml` sections:
   one the mapping is inert — the hosts never reach the allowlist and the
   credential is injected as a raw env value — so the spec is rejected at load.
   To make hosts reachable without injecting a credential, list them under
-  `network.allowedDomains` instead.
+  `network.allowedDomains` instead. The pairing is required in both directions:
+  a `serviceAuth` entry also needs at least one host, either from
+  `serviceDomains` or from its own `hosts` list.
 
 The placeholder convention is Go `fmt`-style `%s`, not `{secret}`. An empty
 `valueFormat` means "inject the raw secret value" with no wrapping (see

--- a/docs/extensions/adding-a-tool.md
+++ b/docs/extensions/adding-a-tool.md
@@ -74,6 +74,8 @@ Secrets are split across `credentials` and `network` (see the README's
 - `network.serviceDomains` (`host -> service-id`) + `network.serviceAuth.<id>`
   (`headerName`, optional `valueFormat` with a Go `fmt`-style `%s`): how the
   gateway injects the credential as an HTTP header when proxying to those hosts.
+  Every service-id in `serviceDomains` needs a `serviceAuth` entry; hosts that
+  only need to be reachable belong under `network.allowedDomains`.
 - `providers[]`: enclave-native auth provider — `name`, `credentials` (a list
   of `credentials.sources` keys), `authFiles` (relative to `sandbox.configDir`),
   `authSession` (`mode: any|all` + `checks`), `oauthPorts`, and

--- a/internal/config/conformance_test.go
+++ b/internal/config/conformance_test.go
@@ -55,15 +55,22 @@ func TestExtensionSurfaceGolden(t *testing.T) {
 		assertGolden(t, "tool-ext-"+name, ext)
 	}
 
-	feats, err := ListFeatures(paths)
+	// Enumerate the feature spec names rather than going through ListFeatures:
+	// that helper warns and skips specs it cannot load, so a broken built-in
+	// feature spec would drop out of the snapshot set instead of failing here.
+	feats, err := listSpecNames(paths, KindMixin)
 	if err != nil {
-		t.Fatalf("ListFeatures: %v", err)
+		t.Fatalf("listSpecNames(features): %v", err)
 	}
 	if len(feats) == 0 {
-		t.Fatal("ListFeatures returned no features; expected the real extensions/features tree")
+		t.Fatal("found no feature specs; expected the real extensions/features tree")
 	}
-	for _, ext := range feats {
-		assertGolden(t, "feature-"+ext.Name, ext)
+	for _, name := range feats {
+		ext, err := LoadFeatureExtension(paths, name)
+		if err != nil {
+			t.Fatalf("LoadFeatureExtension(%s): %v", name, err)
+		}
+		assertGolden(t, "feature-"+name, ext)
 	}
 }
 

--- a/internal/config/extension.go
+++ b/internal/config/extension.go
@@ -8,6 +8,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -118,7 +119,12 @@ func ListFeatures(paths model.Paths) ([]model.Extension, error) {
 	for _, name := range names {
 		ext, err := LoadFeatureExtension(paths, name)
 		if err != nil {
-			continue // Skip invalid extensions
+			// A feature dropped here is silently missing from the built image,
+			// so surface why. A directory without a spec is not an error.
+			if !errors.Is(err, os.ErrNotExist) {
+				specWarn(fmt.Sprintf("feature %q: %v; skipping", name, err))
+			}
+			continue
 		}
 		features = append(features, ext)
 	}

--- a/internal/config/extension.go
+++ b/internal/config/extension.go
@@ -8,7 +8,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -92,25 +91,41 @@ func LoadFeatureExtension(paths model.Paths, name string) (model.Extension, erro
 
 // ListTools returns all tool extension names from both built-in and user extension roots.
 func ListTools(paths model.Paths) ([]string, error) {
-	names, err := listExtensionNames(paths.ToolsDir, paths.UserToolsDir)
+	return listSpecNames(paths, KindSandbox)
+}
+
+// listSpecNames returns the sorted names of the given kind's extensions, from
+// both the built-in and the user root, that carry a spec document. Unlike
+// ListFeatures it never loads those specs, so a name it returns may still fail
+// to load.
+func listSpecNames(paths model.Paths, kind string) ([]string, error) {
+	var builtinDir, userDir string
+	switch kind {
+	case KindSandbox:
+		builtinDir, userDir = paths.ToolsDir, paths.UserToolsDir
+	case KindMixin:
+		builtinDir, userDir = paths.FeaturesDir, paths.UserFeaturesDir
+	default:
+		return nil, fmt.Errorf("unknown extension kind %q", kind)
+	}
+
+	names, err := listExtensionNames(builtinDir, userDir)
 	if err != nil {
 		return nil, err
 	}
 
-	var tools []string
+	var withSpec []string
 	for _, name := range names {
-		if hasSpecFile(paths, name, KindSandbox) {
-			tools = append(tools, name)
+		if hasSpecFile(paths, name, kind) {
+			withSpec = append(withSpec, name)
 		}
 	}
-
-	sort.Strings(tools)
-	return tools, nil
+	return withSpec, nil
 }
 
 // ListFeatures returns all feature extensions from both built-in and user roots, sorted by priority.
 func ListFeatures(paths model.Paths) ([]model.Extension, error) {
-	names, err := listExtensionNames(paths.FeaturesDir, paths.UserFeaturesDir)
+	names, err := listSpecNames(paths, KindMixin)
 	if err != nil {
 		return nil, err
 	}
@@ -120,10 +135,8 @@ func ListFeatures(paths model.Paths) ([]model.Extension, error) {
 		ext, err := LoadFeatureExtension(paths, name)
 		if err != nil {
 			// A feature dropped here is silently missing from the built image,
-			// so surface why. A directory without a spec is not an error.
-			if !errors.Is(err, os.ErrNotExist) {
-				specWarn(fmt.Sprintf("feature %q: %v; skipping", name, err))
-			}
+			// so surface why. Spec-less directories are already filtered out.
+			specWarn(fmt.Sprintf("feature %q: %v; skipping", name, err))
 			continue
 		}
 		features = append(features, ext)

--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -318,7 +318,7 @@ func TestLoadProfileRejectsSecretReleaseWithEmptyHosts(t *testing.T) {
 	}`)
 
 	_, err := LoadProfile(paths, "tool")
-	if err == nil || !strings.Contains(err.Error(), "hosts must contain at least one domain pattern") {
+	if err == nil || !strings.Contains(err.Error(), "has no hosts to release the credential to") {
 		t.Fatalf("LoadProfile() error = %v, want empty-hosts validation error", err)
 	}
 }

--- a/internal/config/secrets_test.go
+++ b/internal/config/secrets_test.go
@@ -105,6 +105,28 @@ func TestValidateAndNormalizeSecretConfigsInvalidParser(t *testing.T) {
 	}
 }
 
+// TestValidateAndNormalizeSecretConfigsEmptyReleaseHosts covers the model-layer
+// guard directly. Spec loading now rejects a hostless serviceAuth entry earlier
+// and with a message that names serviceDomains, so this is the only path left
+// that exercises the normalizeHosts check.
+func TestValidateAndNormalizeSecretConfigsEmptyReleaseHosts(t *testing.T) {
+	in := map[string]model.SecretConfig{
+		"demo": {
+			EnvVars: []string{"DEMO_KEY"},
+			Release: &model.SecretReleaseConfig{
+				HTTP: &model.HTTPSecretReleaseConfig{Header: "authorization"},
+			},
+		},
+	}
+	_, err := validateAndNormalizeSecretConfigs(in)
+	if err == nil {
+		t.Fatalf("expected empty release hosts error, got nil")
+	}
+	if !strings.Contains(err.Error(), "hosts must contain at least one domain pattern") {
+		t.Fatalf("error = %v, want it to mention the empty hosts list", err)
+	}
+}
+
 func TestValidateAndNormalizeSecretConfigsEmptyFilePath(t *testing.T) {
 	in := map[string]model.SecretConfig{
 		"demo": {

--- a/internal/config/spec_map.go
+++ b/internal/config/spec_map.go
@@ -17,13 +17,18 @@ import (
 
 // validateServiceAuthMappings fails loudly when a network.serviceAuth or
 // network.serviceDomains service id does not map to a declared
-// credentials.sources id, or when a serviceDomains id has no serviceAuth entry.
+// credentials.sources id, and when the serviceDomains ↔ serviceAuth pairing is
+// incomplete in either direction.
+//
 // buildSecrets only builds an HTTP release rule for ids present in both
-// credentials.sources and network.serviceAuth, so either mismatch (a typo, or a
-// dropped serviceAuth line) is otherwise silently inert: the token is injected
-// as a raw env value instead of a proxy-swapped placeholder — a secret-leak
-// risk — and the serviceDomains hosts drop out of the release hosts unioned
-// into the effective allowlist.
+// credentials.sources and network.serviceAuth, so a serviceDomains id with no
+// serviceAuth entry (a typo, or a dropped serviceAuth line) is silently inert:
+// the token is injected as a raw env value instead of a proxy-swapped
+// placeholder — a secret-leak risk — and the serviceDomains hosts drop out of
+// the release hosts unioned into the effective allowlist. The reverse, a
+// serviceAuth entry with no hosts from either source, would otherwise be
+// rejected downstream by normalizeHosts, but with a message that never names
+// serviceDomains; catching it here points both directions at the same remedy.
 func validateServiceAuthMappings(doc specDocument, specPath string) error {
 	if doc.Network == nil {
 		return nil
@@ -34,20 +39,46 @@ func validateServiceAuthMappings(doc specDocument, specPath string) error {
 			sources[id] = struct{}{}
 		}
 	}
+	// Unknown ids come first: a typo'd id also breaks the pairing, and reporting
+	// the pairing gap would send the author to the wrong line.
 	for id := range doc.Network.ServiceAuth {
 		if _, ok := sources[id]; !ok {
 			return fmt.Errorf("%s: network.serviceAuth[%q] has no matching credentials.sources entry", specPath, id)
 		}
 	}
+	hostedServices := map[string]struct{}{}
 	for host, id := range doc.Network.ServiceDomains {
 		if _, ok := sources[id]; !ok {
 			return fmt.Errorf("%s: network.serviceDomains[%q] references service %q with no matching credentials.sources entry", specPath, host, id)
 		}
+		if strings.TrimSpace(host) != "" {
+			hostedServices[id] = struct{}{}
+		}
+	}
+
+	// Then the pairing, in both directions.
+	for id, auth := range doc.Network.ServiceAuth {
+		if _, ok := hostedServices[id]; !ok && !hasNonBlank(auth.Hosts) {
+			return fmt.Errorf("%s: network.serviceAuth[%q] has no hosts to release the credential to (add a hosts list, or map hosts to this service under network.serviceDomains)", specPath, id)
+		}
+	}
+	for host, id := range doc.Network.ServiceDomains {
 		if _, ok := doc.Network.ServiceAuth[id]; !ok {
 			return fmt.Errorf("%s: network.serviceDomains[%q] references service %q with no matching network.serviceAuth entry (add one, or list the hosts under network.allowedDomains instead)", specPath, host, id)
 		}
 	}
 	return nil
+}
+
+// hasNonBlank reports whether hosts holds at least one entry that survives the
+// blank-stripping normalizeHosts applies later.
+func hasNonBlank(hosts []string) bool {
+	for _, host := range hosts {
+		if strings.TrimSpace(host) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // validateProxyManaged fails loudly when an environment.proxyManaged entry

--- a/internal/config/spec_map.go
+++ b/internal/config/spec_map.go
@@ -17,10 +17,13 @@ import (
 
 // validateServiceAuthMappings fails loudly when a network.serviceAuth or
 // network.serviceDomains service id does not map to a declared
-// credentials.sources id. buildSecrets only walks credentials.sources, so an
-// unmatched id (e.g. a typo) is otherwise silently dropped: the secret ends up
-// with no HTTP release rule and its token is injected as a raw env value
-// instead of a proxy-swapped placeholder — a secret-leak risk.
+// credentials.sources id, or when a serviceDomains id has no serviceAuth entry.
+// buildSecrets only builds an HTTP release rule for ids present in both
+// credentials.sources and network.serviceAuth, so either mismatch (a typo, or a
+// dropped serviceAuth line) is otherwise silently inert: the token is injected
+// as a raw env value instead of a proxy-swapped placeholder — a secret-leak
+// risk — and the serviceDomains hosts drop out of the release hosts unioned
+// into the effective allowlist.
 func validateServiceAuthMappings(doc specDocument, specPath string) error {
 	if doc.Network == nil {
 		return nil
@@ -39,6 +42,9 @@ func validateServiceAuthMappings(doc specDocument, specPath string) error {
 	for host, id := range doc.Network.ServiceDomains {
 		if _, ok := sources[id]; !ok {
 			return fmt.Errorf("%s: network.serviceDomains[%q] references service %q with no matching credentials.sources entry", specPath, host, id)
+		}
+		if _, ok := doc.Network.ServiceAuth[id]; !ok {
+			return fmt.Errorf("%s: network.serviceDomains[%q] references service %q with no matching network.serviceAuth entry (add one, or list the hosts under network.allowedDomains instead)", specPath, host, id)
 		}
 	}
 	return nil

--- a/internal/config/spec_map_test.go
+++ b/internal/config/spec_map_test.go
@@ -57,6 +57,27 @@ network:
 		}
 	})
 
+	t.Run("serviceDomains id without serviceAuth fails", func(t *testing.T) {
+		doc := mustDoc(t, `
+schemaVersion: "1"
+kind: mixin
+name: github-cli
+credentials:
+  sources:
+    github-token: { env: [GH_TOKEN] }
+    github-enterprise-token: { env: [GH_ENTERPRISE_TOKEN] }
+network:
+  serviceDomains: { api.github.com: github-token, ghe.com: github-enterprise-token }
+  serviceAuth: { github-token: { headerName: authorization, valueFormat: "Bearer %s" } }
+`)
+		// Without the serviceAuth entry the enterprise token gets no release
+		// rule: ghe.com drops out of the release hosts unioned into the
+		// allowlist and the token is injected raw instead of proxy-swapped.
+		if err := validateServiceAuthMappings(doc, "github-cli/spec.yaml"); err == nil {
+			t.Fatal("expected error for serviceDomains id with no matching network.serviceAuth entry")
+		}
+	})
+
 	t.Run("matching ids pass", func(t *testing.T) {
 		doc := mustDoc(t, `
 schemaVersion: "1"

--- a/internal/config/spec_map_test.go
+++ b/internal/config/spec_map_test.go
@@ -8,6 +8,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/yaml"
@@ -75,6 +76,68 @@ network:
 		// allowlist and the token is injected raw instead of proxy-swapped.
 		if err := validateServiceAuthMappings(doc, "github-cli/spec.yaml"); err == nil {
 			t.Fatal("expected error for serviceDomains id with no matching network.serviceAuth entry")
+		}
+	})
+
+	t.Run("serviceAuth id without hosts fails", func(t *testing.T) {
+		doc := mustDoc(t, `
+schemaVersion: "1"
+kind: mixin
+name: github-cli
+credentials:
+  sources:
+    github-token: { env: [GH_TOKEN] }
+network:
+  serviceAuth: { github-token: { headerName: authorization } }
+`)
+		// The mirror image of the case above: with no hosts from either
+		// serviceDomains or serviceAuth.hosts, the release rule has nothing to
+		// release the credential to.
+		err := validateServiceAuthMappings(doc, "github-cli/spec.yaml")
+		if err == nil {
+			t.Fatal("expected error for serviceAuth id with no hosts")
+		}
+		if !strings.Contains(err.Error(), "network.serviceDomains") {
+			t.Fatalf("error = %v, want it to name network.serviceDomains as a remedy", err)
+		}
+	})
+
+	t.Run("unknown id is reported before the pairing gap", func(t *testing.T) {
+		doc := mustDoc(t, `
+schemaVersion: "1"
+kind: mixin
+name: github-cli
+credentials:
+  sources:
+    github-token: { env: [GH_TOKEN] }
+network:
+  serviceDomains: { api.github.com: github-tokn }
+  serviceAuth: { github-token: { headerName: authorization } }
+`)
+		// The typo leaves github-token hostless too, but pointing the author at
+		// the serviceAuth entry would hide the actual mistake.
+		err := validateServiceAuthMappings(doc, "github-cli/spec.yaml")
+		if err == nil {
+			t.Fatal("expected error for the typo'd serviceDomains id")
+		}
+		if !strings.Contains(err.Error(), "no matching credentials.sources entry") {
+			t.Fatalf("error = %v, want it to name the unknown credentials.sources id", err)
+		}
+	})
+
+	t.Run("serviceAuth hosts without serviceDomains pass", func(t *testing.T) {
+		doc := mustDoc(t, `
+schemaVersion: "1"
+kind: mixin
+name: gitlab-cli
+credentials:
+  sources:
+    gitlab-token: { env: [GITLAB_TOKEN] }
+network:
+  serviceAuth: { gitlab-token: { headerName: private-token, hosts: [gitlab.com] } }
+`)
+		if err := validateServiceAuthMappings(doc, "gitlab-cli/spec.yaml"); err != nil {
+			t.Fatalf("unexpected error for serviceAuth-declared hosts: %v", err)
 		}
 	})
 


### PR DESCRIPTION
#### What it does

Closes a fail-open gap in extension spec validation.

`network.serviceDomains` maps a host to a service id; `network.serviceAuth.<id>` defines how the gateway injects that credential. `buildSecrets` attaches an HTTP release rule only to ids present in **both** `credentials.sources` and `network.serviceAuth`, and `EffectiveResolver` unions the release hosts into the effective allowlist. A `serviceDomains` entry whose id had no `serviceAuth` entry was therefore inert in two security-relevant ways at once:

- its hosts dropped out of the effective allowlist, and
- the credential was injected as a raw env value instead of a proxy-swapped placeholder,

while `enclave validate-extensions` still reported `ok`. Deleting a single `serviceAuth` line from a spec was enough to trigger both, with no signal.

`validateServiceAuthMappings` now rejects that at load and names the remedy (add the `serviceAuth` entry, or list the hosts under `network.allowedDomains` if they only need to be reachable). The reverse direction — a `serviceAuth` entry with no hosts from either source — was already rejected by `normalizeHosts`, so the `serviceDomains` ↔ `serviceAuth` mapping is now required in both directions.

One related fix: `ListFeatures` swallowed every spec load error, so for a mixin the new load failure would have degraded to "feature silently missing from the built image". It now warns (on stderr, so shell completion stays intact) before skipping.

All built-in specs already satisfy the rule; no extension changes were needed.

#### How to test

`make build && make test && make lint`. The regression test is `TestValidateServiceAuthMappings/serviceDomains_id_without_serviceAuth_fails`.

End-to-end, with a user-authored feature spec:

```bash
TMP=$(mktemp -d)
mkdir -p $TMP/config/enclave/extensions/features/broken-feat
sed '/github-enterprise-token: { headerName/d' extensions/features/github-cli/spec.yaml \
  | sed 's/^name: github-cli/name: broken-feat/' \
  > $TMP/config/enclave/extensions/features/broken-feat/spec.yaml
XDG_CONFIG_HOME=$TMP/config ./bin/enclave validate-extensions   # before: "ok"; now: exits 1 naming the host and service
XDG_CONFIG_HOME=$TMP/config ./bin/enclave features              # now warns instead of silently omitting the feature
```

#### Follow-ups

- The `ListFeatures` skip-warning has no unit test: `specWarn` is called directly rather than injected, and threading a sink through an exported function with nine call sites seemed like more churn than a log line justifies. Verified manually as above.
- `ListFeatures` runs several times per `enclave run`, so the warning repeats. `warnReservedFields` already behaves that way, so this is the existing sink's behavior rather than something new here.

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

A spec that was previously accepted and silently inert is now a load error. No built-in spec is affected; a third-party sbx kit that uses `serviceDomains` purely for host scoping would need those hosts moved to `network.allowedDomains`.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
