### PR TITLE
fix: keep pnpm store in persistent cache

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -93,7 +93,15 @@ The image rebuilds when the Dockerfile template, entrypoint, target, base image/
 
 `--no-rebuild` bypasses all runtime and gateway image builds for the current invocation, including automatic update probes and rebuilds. It uses existing local images as-is and fails fast if a required image is missing.
 
-`--no-cache` disables the runtime package caches (host directories bind-mounted from `~/.cache/enclave/`) and does not affect the Docker build cache.
+`--no-cache` disables the runtime package cache mounts from `~/.cache/enclave/`
+and does not affect the Docker build cache. Package managers can still use
+container-local caches that are discarded with the container.
+
+Enclave explicitly points pnpm at `~/.local/share/pnpm/store` to prevent its
+mount-boundary detection from creating `.pnpm-store` in the project. The store
+is backed by Enclave's persistent cache unless `--no-cache` is set. This runtime
+setting takes precedence over a project `storeDir`; when the project and cache
+are on different filesystems, pnpm copies packages instead of hard-linking them.
 
 By default, enclave builds with `docker build` and inline image cache.
 `--cache-from <image>` adds image cache sources, and the current tool image's

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -97,11 +97,12 @@ The image rebuilds when the Dockerfile template, entrypoint, target, base image/
 and does not affect the Docker build cache. Package managers can still use
 container-local caches that are discarded with the container.
 
-Enclave explicitly points pnpm at `~/.local/share/pnpm/store` to prevent its
-mount-boundary detection from creating `.pnpm-store` in the project. The store
-is backed by Enclave's persistent cache unless `--no-cache` is set. This runtime
-setting takes precedence over a project `storeDir`; when the project and cache
-are on different filesystems, pnpm copies packages instead of hard-linking them.
+Enclave pins the pnpm store to `~/.local/share/pnpm/store`, backed by the
+persistent cache unless `--no-cache` is set, so pnpm's mount-boundary detection
+cannot create `.pnpm-store` in the project. The path is set via
+`PNPM_CONFIG_STORE_DIR` (pnpm 11 and later) and a `store-dir` entry in pnpm's
+global config file (pnpm 9 and 10), which project-level pnpm config overrides. Store and project
+are separate mounts, so pnpm copies packages instead of hard-linking them.
 
 By default, enclave builds with `docker build` and inline image cache.
 `--cache-from <image>` adds image cache sources, and the current tool image's

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -418,6 +418,7 @@ normalize_devcontainer_paths() {
         COREPACK_ROOT
         VOLTA_HOME
         FNM_DIR
+        PNPM_CONFIG_STORE_DIR
         PNPM_STORE_DIR
         YARN_CACHE_FOLDER
         XDG_CACHE_HOME

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -419,13 +419,13 @@ normalize_devcontainer_paths() {
         VOLTA_HOME
         FNM_DIR
         PNPM_CONFIG_STORE_DIR
-        PNPM_STORE_DIR
         YARN_CACHE_FOLDER
         XDG_CACHE_HOME
         XDG_CONFIG_HOME
         XDG_DATA_HOME
         npm_config_prefix
         npm_config_cache
+        npm_config_store_dir
         npm_config_userconfig
     )
     local -a extra_rewrite_vars=()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -425,7 +425,6 @@ normalize_devcontainer_paths() {
         XDG_DATA_HOME
         npm_config_prefix
         npm_config_cache
-        npm_config_store_dir
         npm_config_userconfig
     )
     local -a extra_rewrite_vars=()
@@ -510,6 +509,54 @@ normalize_devcontainer_paths() {
     if [ "$changed" = "1" ]; then
         echo "Normalized devcontainer paths from $remote_home to $current_home"
     fi
+}
+
+# Rewrites a config file in place with store-dir set to $2, preserving any other
+# entries. In place because ~/.npmrc is a bind-mounted file, where replacing the
+# inode via mktemp+mv fails.
+write_store_dir_config() {
+    local file="$1"
+    local store_dir="$2"
+    local existing=""
+
+    if [ -e "$file" ]; then
+        [ -w "$file" ] || return
+        # Drop a previously written entry so restarts cannot accumulate
+        # duplicates or keep a stale path from an earlier container home.
+        existing="$(grep -v '^[[:space:]]*store-dir[[:space:]]*=' "$file" || true)"
+    fi
+    {
+        if [ -n "$existing" ]; then
+            printf '%s\n' "$existing"
+        fi
+        if [ -n "$store_dir" ]; then
+            printf 'store-dir=%s\n' "$store_dir"
+        fi
+    } > "$file" 2>/dev/null || true
+}
+
+# pnpm 11 and later read PNPM_CONFIG_STORE_DIR from the environment, while pnpm 9
+# and 10 ignore it and take store-dir from pnpm's global config file (which 11 and
+# later in turn ignore). The file covers the older versions without depending on
+# PATH, so pnpm installed after startup via corepack, a global install, or an nvm
+# version switch is still pinned to the cache-backed store. It is pnpm's own file
+# rather than ~/.npmrc, where npm 11+ warns about store-dir as an unknown user
+# config on every npm invocation.
+configure_pnpm_store() {
+    local store_dir="${PNPM_CONFIG_STORE_DIR:-}"
+    if [ -z "$store_dir" ] || [ -z "${HOME:-}" ]; then
+        return
+    fi
+
+    # Earlier releases wrote the key to ~/.npmrc; strip it so the npm warning
+    # does not survive in the persisted file.
+    if [ -e "$HOME/.npmrc" ] && grep -q '^[[:space:]]*store-dir[[:space:]]*=' "$HOME/.npmrc" 2>/dev/null; then
+        write_store_dir_config "$HOME/.npmrc" ""
+    fi
+
+    local rc_dir="${XDG_CONFIG_HOME:-$HOME/.config}/pnpm"
+    mkdir -p "$rc_dir" 2>/dev/null || return
+    write_store_dir_config "$rc_dir/rc" "$store_dir"
 }
 
 cleanup_devcontainer_once_stamps() {
@@ -599,6 +646,11 @@ run_devcontainer_command() {
 
 if [ "${ENCLAVE_DEVCONTAINER:-}" = "1" ]; then
     normalize_devcontainer_paths
+fi
+
+configure_pnpm_store
+
+if [ "${ENCLAVE_DEVCONTAINER:-}" = "1" ]; then
     run_devcontainer_command "post-create" "${ENCLAVE_DEVCONTAINER_POST_CREATE:-}" "1"
     run_devcontainer_command "post-start" "${ENCLAVE_DEVCONTAINER_POST_START:-}" ""
 fi

--- a/internal/runtime/entrypoint_colorterm_test.go
+++ b/internal/runtime/entrypoint_colorterm_test.go
@@ -9,7 +9,6 @@ package runtime
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -34,63 +33,10 @@ func TestEntrypoint_COLORTERMPreservesExplicitValue(t *testing.T) {
 	}
 }
 
-func TestEntrypointNormalizesPnpmStoreForDevcontainerUser(t *testing.T) {
-	home := t.TempDir()
-	projectDir := filepath.Join(home, "project")
-	if err := os.MkdirAll(projectDir, 0o755); err != nil {
-		t.Fatalf("mkdir project dir: %v", err)
-	}
-
-	entrypointPath := filepath.Join("..", "..", "entrypoint.sh")
-	captureEnv := `printf "%s" "${PNPM_CONFIG_STORE_DIR:-}" > "$HOME/pnpm-store-dir.out"`
-	cmd := exec.Command("bash", entrypointPath, "bash", "-c", captureEnv)
-	cmd.Env = []string{
-		"PATH=" + os.Getenv("PATH"),
-		"HOME=" + home,
-		"PROJECT_DIR=" + projectDir,
-		"TOOL=pi",
-		"ENCLAVE_DEVCONTAINER=1",
-		"ENCLAVE_DEVCONTAINER_REMOTE_USER=node",
-		"PNPM_CONFIG_STORE_DIR=/home/node/.local/share/pnpm/store",
-	}
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, string(output))
-	}
-	value, err := os.ReadFile(filepath.Join(home, "pnpm-store-dir.out"))
-	if err != nil {
-		t.Fatalf("read pnpm store output: %v", err)
-	}
-	want := filepath.Join(home, ".local", "share", "pnpm", "store")
-	if string(value) != want {
-		t.Fatalf("PNPM_CONFIG_STORE_DIR = %q, want %q", string(value), want)
-	}
-}
-
 func runEntrypointCaptureCOLORTERM(t *testing.T, extraEnv []string) (string, string, error) {
 	t.Helper()
 
-	home := t.TempDir()
-	projectDir := filepath.Join(home, "project")
-	if err := os.MkdirAll(projectDir, 0o755); err != nil {
-		t.Fatalf("mkdir project dir: %v", err)
-	}
-
-	entrypointPath := filepath.Join("..", "..", "entrypoint.sh")
-	cmd := exec.Command("bash", entrypointPath, "bash", "-lc", `printf "%s" "${COLORTERM:-}" > "$HOME/colorterm.out"`)
-	env := []string{
-		"PATH=" + os.Getenv("PATH"),
-		"HOME=" + home,
-		"PROJECT_DIR=" + projectDir,
-		"TOOL=pi",
-	}
-	if len(extraEnv) > 0 {
-		env = append(env, extraEnv...)
-	}
-	cmd.Env = env
-
-	out, err := cmd.CombinedOutput()
+	home, out, err := runEntrypointCommand(t, extraEnv, "bash", "-lc", `printf "%s" "${COLORTERM:-}" > "$HOME/colorterm.out"`)
 	valueBytes, readErr := os.ReadFile(filepath.Join(home, "colorterm.out"))
 	if readErr != nil {
 		t.Fatalf("read colorterm output: %v\nentrypoint output:\n%s", readErr, string(out))

--- a/internal/runtime/entrypoint_colorterm_test.go
+++ b/internal/runtime/entrypoint_colorterm_test.go
@@ -34,6 +34,40 @@ func TestEntrypoint_COLORTERMPreservesExplicitValue(t *testing.T) {
 	}
 }
 
+func TestEntrypointNormalizesPnpmStoreForDevcontainerUser(t *testing.T) {
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+
+	entrypointPath := filepath.Join("..", "..", "entrypoint.sh")
+	captureEnv := `printf "%s" "${PNPM_CONFIG_STORE_DIR:-}" > "$HOME/pnpm-store-dir.out"`
+	cmd := exec.Command("bash", entrypointPath, "bash", "-c", captureEnv)
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + home,
+		"PROJECT_DIR=" + projectDir,
+		"TOOL=pi",
+		"ENCLAVE_DEVCONTAINER=1",
+		"ENCLAVE_DEVCONTAINER_REMOTE_USER=node",
+		"PNPM_CONFIG_STORE_DIR=/home/node/.local/share/pnpm/store",
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, string(output))
+	}
+	value, err := os.ReadFile(filepath.Join(home, "pnpm-store-dir.out"))
+	if err != nil {
+		t.Fatalf("read pnpm store output: %v", err)
+	}
+	want := filepath.Join(home, ".local", "share", "pnpm", "store")
+	if string(value) != want {
+		t.Fatalf("PNPM_CONFIG_STORE_DIR = %q, want %q", string(value), want)
+	}
+}
+
 func runEntrypointCaptureCOLORTERM(t *testing.T, extraEnv []string) (string, string, error) {
 	t.Helper()
 

--- a/internal/runtime/entrypoint_devcontainer_test.go
+++ b/internal/runtime/entrypoint_devcontainer_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestEntrypointNormalizesPnpmStoreForDevcontainerUser(t *testing.T) {
+	captureEnv := `{
+printf 'PNPM_CONFIG_STORE_DIR=%s\n' "${PNPM_CONFIG_STORE_DIR:-}"
+printf 'npm_config_store_dir=%s\n' "${npm_config_store_dir:-}"
+} > "$HOME/pnpm-store-dir.out"`
+	home, output, err := runEntrypointCommand(t, []string{
+		"ENCLAVE_DEVCONTAINER=1",
+		"ENCLAVE_DEVCONTAINER_REMOTE_USER=node",
+		"PNPM_CONFIG_STORE_DIR=/home/node/.local/share/pnpm/store",
+		"npm_config_store_dir=/home/node/.local/share/pnpm/store",
+	}, "bash", "-c", captureEnv)
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
+	}
+
+	values := readEntrypointEnvFile(t, filepath.Join(home, "pnpm-store-dir.out"))
+	want := filepath.Join(home, ".local", "share", "pnpm", "store")
+	for _, key := range []string{"PNPM_CONFIG_STORE_DIR", "npm_config_store_dir"} {
+		if values[key] != want {
+			t.Fatalf("%s = %q, want %q", key, values[key], want)
+		}
+	}
+}

--- a/internal/runtime/entrypoint_devcontainer_test.go
+++ b/internal/runtime/entrypoint_devcontainer_test.go
@@ -13,15 +13,11 @@ import (
 )
 
 func TestEntrypointNormalizesPnpmStoreForDevcontainerUser(t *testing.T) {
-	captureEnv := `{
-printf 'PNPM_CONFIG_STORE_DIR=%s\n' "${PNPM_CONFIG_STORE_DIR:-}"
-printf 'npm_config_store_dir=%s\n' "${npm_config_store_dir:-}"
-} > "$HOME/pnpm-store-dir.out"`
+	captureEnv := `printf 'PNPM_CONFIG_STORE_DIR=%s\n' "${PNPM_CONFIG_STORE_DIR:-}" > "$HOME/pnpm-store-dir.out"`
 	home, output, err := runEntrypointCommand(t, []string{
 		"ENCLAVE_DEVCONTAINER=1",
 		"ENCLAVE_DEVCONTAINER_REMOTE_USER=node",
 		"PNPM_CONFIG_STORE_DIR=/home/node/.local/share/pnpm/store",
-		"npm_config_store_dir=/home/node/.local/share/pnpm/store",
 	}, "bash", "-c", captureEnv)
 	if err != nil {
 		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
@@ -29,9 +25,7 @@ printf 'npm_config_store_dir=%s\n' "${npm_config_store_dir:-}"
 
 	values := readEntrypointEnvFile(t, filepath.Join(home, "pnpm-store-dir.out"))
 	want := filepath.Join(home, ".local", "share", "pnpm", "store")
-	for _, key := range []string{"PNPM_CONFIG_STORE_DIR", "npm_config_store_dir"} {
-		if values[key] != want {
-			t.Fatalf("%s = %q, want %q", key, values[key], want)
-		}
+	if values["PNPM_CONFIG_STORE_DIR"] != want {
+		t.Fatalf("PNPM_CONFIG_STORE_DIR = %q, want %q", values["PNPM_CONFIG_STORE_DIR"], want)
 	}
 }

--- a/internal/runtime/entrypoint_helpers_test.go
+++ b/internal/runtime/entrypoint_helpers_test.go
@@ -17,6 +17,30 @@ import (
 
 const claudeCredentialsFile = ".credentials.json"
 
+func runEntrypointCommand(t *testing.T, extraEnv []string, args ...string) (string, string, error) {
+	t.Helper()
+
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+
+	entrypointPath := filepath.Join("..", "..", "entrypoint.sh")
+	cmdArgs := append([]string{entrypointPath}, args...)
+	cmd := exec.Command("bash", cmdArgs...)
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + home,
+		"PROJECT_DIR=" + projectDir,
+		"TOOL=pi",
+	}
+	cmd.Env = append(cmd.Env, extraEnv...)
+
+	output, err := cmd.CombinedOutput()
+	return home, string(output), err
+}
+
 func claudeCreds(expiresAt int) string {
 	return `{"claudeAiOauth":{"expiresAt":` + strconv.Itoa(expiresAt) + `}}`
 }

--- a/internal/runtime/entrypoint_helpers_test.go
+++ b/internal/runtime/entrypoint_helpers_test.go
@@ -21,6 +21,15 @@ func runEntrypointCommand(t *testing.T, extraEnv []string, args ...string) (stri
 	t.Helper()
 
 	home := t.TempDir()
+	output, err := runEntrypointCommandInHome(t, home, extraEnv, args...)
+	return home, output, err
+}
+
+// runEntrypointCommandInHome runs the entrypoint against a caller-owned home so
+// tests can seed files or invoke it repeatedly with the same state.
+func runEntrypointCommandInHome(t *testing.T, home string, extraEnv []string, args ...string) (string, error) {
+	t.Helper()
+
 	projectDir := filepath.Join(home, "project")
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatalf("mkdir project dir: %v", err)
@@ -38,7 +47,7 @@ func runEntrypointCommand(t *testing.T, extraEnv []string, args ...string) (stri
 	cmd.Env = append(cmd.Env, extraEnv...)
 
 	output, err := cmd.CombinedOutput()
-	return home, string(output), err
+	return string(output), err
 }
 
 func claudeCreds(expiresAt int) string {

--- a/internal/runtime/entrypoint_pnpm_test.go
+++ b/internal/runtime/entrypoint_pnpm_test.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const pnpmTestStoreDir = "/home/agent/.local/share/pnpm/store"
+
+func pnpmGlobalConfigPath(home string) string {
+	return filepath.Join(home, ".config", "pnpm", "rc")
+}
+
+// pnpm 9 and 10 read the store location from pnpm's global config file; pnpm 11
+// and later read PNPM_CONFIG_STORE_DIR from the environment and ignore the file.
+func TestEntrypointWritesPnpmStoreToGlobalConfig(t *testing.T) {
+	home, output, err := runEntrypointCommand(t, []string{
+		"PNPM_CONFIG_STORE_DIR=" + pnpmTestStoreDir,
+	}, "true")
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
+	}
+
+	assertFileContent(t, pnpmGlobalConfigPath(home), "store-dir="+pnpmTestStoreDir+"\n")
+}
+
+func TestEntrypointWritesPnpmStoreToXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	xdgDir := filepath.Join(home, "xdg")
+
+	output, err := runEntrypointCommandInHome(t, home, []string{
+		"PNPM_CONFIG_STORE_DIR=" + pnpmTestStoreDir,
+		"XDG_CONFIG_HOME=" + xdgDir,
+	}, "true")
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
+	}
+
+	assertFileContent(t, filepath.Join(xdgDir, "pnpm", "rc"), "store-dir="+pnpmTestStoreDir+"\n")
+}
+
+// store-dir in ~/.npmrc makes npm 11+ warn about an unknown user config on every
+// invocation, so it must not land there.
+func TestEntrypointLeavesNpmrcAlone(t *testing.T) {
+	home := t.TempDir()
+	npmrc := filepath.Join(home, ".npmrc")
+	writeFile(t, npmrc, "registry=https://example.test/\n")
+
+	output, err := runEntrypointCommandInHome(t, home, []string{
+		"PNPM_CONFIG_STORE_DIR=" + pnpmTestStoreDir,
+	}, "true")
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
+	}
+
+	assertFileContent(t, npmrc, "registry=https://example.test/\n")
+}
+
+// ~/.npmrc persists across sessions, so an entry written by an earlier release
+// has to be cleaned up rather than left to keep warning.
+func TestEntrypointRemovesStoreDirFromNpmrc(t *testing.T) {
+	home := t.TempDir()
+	npmrc := filepath.Join(home, ".npmrc")
+	writeFile(t, npmrc, "registry=https://example.test/\nstore-dir=/stale/store\n")
+
+	output, err := runEntrypointCommandInHome(t, home, []string{
+		"PNPM_CONFIG_STORE_DIR=" + pnpmTestStoreDir,
+	}, "true")
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
+	}
+
+	assertFileContent(t, npmrc, "registry=https://example.test/\n")
+	assertFileContent(t, pnpmGlobalConfigPath(home), "store-dir="+pnpmTestStoreDir+"\n")
+}
+
+func TestEntrypointKeepsOtherPnpmGlobalConfigEntries(t *testing.T) {
+	home := t.TempDir()
+	rc := pnpmGlobalConfigPath(home)
+	writeFile(t, rc, "store-dir=/stale/store\nnode-linker=hoisted\n")
+
+	output, err := runEntrypointCommandInHome(t, home, []string{
+		"PNPM_CONFIG_STORE_DIR=" + pnpmTestStoreDir,
+	}, "true")
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
+	}
+
+	assertFileContent(t, rc, "node-linker=hoisted\nstore-dir="+pnpmTestStoreDir+"\n")
+}
+
+func TestEntrypointRewritesPnpmStoreIdempotently(t *testing.T) {
+	home := t.TempDir()
+	for i := 0; i < 2; i++ {
+		output, err := runEntrypointCommandInHome(t, home, []string{
+			"PNPM_CONFIG_STORE_DIR=" + pnpmTestStoreDir,
+		}, "true")
+		if err != nil {
+			t.Fatalf("entrypoint run %d failed: %v\noutput:\n%s", i, err, output)
+		}
+	}
+
+	data, err := os.ReadFile(pnpmGlobalConfigPath(home))
+	if err != nil {
+		t.Fatalf("read pnpm config: %v", err)
+	}
+	if got := strings.Count(string(data), "store-dir="); got != 1 {
+		t.Fatalf("store-dir entries = %d, want 1\nconfig:\n%s", got, data)
+	}
+}
+
+func TestEntrypointDoesNotExportLegacyStoreEnv(t *testing.T) {
+	home, output, err := runEntrypointCommand(t, []string{
+		"PNPM_CONFIG_STORE_DIR=" + pnpmTestStoreDir,
+	}, "bash", "-c", `printf 'store=%s\n' "${npm_config_store_dir:-}" > "$HOME/pnpm-env.out"`)
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
+	}
+
+	values := readEntrypointEnvFile(t, filepath.Join(home, "pnpm-env.out"))
+	if values["store"] != "" {
+		t.Fatalf("npm_config_store_dir leaked into the environment: %q", values["store"])
+	}
+}
+
+func TestEntrypointSkipsPnpmConfigWithoutStoreDir(t *testing.T) {
+	home, output, err := runEntrypointCommand(t, nil, "true")
+	if err != nil {
+		t.Fatalf("entrypoint failed: %v\noutput:\n%s", err, output)
+	}
+
+	if _, err := os.Stat(pnpmGlobalConfigPath(home)); !os.IsNotExist(err) {
+		t.Fatalf("expected no pnpm global config, stat error = %v", err)
+	}
+}

--- a/internal/runtime/env_variables_test.go
+++ b/internal/runtime/env_variables_test.go
@@ -92,12 +92,14 @@ func TestAddCacheMountsConfiguresPnpmStore(t *testing.T) {
 	r.addCacheMounts(mounts)
 
 	want := "/home/agent/.local/share/pnpm/store"
-	if !envSliceContainsKV(mounts.Env(), "PNPM_CONFIG_STORE_DIR", want) {
-		t.Fatalf("expected PNPM_CONFIG_STORE_DIR=%s, got %v", want, mounts.Env())
+	for _, key := range []string{"PNPM_CONFIG_STORE_DIR", "npm_config_store_dir"} {
+		if !envSliceContainsKV(mounts.Env(), key, want) {
+			t.Fatalf("expected %s=%s, got %v", key, want, mounts.Env())
+		}
 	}
 }
 
-func TestAddCacheMountsOmitsPnpmStoreWithoutCache(t *testing.T) {
+func TestAddCacheMountsUsesEphemeralPnpmStoreWithoutCache(t *testing.T) {
 	r := &Runtime{
 		run:           model.RunOptions{NoCache: true},
 		containerHome: "/home/agent",
@@ -106,8 +108,14 @@ func TestAddCacheMountsOmitsPnpmStoreWithoutCache(t *testing.T) {
 	mounts := newMountAccumulator(nil, nil)
 	r.addCacheMounts(mounts)
 
-	if envSliceHasKey(mounts.Env(), "PNPM_CONFIG_STORE_DIR") {
-		t.Fatalf("did not expect PNPM_CONFIG_STORE_DIR with cache disabled, got %v", mounts.Env())
+	want := "/home/agent/.local/share/pnpm/store"
+	for _, key := range []string{"PNPM_CONFIG_STORE_DIR", "npm_config_store_dir"} {
+		if !envSliceContainsKV(mounts.Env(), key, want) {
+			t.Fatalf("expected %s=%s, got %v", key, want, mounts.Env())
+		}
+	}
+	if len(mounts.Mounts()) != 0 {
+		t.Fatalf("did not expect cache mounts with cache disabled, got %v", mounts.Mounts())
 	}
 }
 

--- a/internal/runtime/env_variables_test.go
+++ b/internal/runtime/env_variables_test.go
@@ -80,6 +80,37 @@ func TestBaseMountsIncludesMixinEnvVariables(t *testing.T) {
 	}
 }
 
+func TestAddCacheMountsConfiguresPnpmStore(t *testing.T) {
+	r := &Runtime{
+		host:          model.Host{Home: t.TempDir()},
+		project:       model.Project{Hash: "project-hash"},
+		profile:       model.Profile{Name: "demo"},
+		containerHome: "/home/agent",
+	}
+
+	mounts := newMountAccumulator(nil, nil)
+	r.addCacheMounts(mounts)
+
+	want := "/home/agent/.local/share/pnpm/store"
+	if !envSliceContainsKV(mounts.Env(), "PNPM_CONFIG_STORE_DIR", want) {
+		t.Fatalf("expected PNPM_CONFIG_STORE_DIR=%s, got %v", want, mounts.Env())
+	}
+}
+
+func TestAddCacheMountsOmitsPnpmStoreWithoutCache(t *testing.T) {
+	r := &Runtime{
+		run:           model.RunOptions{NoCache: true},
+		containerHome: "/home/agent",
+	}
+
+	mounts := newMountAccumulator(nil, nil)
+	r.addCacheMounts(mounts)
+
+	if envSliceHasKey(mounts.Env(), "PNPM_CONFIG_STORE_DIR") {
+		t.Fatalf("did not expect PNPM_CONFIG_STORE_DIR with cache disabled, got %v", mounts.Env())
+	}
+}
+
 // TestSpecProxyManagedUnionsMixins covers proxyManaged aliases declared by a
 // mixin surviving into placeholder selection.
 func TestSpecProxyManagedUnionsMixins(t *testing.T) {

--- a/internal/runtime/env_variables_test.go
+++ b/internal/runtime/env_variables_test.go
@@ -92,10 +92,8 @@ func TestAddCacheMountsConfiguresPnpmStore(t *testing.T) {
 	r.addCacheMounts(mounts)
 
 	want := "/home/agent/.local/share/pnpm/store"
-	for _, key := range []string{"PNPM_CONFIG_STORE_DIR", "npm_config_store_dir"} {
-		if !envSliceContainsKV(mounts.Env(), key, want) {
-			t.Fatalf("expected %s=%s, got %v", key, want, mounts.Env())
-		}
+	if !envSliceContainsKV(mounts.Env(), "PNPM_CONFIG_STORE_DIR", want) {
+		t.Fatalf("expected PNPM_CONFIG_STORE_DIR=%s, got %v", want, mounts.Env())
 	}
 }
 
@@ -109,10 +107,8 @@ func TestAddCacheMountsUsesEphemeralPnpmStoreWithoutCache(t *testing.T) {
 	r.addCacheMounts(mounts)
 
 	want := "/home/agent/.local/share/pnpm/store"
-	for _, key := range []string{"PNPM_CONFIG_STORE_DIR", "npm_config_store_dir"} {
-		if !envSliceContainsKV(mounts.Env(), key, want) {
-			t.Fatalf("expected %s=%s, got %v", key, want, mounts.Env())
-		}
+	if !envSliceContainsKV(mounts.Env(), "PNPM_CONFIG_STORE_DIR", want) {
+		t.Fatalf("expected PNPM_CONFIG_STORE_DIR=%s, got %v", want, mounts.Env())
 	}
 	if len(mounts.Mounts()) != 0 {
 		t.Fatalf("did not expect cache mounts with cache disabled, got %v", mounts.Mounts())

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1097,9 +1097,7 @@ func (r *Runtime) addSessionMonitorEnv(mounts *mountAccumulator) {
 
 func (r *Runtime) addCacheMounts(mounts *mountAccumulator) {
 	pnpmStoreDir := r.containerHome + "/.local/share/pnpm/store"
-	// pnpm 11 uses PNPM_CONFIG_*; pnpm 10 and older use npm_config_*.
 	mounts.AddEnv("PNPM_CONFIG_STORE_DIR", pnpmStoreDir)
-	mounts.AddEnv("npm_config_store_dir", pnpmStoreDir)
 
 	if r.run.NoCache {
 		return

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1120,6 +1120,7 @@ func (r *Runtime) addCacheMounts(mounts *mountAccumulator) {
 	mounts.AddMount(bindMount(filepath.Join(cacheDir, "cargo"), r.containerHome+"/.cargo", false))
 	// pnpm store
 	mounts.AddMount(bindMount(filepath.Join(cacheDir, "pnpm"), r.containerHome+"/.local/share/pnpm", false))
+	mounts.AddEnv("PNPM_CONFIG_STORE_DIR", r.containerHome+"/.local/share/pnpm/store")
 	// uv (Python) cache
 	mounts.AddMount(bindMount(filepath.Join(cacheDir, "uv"), r.containerHome+"/.cache/uv", false))
 	// Yarn cache

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1096,6 +1096,11 @@ func (r *Runtime) addSessionMonitorEnv(mounts *mountAccumulator) {
 }
 
 func (r *Runtime) addCacheMounts(mounts *mountAccumulator) {
+	pnpmStoreDir := r.containerHome + "/.local/share/pnpm/store"
+	// pnpm 11 uses PNPM_CONFIG_*; pnpm 10 and older use npm_config_*.
+	mounts.AddEnv("PNPM_CONFIG_STORE_DIR", pnpmStoreDir)
+	mounts.AddEnv("npm_config_store_dir", pnpmStoreDir)
+
 	if r.run.NoCache {
 		return
 	}
@@ -1120,7 +1125,6 @@ func (r *Runtime) addCacheMounts(mounts *mountAccumulator) {
 	mounts.AddMount(bindMount(filepath.Join(cacheDir, "cargo"), r.containerHome+"/.cargo", false))
 	// pnpm store
 	mounts.AddMount(bindMount(filepath.Join(cacheDir, "pnpm"), r.containerHome+"/.local/share/pnpm", false))
-	mounts.AddEnv("PNPM_CONFIG_STORE_DIR", r.containerHome+"/.local/share/pnpm/store")
 	// uv (Python) cache
 	mounts.AddMount(bindMount(filepath.Join(cacheDir, "uv"), r.containerHome+"/.cache/uv", false))
 	// Yarn cache


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
 - Configure pnpm to use Enclave's persistent cache mount instead of creating
    `.pnpm-store` in the project workspace
  - Preserve `--no-cache` behavior and normalize the store path for devcontainer
    remote users
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
