### PR TITLE
fix: confine the arch import walk to this module

### DIFF
--- a/internal/arch/arch_test.go
+++ b/internal/arch/arch_test.go
@@ -14,6 +14,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -50,6 +51,9 @@ func TestDockerImportsConfinedToBackendAndCarveOuts(t *testing.T) {
 		if d.IsDir() {
 			name := d.Name()
 			if name == ".git" || name == "node_modules" || name == "frontend" || name == "bin" {
+				return filepath.SkipDir
+			}
+			if path != root && isModuleRoot(path) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -127,6 +131,14 @@ func isAllowedDockerImporter(rel string) bool {
 		}
 	}
 	return false
+}
+
+// isModuleRoot reports whether dir carries its own go.mod. Nested modules are
+// separate checkouts (agent worktrees, scratch clones) that the Go toolchain
+// excludes from ./..., so the boundary walk must exclude them too.
+func isModuleRoot(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "go.mod"))
+	return err == nil
 }
 
 func repoRoot(t *testing.T) string {


### PR DESCRIPTION
## Problem

`TestDockerImportsConfinedToBackendAndCarveOuts` walks the whole repository root and skips only `.git`, `node_modules`, `frontend`, and `bin`. It therefore descends into nested checkouts that live inside the worktree, such as agent worktrees under `.claude/`, and reports their files as boundary violations:

```
--- FAIL: TestDockerImportsConfinedToBackendAndCarveOuts
    arch_test.go:83: files import enclave/internal/docker outside the Docker backend and approved integration paths:
          .claude/worktrees/<name>/internal/app/build.go
          .claude/worktrees/<name>/internal/backend/docker/docker.go
          ...
```

Those files are not part of this module. `go list ./...` and `go test ./...` both stop at nested module boundaries, so the toolchain never builds them; only this hand-rolled walk saw them. The paths also cannot match the allowlist, since the allowlist entries are module-relative prefixes like `internal/docker/`.

The result is that `make test` fails for anyone with a nested checkout under the repository, which is easy to hit because `.claude/` is gitignored and agent tooling puts worktrees there.

## Fix

Skip directories that carry their own `go.mod`, so the walk covers the same files the toolchain builds. Only the root `go.mod` is tracked in this repository, so no first-party code is excluded.

## Verification

- The failing test passes with a nested worktree present in the working tree.
- Reintroducing a genuine violation (a file in `internal/runtime` importing `internal/docker`) still fails the test, so the guard is not weakened.
- `make build`, `make test`, and `make check-license-headers` pass. `make lint` could not run locally because `shellcheck` is not installed; `go vet` and `golangci-lint` are clean on the changed package.