### PR TITLE
docs: add a configuration page to the website

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,10 +27,14 @@ Security guardrail: project config cannot elevate guarded options. Each is
 ignored with a warning naming the file; use global config or CLI flags for
 explicit host opt-in. Guarded at project scope: `tool`, `yolo`,
 `allow_all_network=true`, `allow_domains`, `pass_env`, `host_config`,
-`host_config_paths` (including under `tool_overrides.<tool>`), `base_image`,
-`bridge_ports`, `add_dirs`/`add_readonly_dirs` entries outside the project
-subtree, `project_mount="writable"`, and any `worktree_metadata` value that
-relaxes the inherited mode.
+`tool_overrides.<tool>.host_config_paths`, `base_image`, `bridge_ports`,
+`add_dirs`/`add_readonly_dirs` entries outside the project subtree,
+`project_mount="writable"`, and any `worktree_metadata` value that relaxes the
+inherited mode.
+
+Top-level `host_config_paths` is not part of that set: it is ignored with a
+warning in any config file, global included, because passthrough paths are only
+supported under `tool_overrides.<tool>`.
 
 ## Config Keys
 
@@ -40,7 +44,7 @@ relaxes the inherited mode.
 | `backend` | Isolation backend (`docker`, default; experimental `qemu`) |
 | `host_config` | `none` (default) or `passthrough` |
 | `tool_overrides.<tool>.host_config_paths` | Per-tool passthrough path directives (`default`, `+path`, `-path`, or explicit list) |
-| `yolo` | Enable YOLO mode (default: `true`) |
+| `yolo` | Enable YOLO mode (default: `true`). Only consulted when the selected tool's profile leaves `yoloEnabled` unset; every bundled CLI agent sets it, so use `--yolo`/`--no-yolo` for those |
 | `ephemeral` | Run without persistent auth/env stores |
 | `auth_scope` | `shared` or `project` (default: `shared`) |
 | `auth_name` | Named per-tool shared auth identity slug; unset uses the default store |
@@ -95,7 +99,7 @@ option has no effect.
 ```json
 {
   "tool": "codex",
-  "yolo": false,
+  "project_mount": "readonly",
   "secrets_scope": "project",
   "pass_env": ["GITHUB_TOKEN"],
   "allow_all_network": false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,14 @@ substitute it for `~/.config/enclave/` in every path below.
 4. Global config (`~/.config/enclave/config.json`)
 5. Built-in defaults
 
-Security guardrail: project config cannot elevate guarded options such as `allow_all_network=true` or `allow_domains`. Those values are ignored with a warning; use global config or CLI flags for explicit host opt-in.
+Security guardrail: project config cannot elevate guarded options. Each is
+ignored with a warning naming the file; use global config or CLI flags for
+explicit host opt-in. Guarded at project scope: `tool`, `yolo`,
+`allow_all_network=true`, `allow_domains`, `pass_env`, `host_config`,
+`host_config_paths` (including under `tool_overrides.<tool>`), `base_image`,
+`bridge_ports`, `add_dirs`/`add_readonly_dirs` entries outside the project
+subtree, `project_mount="writable"`, and any `worktree_metadata` value that
+relaxes the inherited mode.
 
 ## Config Keys
 

--- a/website/docs/docs/cli.md
+++ b/website/docs/docs/cli.md
@@ -125,5 +125,5 @@ detaching, so use the detach key when you want to leave the container running.
 ## Next steps
 
 New to Enclave? Start with [Getting Started](/getting-started) to install it and
-run your first session. Deeper guides for custom skills, extra mounts, and
-per-project network allowlists are on the way.
+run your first session. To make any of these flags stick — per project or
+globally — see [Configuration](/configuration).

--- a/website/docs/docs/cli.md
+++ b/website/docs/docs/cli.md
@@ -15,6 +15,9 @@ their changes colliding, give each one its own git worktree (see
 :::info
 The CLI is still evolving, and more commands and flags are on the way. This page
 covers the core commands available today; it will grow as the surface stabilizes.
+For everything else, including session inspection, cleanup, the network and
+auth subcommands, and build flags, see the
+[CLI reference](https://github.com/eclipse-enclave/enclave/blob/main/docs/cli-reference.md).
 :::
 
 ## Overview
@@ -125,5 +128,7 @@ detaching, so use the detach key when you want to leave the container running.
 ## Next steps
 
 New to Enclave? Start with [Getting Started](/getting-started) to install it and
-run your first session. To make any of these flags stick — per project or
-globally — see [Configuration](/configuration).
+run your first session. To make any of these flags stick, per project or
+globally, see [Configuration](/configuration). For the complete command and
+flag list, see the
+[CLI reference](https://github.com/eclipse-enclave/enclave/blob/main/docs/cli-reference.md).

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -18,7 +18,7 @@ A setting can come from three places:
 | Project config | `~/.config/enclave/projects/<hash>/config.json` | one repository |
 | Global config | `~/.config/enclave/config.json` | your defaults everywhere |
 
-Both files are plain JSON. Every key is optional, and every key has a matching
+Both files are plain JSON. Every key is optional, and most keys have a matching
 CLI flag:
 
 ```json
@@ -87,7 +87,7 @@ enclave config --json            # the same data, machine-readable
 | Key | Flag | What it does |
 | --- | --- | --- |
 | `tool` | `--tool <name>` | Which agent runs. Defaults to `claude`; `enclave tools` lists what is installed. |
-| `yolo` | `--no-yolo` | Full autonomy, on by default. Turn it off to make the agent ask for confirmation again. |
+| `yolo` | `--no-yolo` | Full autonomy, on by default. Pass `--no-yolo` to make the agent ask for confirmation again. Every bundled CLI agent pins the mode in its own profile, so `"yolo": false` in a config file does not reach them; use the flag. |
 | `features` | `--features <list>` | Extra tooling baked into the image (see [Features](#features)). |
 | `ports` | `-p 3000` | Publish a container port to the host, so the agent's dev server is reachable from your browser. |
 | `bridge_ports` | `--bridge-port 9800` | The other direction: make a host service reachable at `localhost:9800` inside the container. |
@@ -202,6 +202,7 @@ global config or pass them on the command line instead.
 | `add_dirs`, `add_readonly_dirs` outside the project | Project scope can only mount subdirectories of the project itself. |
 | `base_image`, `bridge_ports` | Base image and host-port bridging stay host-side decisions. |
 | `project_mount: "writable"` | Project scope can tighten a stricter global default, never loosen it. |
+| `worktree_metadata` values that relax the inherited mode | Same rule for the linked-worktree git metadata mounts: tighten only. |
 
 ## Per-tool overrides
 

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -7,8 +7,8 @@ title: Configuration
 
 Enclave works without any configuration: `enclave` starts the `claude` agent at
 full autonomy, in a container, behind a restricted network. You configure it
-when you want something else — a different agent, one more allowed domain, an
-extra directory mounted in.
+when you want something else, such as a different agent, one more allowed
+domain, or an extra directory mounted in.
 
 A setting can come from three places:
 
@@ -29,7 +29,7 @@ CLI flag:
 }
 ```
 
-:::note macOS
+:::note[macOS]
 The config root is `~/Library/Application Support/org.eclipse.enclave/config/`
 instead of `~/.config/enclave/`. Substitute it in every path on this page.
 :::
@@ -47,13 +47,11 @@ enclave config
 ```text
 Global Config: /home/you/.config/enclave/config.json (missing)
 Project Config: /home/you/.config/enclave/projects/1a2b3c4d5e6f/config.json (missing)
-
-Config sources (highest wins): cli > tool_override > project > global > default
 ```
 
-Create either file yourself — `mkdir -p` its directory, start with `{}` — and
-Enclave picks it up on the next run. JSON comments are not supported, so keep
-the file strict JSON.
+Create either file yourself, with `mkdir -p` on its directory and `{}` as the
+starting content, and Enclave picks it up on the next run. JSON comments are not
+supported, so keep the file strict JSON.
 
 Two things follow from the layout:
 
@@ -82,7 +80,7 @@ enclave config --view diff       # only values that something overrode
 enclave config --json            # the same data, machine-readable
 ```
 
-## The options you will actually use
+## Most commonly used options
 
 ### Agent and session
 
@@ -92,7 +90,7 @@ enclave config --json            # the same data, machine-readable
 | `yolo` | `--no-yolo` | Full autonomy, on by default. Turn it off to make the agent ask for confirmation again. |
 | `features` | `--features <list>` | Extra tooling baked into the image (see [Features](#features)). |
 | `session_monitor` | `--session-monitor` | Run the agent under a managed tmux session so `enclave status` can snapshot what it is doing. |
-| `ports` | `-p 3000` | Publish a container port to the host — reach the agent's dev server from your browser. |
+| `ports` | `-p 3000` | Publish a container port to the host, so the agent's dev server is reachable from your browser. |
 | `bridge_ports` | `--bridge-port 9800` | The other direction: make a host service reachable at `localhost:9800` inside the container. |
 
 :::note
@@ -137,7 +135,7 @@ global config or pass them on the command line instead.
 
 | Ignored in project config | Why |
 | --- | --- |
-| `tool` | Choosing the agent stays a user decision — pass `--tool` or set it globally. |
+| `tool` | Choosing the agent stays a user decision. Pass `--tool` or set it globally. |
 | `yolo` | A repository cannot decide how much autonomy its agent gets. |
 | `allow_all_network`, `allow_domains` | A repository cannot widen its own network allowlist. |
 | `pass_env` | A repository cannot ask for your host environment variables. |
@@ -182,8 +180,8 @@ Use `+` and `-` to adjust the inherited set instead of replacing it:
 ```
 
 A list without prefixes replaces the set entirely, and `[]` means none. Check the
-result before you build — `enclave features` marks every feature `✓` or `✗` and
-names the config file that switched it off:
+result before you build with `enclave features`, which marks every feature `✓`
+or `✗` and names the config file that switched it off:
 
 ```bash
 enclave features
@@ -198,7 +196,7 @@ By default the container starts from Enclave's own agent config, not your host
 one. Two ways to change that:
 
 **Pass reviewed paths through from the host.** `host_config: "passthrough"`
-copies a per-tool allow-list of files out of your host config directory — for
+copies a per-tool allow-list of files out of your host config directory. For
 Claude that is `agents/`, `commands/`, `settings.json`, and `skills/` under
 `~/.claude`. Auth files, OAuth JSON, and session/history state are blocked even
 if you add them to the list. Narrow or widen the list per tool:
@@ -216,7 +214,7 @@ if you add them to the list. Narrow or widen the list per tool:
 
 **Or keep a separate, container-only config.** Files under
 `~/.config/enclave/tools/<tool>/` mirror the agent's native config layout and are
-overlaid at session start — `~/.config/enclave/tools/claude/settings.json`
+overlaid at session start, so `~/.config/enclave/tools/claude/settings.json`
 becomes the container's `~/.claude/settings.json`. Per project, use
 `~/.config/enclave/projects/<hash>/<tool>/config/`. Shared skills go in
 `~/.config/enclave/skills/<skill>/` and reach every skill-capable agent.
@@ -228,7 +226,7 @@ passthrough safety rules are documented in
 
 ## Going further
 
-- [Configuration reference](https://github.com/eclipse-enclave/enclave/blob/main/docs/configuration.md) — every key, patches, skills, precedence details
-- [CLI reference](https://github.com/eclipse-enclave/enclave/blob/main/docs/cli-reference.md) — every command and flag
-- [Networking](https://github.com/eclipse-enclave/enclave/blob/main/docs/networking.md) — allowlists, the gateway, port forwarding
-- [Authentication and secrets](https://github.com/eclipse-enclave/enclave/blob/main/docs/auth.md) — logins, secrets layers, API keys
+- [Configuration reference](https://github.com/eclipse-enclave/enclave/blob/main/docs/configuration.md): every key, patches, skills, precedence details
+- [CLI reference](https://github.com/eclipse-enclave/enclave/blob/main/docs/cli-reference.md): every command and flag
+- [Networking](https://github.com/eclipse-enclave/enclave/blob/main/docs/networking.md): allowlists, the gateway, port forwarding
+- [Authentication and secrets](https://github.com/eclipse-enclave/enclave/blob/main/docs/auth.md): logins, secrets layers, API keys

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -1,0 +1,234 @@
+---
+sidebar_position: 4
+title: Configuration
+---
+
+# Configuration
+
+Enclave works without any configuration: `enclave` starts the `claude` agent at
+full autonomy, in a container, behind a restricted network. You configure it
+when you want something else — a different agent, one more allowed domain, an
+extra directory mounted in.
+
+A setting can come from three places:
+
+| Layer | Where | Use it for |
+| --- | --- | --- |
+| CLI flag | `enclave --tool codex` | a single run |
+| Project config | `~/.config/enclave/projects/<hash>/config.json` | one repository |
+| Global config | `~/.config/enclave/config.json` | your defaults everywhere |
+
+Both files are plain JSON. Every key is optional, and every key has a matching
+CLI flag:
+
+```json
+{
+  "tool": "codex",
+  "features": ["+playwright"],
+  "add_readonly_dirs": ["~/reference/specs"]
+}
+```
+
+:::note macOS
+The config root is `~/Library/Application Support/org.eclipse.enclave/config/`
+instead of `~/.config/enclave/`. Substitute it in every path on this page.
+:::
+
+## Find your config files
+
+Project config is keyed by a hash of the project directory, so you never have to
+write that path yourself. `enclave config` prints both files, whether or not they
+exist yet:
+
+```bash
+enclave config
+```
+
+```text
+Global Config: /home/you/.config/enclave/config.json (missing)
+Project Config: /home/you/.config/enclave/projects/1a2b3c4d5e6f/config.json (missing)
+
+Config sources (highest wins): cli > tool_override > project > global > default
+```
+
+Create either file yourself — `mkdir -p` its directory, start with `{}` — and
+Enclave picks it up on the next run. JSON comments are not supported, so keep
+the file strict JSON.
+
+Two things follow from the layout:
+
+- Project config lives **outside** the worktree, keyed by hash. A repository
+  cannot carry its own sandbox policy, and an agent working in it cannot rewrite
+  the rules it runs under.
+- **Each git worktree is its own project.** A worktree at `../myproject-agent`
+  gets its own hash, its own project config, and its own persistent state.
+
+## Precedence
+
+Highest wins:
+
+1. CLI flags
+2. Per-tool overrides (`tool_overrides.<tool>`, see below)
+3. Project config
+4. Global config
+5. Built-in defaults
+
+When a value is not what you expect, ask Enclave where it came from:
+
+```bash
+enclave config --view source     # annotate every value with its origin
+enclave config --view effective  # just the resolved values
+enclave config --view diff       # only values that something overrode
+enclave config --json            # the same data, machine-readable
+```
+
+## The options you will actually use
+
+### Agent and session
+
+| Key | Flag | What it does |
+| --- | --- | --- |
+| `tool` | `--tool <name>` | Which agent runs. Defaults to `claude`; `enclave tools` lists what is installed. |
+| `yolo` | `--no-yolo` | Full autonomy, on by default. Turn it off to make the agent ask for confirmation again. |
+| `features` | `--features <list>` | Extra tooling baked into the image (see [Features](#features)). |
+| `session_monitor` | `--session-monitor` | Run the agent under a managed tmux session so `enclave status` can snapshot what it is doing. |
+| `ports` | `-p 3000` | Publish a container port to the host — reach the agent's dev server from your browser. |
+| `bridge_ports` | `--bridge-port 9800` | The other direction: make a host service reachable at `localhost:9800` inside the container. |
+
+:::note
+On Linux, a bridged host service has to listen on the Docker bridge IP rather
+than `127.0.0.1`, and the host firewall has to let the bridge network through.
+See [Bridging host ports](https://github.com/eclipse-enclave/enclave/blob/main/docs/networking.md#bridging-host-ports).
+:::
+
+### Files
+
+| Key | Flag | What it does |
+| --- | --- | --- |
+| `add_dirs` | `--add-dir <path>` | Mount another host directory, writable, at the same path inside the container. |
+| `add_readonly_dirs` | `--add-readonly-dir <path>` | The same, read-only. Good for reference material you do not want touched. |
+| `project_mount` | `--project-mount readonly` | Mount the project read-only: the agent can read and analyze, only you can write. |
+
+### Network
+
+| Key | Flag | What it does |
+| --- | --- | --- |
+| `allow_domains` | `--allow-domain <domain>` | Add domains to the gateway allowlist. Bare DNS names only, no scheme or path. |
+| `allow_all_network` | `--allow-all-network` | Turn network filtering off entirely for the session. |
+| `network_log` | `--network-log requests` | Log request-level audit events instead of coarse pass/deny. |
+
+### Auth and secrets
+
+| Key | Flag | What it does |
+| --- | --- | --- |
+| `auth_name` | `--auth-name <slug>` | Keep several logins per agent (`personal`, `api`, …) and pick one per run. |
+| `auth_scope` | `--auth-scope project` | Isolate credentials per project instead of sharing them per agent. |
+| `pass_env` | `--pass-env KEY1,KEY2` | Forward specific host environment variables in. Nothing else leaks in. |
+| `secrets_scope` | `--secrets-scope global` | Which layers of the secrets files are read. |
+
+The full key list, including build and persistence options, is in
+[docs/configuration.md](https://github.com/eclipse-enclave/enclave/blob/main/docs/configuration.md).
+
+## What project config cannot do
+
+Project config is deliberately weaker than global config: settings that would
+widen the sandbox are ignored there, with a warning naming the file. Set them in
+global config or pass them on the command line instead.
+
+| Ignored in project config | Why |
+| --- | --- |
+| `tool` | Choosing the agent stays a user decision — pass `--tool` or set it globally. |
+| `yolo` | A repository cannot decide how much autonomy its agent gets. |
+| `allow_all_network`, `allow_domains` | A repository cannot widen its own network allowlist. |
+| `pass_env` | A repository cannot ask for your host environment variables. |
+| `host_config`, `tool_overrides.<tool>.host_config_paths` | A repository cannot widen host-config passthrough. |
+| `add_dirs`, `add_readonly_dirs` outside the project | Project scope can only mount subdirectories of the project itself. |
+| `base_image`, `bridge_ports` | Base image and host-port bridging stay host-side decisions. |
+| `project_mount: "writable"` | Project scope can tighten a stricter global default, never loosen it. |
+
+## Per-tool overrides
+
+`tool_overrides.<tool>` applies to one agent only, and wins over the surrounding
+project and global values:
+
+```json
+{
+  "tool": "claude",
+  "allow_domains": ["api.deepseek.com"],
+  "tool_overrides": {
+    "codex": {
+      "auth_name": "personal",
+      "features": ["+python-dev"]
+    }
+  }
+}
+```
+
+Overrides take the same keys as the surrounding file, except `tool` itself and a
+nested `tool_overrides`.
+
+## Features
+
+Features are optional tool stacks compiled into the image. `devtools`,
+`github-cli`, `node-dev`, and `python-dev` are on by default; `playwright`,
+`debug-tools`, `gitlab-cli`, and `shell-extras` are opt-in.
+
+Use `+` and `-` to adjust the inherited set instead of replacing it:
+
+```json
+{
+  "features": ["+playwright", "-python-dev"]
+}
+```
+
+A list without prefixes replaces the set entirely, and `[]` means none. Check the
+result before you build — `enclave features` marks every feature `✓` or `✗` and
+names the config file that switched it off:
+
+```bash
+enclave features
+```
+
+The same syntax works on the command line: `--features +playwright`, or the
+keywords `--features default|all|none`.
+
+## Reuse the agent config you already have
+
+By default the container starts from Enclave's own agent config, not your host
+one. Two ways to change that:
+
+**Pass reviewed paths through from the host.** `host_config: "passthrough"`
+copies a per-tool allow-list of files out of your host config directory — for
+Claude that is `agents/`, `commands/`, `settings.json`, and `skills/` under
+`~/.claude`. Auth files, OAuth JSON, and session/history state are blocked even
+if you add them to the list. Narrow or widen the list per tool:
+
+```json
+{
+  "host_config": "passthrough",
+  "tool_overrides": {
+    "claude": {
+      "host_config_paths": ["default", "-skills/"]
+    }
+  }
+}
+```
+
+**Or keep a separate, container-only config.** Files under
+`~/.config/enclave/tools/<tool>/` mirror the agent's native config layout and are
+overlaid at session start — `~/.config/enclave/tools/claude/settings.json`
+becomes the container's `~/.claude/settings.json`. Per project, use
+`~/.config/enclave/projects/<hash>/<tool>/config/`. Shared skills go in
+`~/.config/enclave/skills/<skill>/` and reach every skill-capable agent.
+
+Both mechanisms compose, and JSON/TOML *patches* can merge into a file instead of
+replacing it. The precedence order, the patch merge semantics, and the full
+passthrough safety rules are documented in
+[docs/configuration.md](https://github.com/eclipse-enclave/enclave/blob/main/docs/configuration.md).
+
+## Going further
+
+- [Configuration reference](https://github.com/eclipse-enclave/enclave/blob/main/docs/configuration.md) — every key, patches, skills, precedence details
+- [CLI reference](https://github.com/eclipse-enclave/enclave/blob/main/docs/cli-reference.md) — every command and flag
+- [Networking](https://github.com/eclipse-enclave/enclave/blob/main/docs/networking.md) — allowlists, the gateway, port forwarding
+- [Authentication and secrets](https://github.com/eclipse-enclave/enclave/blob/main/docs/auth.md) — logins, secrets layers, API keys

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -89,7 +89,6 @@ enclave config --json            # the same data, machine-readable
 | `tool` | `--tool <name>` | Which agent runs. Defaults to `claude`; `enclave tools` lists what is installed. |
 | `yolo` | `--no-yolo` | Full autonomy, on by default. Turn it off to make the agent ask for confirmation again. |
 | `features` | `--features <list>` | Extra tooling baked into the image (see [Features](#features)). |
-| `session_monitor` | `--session-monitor` | Run the agent under a managed tmux session so `enclave status` can snapshot what it is doing. |
 | `ports` | `-p 3000` | Publish a container port to the host, so the agent's dev server is reachable from your browser. |
 | `bridge_ports` | `--bridge-port 9800` | The other direction: make a host service reachable at `localhost:9800` inside the container. |
 
@@ -125,6 +124,66 @@ See [Bridging host ports](https://github.com/eclipse-enclave/enclave/blob/main/d
 | `secrets_scope` | `--secrets-scope global` | Which layers of the secrets files are read. |
 
 The full key list, including build and persistence options, is in
+[docs/configuration.md](https://github.com/eclipse-enclave/enclave/blob/main/docs/configuration.md).
+
+## Features
+
+Features are optional tool stacks compiled into the image. `devtools`,
+`github-cli`, `node-dev`, and `python-dev` are on by default; `playwright`,
+`debug-tools`, `gitlab-cli`, and `shell-extras` are opt-in.
+
+Use `+` and `-` to adjust the inherited set instead of replacing it:
+
+```json
+{
+  "features": ["+playwright", "-python-dev"]
+}
+```
+
+A list without prefixes replaces the set entirely, and `[]` means none. Check the
+result before you build with `enclave features`, which marks every feature `✓`
+or `✗` and names the config file that switched it off:
+
+```bash
+enclave features
+```
+
+The same syntax works on the command line: `--features +playwright`, or the
+keywords `--features default|all|none`.
+
+## Reuse the agent config you already have
+
+By default the container starts from Enclave's own agent config, not your host
+one. Two ways to change that:
+
+**Pass reviewed paths through from the host.** `host_config: "passthrough"`
+copies a per-tool allow-list of files out of your host config directory. For
+Claude that is `agents/`, `commands/`, `settings.json`, and `skills/` under
+`~/.claude`. Auth files, OAuth JSON, and session/history state are blocked even
+if you add them to the list. Narrow or widen the list per tool, under the
+[per-tool override](#per-tool-overrides) for that agent:
+
+```json
+{
+  "host_config": "passthrough",
+  "tool_overrides": {
+    "claude": {
+      "host_config_paths": ["default", "-skills/"]
+    }
+  }
+}
+```
+
+**Or keep a separate, container-only config.** Files under
+`~/.config/enclave/tools/<tool>/` mirror the agent's native config layout and are
+overlaid at session start, so `~/.config/enclave/tools/claude/settings.json`
+becomes the container's `~/.claude/settings.json`. Per project, use
+`~/.config/enclave/projects/<hash>/<tool>/config/`. Shared skills go in
+`~/.config/enclave/skills/<skill>/` and reach every skill-capable agent.
+
+Both mechanisms compose, and JSON/TOML *patches* can merge into a file instead of
+replacing it. The precedence order, the patch merge semantics, and the full
+passthrough safety rules are documented in
 [docs/configuration.md](https://github.com/eclipse-enclave/enclave/blob/main/docs/configuration.md).
 
 ## What project config cannot do
@@ -164,65 +223,6 @@ project and global values:
 
 Overrides take the same keys as the surrounding file, except `tool` itself and a
 nested `tool_overrides`.
-
-## Features
-
-Features are optional tool stacks compiled into the image. `devtools`,
-`github-cli`, `node-dev`, and `python-dev` are on by default; `playwright`,
-`debug-tools`, `gitlab-cli`, and `shell-extras` are opt-in.
-
-Use `+` and `-` to adjust the inherited set instead of replacing it:
-
-```json
-{
-  "features": ["+playwright", "-python-dev"]
-}
-```
-
-A list without prefixes replaces the set entirely, and `[]` means none. Check the
-result before you build with `enclave features`, which marks every feature `✓`
-or `✗` and names the config file that switched it off:
-
-```bash
-enclave features
-```
-
-The same syntax works on the command line: `--features +playwright`, or the
-keywords `--features default|all|none`.
-
-## Reuse the agent config you already have
-
-By default the container starts from Enclave's own agent config, not your host
-one. Two ways to change that:
-
-**Pass reviewed paths through from the host.** `host_config: "passthrough"`
-copies a per-tool allow-list of files out of your host config directory. For
-Claude that is `agents/`, `commands/`, `settings.json`, and `skills/` under
-`~/.claude`. Auth files, OAuth JSON, and session/history state are blocked even
-if you add them to the list. Narrow or widen the list per tool:
-
-```json
-{
-  "host_config": "passthrough",
-  "tool_overrides": {
-    "claude": {
-      "host_config_paths": ["default", "-skills/"]
-    }
-  }
-}
-```
-
-**Or keep a separate, container-only config.** Files under
-`~/.config/enclave/tools/<tool>/` mirror the agent's native config layout and are
-overlaid at session start, so `~/.config/enclave/tools/claude/settings.json`
-becomes the container's `~/.claude/settings.json`. Per project, use
-`~/.config/enclave/projects/<hash>/<tool>/config/`. Shared skills go in
-`~/.config/enclave/skills/<skill>/` and reach every skill-capable agent.
-
-Both mechanisms compose, and JSON/TOML *patches* can merge into a file instead of
-replacing it. The precedence order, the patch merge semantics, and the full
-passthrough safety rules are documented in
-[docs/configuration.md](https://github.com/eclipse-enclave/enclave/blob/main/docs/configuration.md).
 
 ## Going further
 

--- a/website/docs/docs/getting-started.md
+++ b/website/docs/docs/getting-started.md
@@ -186,6 +186,6 @@ enclave ps
 
 ## Next steps
 
-See the [CLI Commands](/cli) reference for the full set of commands you can run.
-From there, you can add custom skills, mount extra directories, and set network
-allowlists per tool and per project. Guides for each of those are on the way.
+See the [CLI Commands](/cli) reference for the full set of commands you can run,
+and [Configuration](/configuration) to pick a default agent, mount extra
+directories, or widen the network allowlist per project.

--- a/website/docs/docs/support.md
+++ b/website/docs/docs/support.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: Support
 ---
 

--- a/website/docs/src/css/custom.css
+++ b/website/docs/src/css/custom.css
@@ -294,7 +294,12 @@ div[class^='codeBlockContainer'],
    Tables
    ========================================================================== */
 
+/* Infima sets `display: block` on tables, which makes the rows shrink to fit
+   their content while the table's own border box still spans the full width,
+   so header backgrounds and row rules stop short of the border. */
 .markdown table {
+  display: table;
+  width: 100%;
   border: 1px solid var(--ifm-toc-border-color);
   border-radius: 10px;
   border-collapse: separate;

--- a/website/docs/src/css/custom.css
+++ b/website/docs/src/css/custom.css
@@ -312,10 +312,14 @@ div[class^='codeBlockContainer'],
 .markdown table thead tr {
   border-bottom: 1px solid var(--ifm-toc-border-color);
 }
+/* `overflow-wrap: anywhere` also lowers the cells' min-content width, so a
+   `display: table` table can always satisfy `width: 100%` and wraps on narrow
+   viewports instead of overflowing the rounded, clipped border box. */
 .markdown table th,
 .markdown table td {
   border: 0;
   border-bottom: 1px solid var(--ifm-toc-border-color);
+  overflow-wrap: anywhere;
 }
 .markdown table tbody tr:last-child td {
   border-bottom: 0;


### PR DESCRIPTION
The website docs had nothing on configuration. This adds a Configuration page covering what a user actually reaches for in daily use:

- the three layers (CLI flag, project config, global config) and how to find both files with `enclave config`
- precedence, and the `--view source|effective|diff` modes for debugging a surprising value
- the options most users end up setting, grouped by agent/session, files, network, and auth
- what project config deliberately cannot do, and why
- features (`+`/`-` syntax), per-tool overrides, and reusing host agent config

Details are intentionally left out and cross-referenced to `docs/configuration.md`, `docs/cli-reference.md`, `docs/networking.md`, and `docs/auth.md`.

Every claim on the page was checked against the CLI (defaults, flag parsing, precedence layers, each guardrail warning, feature resolution, passthrough allow-list resolution) and against a real session for the mount promises.

While verifying, `docs/configuration.md` turned out to list only `allow_all_network` and `allow_domains` as guarded at project scope, while the loader also guards `tool`, `yolo`, `pass_env`, `host_config`, `host_config_paths`, `base_image`, `bridge_ports`, out-of-project `add_dirs`, `project_mount="writable"`, and `worktree_metadata` relaxations. That paragraph is corrected here so both pages agree.

The CLI page now also links `docs/cli-reference.md`, since it documents only the core commands and previously offered no way to the rest.

One change reaches beyond this page: Infima sets `display: block` on tables, so rows shrank to fit their content while the table's border box still spanned the full width, leaving header backgrounds short of the border. `.markdown table` is now laid out as a table at full width, which affects every table on the site. The trade-off is that wide tables wrap their cells instead of scrolling horizontally; worth a look on a narrow screen before merging.
