### PR TITLE
build: install npm tools with --ignore-scripts where upstream supports it

### DIFF
--- a/docs/extensions/adding-a-tool.md
+++ b/docs/extensions/adding-a-tool.md
@@ -37,6 +37,22 @@ sandbox:
   settingsTarget: .<tool>/settings.json
 ```
 
+### Installing from npm
+
+For a tool that is a plain npm package, `install.sh` can delegate to the shared
+helper, which installs through the private agent Node runtime and verifies the
+binary landed on `PATH`:
+
+```sh
+enclave-install-npm-tool [npm-flag ...] <package> <binary> [label]
+```
+
+Leading `-`-prefixed arguments are forwarded to `npm install`. Pass
+`--ignore-scripts` unless the package needs its lifecycle scripts, so
+dependency-authored code does not run at image build time. Check upstream
+first: some packages resolve a platform binary in a `postinstall` and break
+without it.
+
 ## 2) Fill in the `sandbox` block
 
 `sandbox.*` is enclave-native tool metadata. Common fields (see the README for

--- a/docs/extensions/adding-a-tool.md
+++ b/docs/extensions/adding-a-tool.md
@@ -47,8 +47,11 @@ binary landed on `PATH`:
 enclave-install-npm-tool [npm-flag ...] <package> <binary> [label]
 ```
 
-Leading `-`-prefixed arguments are forwarded to `npm install`. Pass
-`--ignore-scripts` unless the package needs its lifecycle scripts, so
+Leading `-`-prefixed arguments are forwarded to `npm install`, and must be
+self-contained — `--flag` or `--flag=value`. A flag that takes a separate value
+(`--omit dev`) would consume the package argument.
+
+Pass `--ignore-scripts` unless the package needs its lifecycle scripts, so
 dependency-authored code does not run at image build time. Check upstream
 first: some packages resolve a platform binary in a `postinstall` and break
 without it.

--- a/extensions/tools/claude/README.md
+++ b/extensions/tools/claude/README.md
@@ -62,7 +62,7 @@ left at the Claude Code defaults.
 | File | Purpose |
 |------|---------|
 | `spec.yaml` | Extension manifest (metadata, sandbox behavior, network, credentials) |
-| `install.sh` | Installs Claude Code via `claude.ai/install.sh` |
+| `install.sh` | Installs Claude Code via `claude.ai/install.sh`, plus `@anthropic-ai/sandbox-runtime` from npm with `--ignore-scripts` |
 | `check-update.sh` | Returns the latest GitHub release tag for automatic update probes |
 | `gateway-allowlist.conf` | DNS allowlist for network isolation |
 | `templates/settings.json` | Default settings template |

--- a/extensions/tools/claude/README.md
+++ b/extensions/tools/claude/README.md
@@ -62,7 +62,7 @@ left at the Claude Code defaults.
 | File | Purpose |
 |------|---------|
 | `spec.yaml` | Extension manifest (metadata, sandbox behavior, network, credentials) |
-| `install.sh` | Installs Claude Code via `claude.ai/install.sh`, plus `@anthropic-ai/sandbox-runtime` from npm with `--ignore-scripts` (asserting its declared bins landed) |
+| `install.sh` | Installs Claude Code via `claude.ai/install.sh`, plus `@anthropic-ai/sandbox-runtime` from npm with `--ignore-scripts` (asserting the package landed) |
 | `check-update.sh` | Returns the latest GitHub release tag for automatic update probes |
 | `gateway-allowlist.conf` | DNS allowlist for network isolation |
 | `templates/settings.json` | Default settings template |

--- a/extensions/tools/claude/README.md
+++ b/extensions/tools/claude/README.md
@@ -62,7 +62,7 @@ left at the Claude Code defaults.
 | File | Purpose |
 |------|---------|
 | `spec.yaml` | Extension manifest (metadata, sandbox behavior, network, credentials) |
-| `install.sh` | Installs Claude Code via `claude.ai/install.sh`, plus `@anthropic-ai/sandbox-runtime` from npm with `--ignore-scripts` |
+| `install.sh` | Installs Claude Code via `claude.ai/install.sh`, plus `@anthropic-ai/sandbox-runtime` from npm with `--ignore-scripts` (asserting its declared bins landed) |
 | `check-update.sh` | Returns the latest GitHub release tag for automatic update probes |
 | `gateway-allowlist.conf` | DNS allowlist for network isolation |
 | `templates/settings.json` | Default settings template |

--- a/extensions/tools/claude/install.sh
+++ b/extensions/tools/claude/install.sh
@@ -24,26 +24,12 @@ claude --version
 enclave-agent-npm-install --ignore-scripts @anthropic-ai/sandbox-runtime
 
 # Nothing else in the tree references sandbox-runtime, so an incomplete install
-# would only surface at runtime as degraded sandbox support. Assert the package
-# landed and that every bin it declares exists, which is what would break if
-# upstream started placing those in a postinstall.
+# would only surface at runtime as degraded sandbox support. enclave-agent-npm-install
+# already fails on a declared bin that did not land; assert the package itself
+# did, which it only warns about.
 sandbox_runtime_dir="${npm_config_prefix:-$HOME/.local}/lib/node_modules/@anthropic-ai/sandbox-runtime"
 if [ ! -f "$sandbox_runtime_dir/package.json" ]; then
     echo "sandbox-runtime install failed: $sandbox_runtime_dir/package.json not found" >&2
-    exit 1
-fi
-
-missing_bins=0
-while IFS= read -r bin_path; do
-    [ -n "$bin_path" ] || continue
-    if [ ! -e "$sandbox_runtime_dir/$bin_path" ]; then
-        echo "sandbox-runtime install incomplete: declared bin $bin_path is missing" >&2
-        missing_bins=1
-    fi
-done < <(jq -r '(.bin // empty) | if type == "string" then . else .[] end' "$sandbox_runtime_dir/package.json")
-
-if [ "$missing_bins" -ne 0 ]; then
-    echo "sandbox-runtime may require lifecycle scripts; re-check the --ignore-scripts above" >&2
     exit 1
 fi
 

--- a/extensions/tools/claude/install.sh
+++ b/extensions/tools/claude/install.sh
@@ -22,3 +22,29 @@ claude --version
 # Install sandbox runtime for Claude Code sandbox support.
 # It ships its vendored artifacts prebuilt and declares no lifecycle scripts.
 enclave-agent-npm-install --ignore-scripts @anthropic-ai/sandbox-runtime
+
+# Nothing else in the tree references sandbox-runtime, so an incomplete install
+# would only surface at runtime as degraded sandbox support. Assert the package
+# landed and that every bin it declares exists, which is what would break if
+# upstream started placing those in a postinstall.
+sandbox_runtime_dir="${npm_config_prefix:-$HOME/.local}/lib/node_modules/@anthropic-ai/sandbox-runtime"
+if [ ! -f "$sandbox_runtime_dir/package.json" ]; then
+    echo "sandbox-runtime install failed: $sandbox_runtime_dir/package.json not found" >&2
+    exit 1
+fi
+
+missing_bins=0
+while IFS= read -r bin_path; do
+    [ -n "$bin_path" ] || continue
+    if [ ! -e "$sandbox_runtime_dir/$bin_path" ]; then
+        echo "sandbox-runtime install incomplete: declared bin $bin_path is missing" >&2
+        missing_bins=1
+    fi
+done < <(jq -r '(.bin // empty) | if type == "string" then . else .[] end' "$sandbox_runtime_dir/package.json")
+
+if [ "$missing_bins" -ne 0 ]; then
+    echo "sandbox-runtime may require lifecycle scripts; re-check the --ignore-scripts above" >&2
+    exit 1
+fi
+
+echo "sandbox-runtime installed at: $sandbox_runtime_dir"

--- a/extensions/tools/claude/install.sh
+++ b/extensions/tools/claude/install.sh
@@ -19,5 +19,6 @@ fi
 echo "Claude installed at: $(which claude)"
 claude --version
 
-# Install sandbox runtime for Claude Code sandbox support
-enclave-agent-npm-install @anthropic-ai/sandbox-runtime
+# Install sandbox runtime for Claude Code sandbox support.
+# It ships its vendored artifacts prebuilt and declares no lifecycle scripts.
+enclave-agent-npm-install --ignore-scripts @anthropic-ai/sandbox-runtime

--- a/extensions/tools/codex/README.md
+++ b/extensions/tools/codex/README.md
@@ -61,7 +61,7 @@ status_line = ["git-branch", "context-remaining", "five-hour-limit", "weekly-lim
 | File | Purpose |
 |------|---------|
 | `spec.yaml` | Extension manifest (metadata, sandbox behavior, network, credentials) |
-| `install.sh` | Installs Codex via private agent npm (`enclave-agent-npm-install @openai/codex`) |
+| `install.sh` | Installs Codex via private agent npm (`enclave-install-npm-tool --ignore-scripts @openai/codex`) |
 | `check-update.sh` | Returns the latest npm version for automatic update probes |
 | `gateway-allowlist.conf` | DNS allowlist for network isolation |
 | `templates/config.toml` | Default settings template |

--- a/extensions/tools/codex/install.sh
+++ b/extensions/tools/codex/install.sh
@@ -8,4 +8,6 @@
 
 set -e
 
-enclave-install-npm-tool @openai/codex@latest codex Codex
+# bin/codex.js resolves the vendored binary from the optional platform package
+# at runtime; nothing in the tree declares a lifecycle script.
+enclave-install-npm-tool --ignore-scripts @openai/codex@latest codex Codex

--- a/extensions/tools/opencode/README.md
+++ b/extensions/tools/opencode/README.md
@@ -54,7 +54,7 @@ The default settings template disables sharing and OpenTelemetry.
 | File | Purpose |
 |------|---------|
 | `spec.yaml` | Extension manifest (metadata, sandbox behavior, network, credentials) |
-| `install.sh` | Installs OpenCode via private agent npm (`enclave-agent-npm-install opencode-ai`) |
+| `install.sh` | Installs OpenCode via private agent npm (`enclave-install-npm-tool opencode-ai`; keeps lifecycle scripts, its `postinstall` places the platform binary) |
 | `check-update.sh` | Returns the latest npm version for automatic update probes |
 | `gateway-allowlist.conf` | DNS allowlist for network isolation |
 | `templates/settings.json` | Default settings template |

--- a/extensions/tools/opencode/install.sh
+++ b/extensions/tools/opencode/install.sh
@@ -8,5 +8,7 @@
 
 set -e
 
+# Do not add --ignore-scripts: opencode-ai's postinstall is what places the
+# platform binary, and its bin stub fails with an explicit error without it.
 enclave-install-npm-tool opencode-ai opencode OpenCode
 opencode --version

--- a/extensions/tools/pi/README.md
+++ b/extensions/tools/pi/README.md
@@ -57,7 +57,7 @@ it.
 | File | Purpose |
 |------|---------|
 | `spec.yaml` | Extension manifest (metadata, sandbox behavior, network, credentials) |
-| `install.sh` | Installs Pi via private agent npm (`enclave-agent-npm-install @earendil-works/pi-coding-agent`) |
+| `install.sh` | Installs Pi via private agent npm (`enclave-install-npm-tool --ignore-scripts @earendil-works/pi-coding-agent`) |
 | `check-update.sh` | Returns the latest npm version for automatic update probes |
 | `gateway-allowlist.conf` | DNS allowlist for network isolation |
 | `templates/settings.json` | Default settings template |

--- a/extensions/tools/pi/install.sh
+++ b/extensions/tools/pi/install.sh
@@ -8,4 +8,6 @@
 
 set -e
 
-enclave-install-npm-tool @earendil-works/pi-coding-agent@latest pi Pi
+# Upstream ships prebuilt native modules and needs no lifecycle scripts; their
+# own installer and `pi update --self` pass --ignore-scripts too.
+enclave-install-npm-tool --ignore-scripts @earendil-works/pi-coding-agent@latest pi Pi

--- a/runtime-assets/build-scripts/README.md
+++ b/runtime-assets/build-scripts/README.md
@@ -37,7 +37,7 @@ Build-time selectors:
 - `install-tool-templates.sh`: aggregates `extensions/tools/*/templates/*` into `/usr/local/share/enclave/templates/`.
 - `install-agent-helper-bins.sh`: installs helper binaries into the agent user's local bin.
 - `bin/enclave-agent-npm-install`: low-level npm install helper using the private agent Node runtime. Leading `-`-prefixed arguments are forwarded to `npm install`.
-- `bin/enclave-install-npm-tool`: shared npm-tool installer wrapper used by simple Node-based tool installers. Takes `[npm-flag ...] <package> <binary> [label]` and forwards the flags to `enclave-agent-npm-install`.
+- `bin/enclave-install-npm-tool`: shared npm-tool installer wrapper used by simple Node-based tool installers. Takes `[npm-flag ...] <package> <binary> [label]` and forwards the flags to `enclave-agent-npm-install`. Flags must be self-contained (`--flag` or `--flag=value`); one that takes a separate value would consume the package argument.
 - `bin/enclave-install-tool`: shared tool installer entrypoint used by generated Docker stages.
 
 ## Validation

--- a/runtime-assets/build-scripts/README.md
+++ b/runtime-assets/build-scripts/README.md
@@ -36,7 +36,7 @@ Build-time selectors:
 - `run-feature-installs.sh`: runs enabled feature `install.sh` scripts by phase and priority.
 - `install-tool-templates.sh`: aggregates `extensions/tools/*/templates/*` into `/usr/local/share/enclave/templates/`.
 - `install-agent-helper-bins.sh`: installs helper binaries into the agent user's local bin.
-- `bin/enclave-agent-npm-install`: low-level npm install helper using the private agent Node runtime. Leading `-`-prefixed arguments are forwarded to `npm install`, separated from the package specs by `--`.
+- `bin/enclave-agent-npm-install`: low-level npm install helper using the private agent Node runtime. Leading `-`-prefixed arguments are forwarded to `npm install`, separated from the package specs by `--`. Fails if a package declares a bin that did not land, which is how a missing lifecycle script surfaces.
 - `bin/enclave-install-npm-tool`: shared npm-tool installer wrapper used by simple Node-based tool installers. Takes `[npm-flag ...] <package> <binary> [label]` and forwards the flags to `enclave-agent-npm-install`. Flags must be self-contained (`--flag` or `--flag=value`); one that takes a separate value would consume the package argument.
 - `bin/enclave-install-tool`: shared tool installer entrypoint used by generated Docker stages.
 

--- a/runtime-assets/build-scripts/README.md
+++ b/runtime-assets/build-scripts/README.md
@@ -36,7 +36,7 @@ Build-time selectors:
 - `run-feature-installs.sh`: runs enabled feature `install.sh` scripts by phase and priority.
 - `install-tool-templates.sh`: aggregates `extensions/tools/*/templates/*` into `/usr/local/share/enclave/templates/`.
 - `install-agent-helper-bins.sh`: installs helper binaries into the agent user's local bin.
-- `bin/enclave-agent-npm-install`: low-level npm install helper using the private agent Node runtime. Leading `-`-prefixed arguments are forwarded to `npm install`.
+- `bin/enclave-agent-npm-install`: low-level npm install helper using the private agent Node runtime. Leading `-`-prefixed arguments are forwarded to `npm install`, separated from the package specs by `--`.
 - `bin/enclave-install-npm-tool`: shared npm-tool installer wrapper used by simple Node-based tool installers. Takes `[npm-flag ...] <package> <binary> [label]` and forwards the flags to `enclave-agent-npm-install`. Flags must be self-contained (`--flag` or `--flag=value`); one that takes a separate value would consume the package argument.
 - `bin/enclave-install-tool`: shared tool installer entrypoint used by generated Docker stages.
 

--- a/runtime-assets/build-scripts/README.md
+++ b/runtime-assets/build-scripts/README.md
@@ -36,8 +36,8 @@ Build-time selectors:
 - `run-feature-installs.sh`: runs enabled feature `install.sh` scripts by phase and priority.
 - `install-tool-templates.sh`: aggregates `extensions/tools/*/templates/*` into `/usr/local/share/enclave/templates/`.
 - `install-agent-helper-bins.sh`: installs helper binaries into the agent user's local bin.
-- `bin/enclave-agent-npm-install`: low-level npm install helper using the private agent Node runtime.
-- `bin/enclave-install-npm-tool`: shared npm-tool installer wrapper used by simple Node-based tool installers.
+- `bin/enclave-agent-npm-install`: low-level npm install helper using the private agent Node runtime. Leading `-`-prefixed arguments are forwarded to `npm install`.
+- `bin/enclave-install-npm-tool`: shared npm-tool installer wrapper used by simple Node-based tool installers. Takes `[npm-flag ...] <package> <binary> [label]` and forwards the flags to `enclave-agent-npm-install`.
 - `bin/enclave-install-tool`: shared tool installer entrypoint used by generated Docker stages.
 
 ## Validation

--- a/runtime-assets/build-scripts/bin/enclave-agent-npm-install
+++ b/runtime-assets/build-scripts/bin/enclave-agent-npm-install
@@ -155,6 +155,14 @@ for spec in "${packages[@]}"; do
             echo "$package_name declares bin $bin_name outside its package directory: $bin_path" >&2
             exit 1
         fi
+        # A declared bin that is absent after install means the package expected
+        # a lifecycle script to place it; fail the build instead of degrading at
+        # runtime.
+        if [ ! -e "$target" ]; then
+            echo "$package_name declares bin $bin_name but $target is missing" >&2
+            echo "the package may require lifecycle scripts; re-check any --ignore-scripts for it" >&2
+            exit 1
+        fi
         rewrite_bin_shebang "$target"
 
         link="$install_prefix/bin/$bin_name"

--- a/runtime-assets/build-scripts/bin/enclave-agent-npm-install
+++ b/runtime-assets/build-scripts/bin/enclave-agent-npm-install
@@ -132,13 +132,36 @@ for spec in "${packages[@]}"; do
         end | .[]
     ' "$package_json")
 
+    # rewrite_bin_shebang follows symlinks and writes the resolved file, and
+    # both paths below come from the package's own package.json. Never write
+    # outside the package directory, whatever it declares.
+    package_root="$(realpath -m -- "$package_dir")"
+    resolves_within_package() {
+        case "$(realpath -m -- "$1")" in
+            "$package_root"/*) return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+
     for entry in "${bin_entries[@]}"; do
         [ -n "$entry" ] || continue
         bin_name="${entry%%:*}"
         bin_path="${entry#*:}"
         [ -n "$bin_name" ] || continue
         [ -n "$bin_path" ] || continue
-        rewrite_bin_shebang "$package_dir/$bin_path"
-        rewrite_bin_shebang "$install_prefix/bin/$bin_name"
+
+        target="$package_dir/$bin_path"
+        if ! resolves_within_package "$target"; then
+            echo "$package_name declares bin $bin_name outside its package directory: $bin_path" >&2
+            exit 1
+        fi
+        rewrite_bin_shebang "$target"
+
+        link="$install_prefix/bin/$bin_name"
+        if [ -e "$link" ] && ! resolves_within_package "$link"; then
+            echo "Warning: $link does not resolve into $package_name; leaving it untouched" >&2
+            continue
+        fi
+        rewrite_bin_shebang "$link"
     done
 done

--- a/runtime-assets/build-scripts/bin/enclave-agent-npm-install
+++ b/runtime-assets/build-scripts/bin/enclave-agent-npm-install
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 if [ "$#" -eq 0 ]; then
-    echo "usage: enclave-agent-npm-install <package> [<package> ...]" >&2
+    echo "usage: enclave-agent-npm-install [npm-flag ...] <package> [<package> ...]" >&2
     exit 2
 fi
 

--- a/runtime-assets/build-scripts/bin/enclave-agent-npm-install
+++ b/runtime-assets/build-scripts/bin/enclave-agent-npm-install
@@ -71,8 +71,27 @@ rewrite_bin_shebang() {
     mv "$tmp" "$target"
 }
 
+# Split flags from package specs so npm gets `--` between them: a spec can then
+# never be parsed as an option, whatever the caller passes.
+npm_flags=()
+packages=()
+for arg in "$@"; do
+    if [ "$arg" = "--" ]; then
+        continue
+    fi
+    if [[ "$arg" == -* ]] && [ "${#packages[@]}" -eq 0 ]; then
+        npm_flags+=("$arg")
+    else
+        packages+=("$arg")
+    fi
+done
+if [ "${#packages[@]}" -eq 0 ]; then
+    echo "enclave-agent-npm-install: no package given" >&2
+    exit 2
+fi
+
 first_attempt_log="$(mktemp)"
-if "$npm_bin" install -g --no-audit --no-fund --progress=false "$@" 2>"$first_attempt_log"; then
+if "$npm_bin" install -g --no-audit --no-fund --progress=false "${npm_flags[@]}" -- "${packages[@]}" 2>"$first_attempt_log"; then
     rm -f "$first_attempt_log"
 elif [ "${npm_config_prefer_online:-}" = "true" ]; then
     cat "$first_attempt_log" >&2
@@ -81,7 +100,7 @@ elif [ "${npm_config_prefer_online:-}" = "true" ]; then
 else
     echo "npm install failed in offline-preferred mode; retrying with online metadata..." >&2
     if ! npm_config_prefer_online=true npm_config_prefer_offline=false \
-        "$npm_bin" install -g --no-audit --no-fund --progress=false "$@"; then
+        "$npm_bin" install -g --no-audit --no-fund --progress=false "${npm_flags[@]}" -- "${packages[@]}"; then
         echo "Offline-preferred attempt stderr:" >&2
         cat "$first_attempt_log" >&2
         rm -f "$first_attempt_log"
@@ -90,10 +109,7 @@ else
     rm -f "$first_attempt_log"
 fi
 
-for spec in "$@"; do
-    if [[ "$spec" == -* ]]; then
-        continue
-    fi
+for spec in "${packages[@]}"; do
     package_name="$(normalize_package_name "$spec")"
     package_dir="$install_prefix/lib/node_modules/$package_name"
     package_json="$package_dir/package.json"

--- a/runtime-assets/build-scripts/bin/enclave-install-npm-tool
+++ b/runtime-assets/build-scripts/bin/enclave-install-npm-tool
@@ -29,8 +29,7 @@ package="$1"
 binary="$2"
 label="${3:-$binary}"
 
-# `--` ends npm option parsing so the package spec can never be read as a flag.
-enclave-agent-npm-install "${npm_flags[@]}" -- "$package"
+enclave-agent-npm-install "${npm_flags[@]}" "$package"
 
 if ! command -v "$binary" >/dev/null 2>&1; then
     echo "$label install failed: $binary binary not found" >&2

--- a/runtime-assets/build-scripts/bin/enclave-install-npm-tool
+++ b/runtime-assets/build-scripts/bin/enclave-install-npm-tool
@@ -8,16 +8,30 @@
 
 set -euo pipefail
 
-if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
-    echo "usage: enclave-install-npm-tool <package> <binary> [label]" >&2
+usage() {
+    echo "usage: enclave-install-npm-tool [npm-flag ...] <package> <binary> [label]" >&2
     exit 2
+}
+
+npm_flags=()
+while [ "$#" -gt 0 ] && [[ "$1" == -* ]]; do
+    if [ "$1" = "--" ]; then
+        shift
+        break
+    fi
+    npm_flags+=("$1")
+    shift
+done
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
 fi
 
 package="$1"
 binary="$2"
 label="${3:-$binary}"
 
-enclave-agent-npm-install "$package"
+enclave-agent-npm-install "${npm_flags[@]}" "$package"
 
 if ! command -v "$binary" >/dev/null 2>&1; then
     echo "$label install failed: $binary binary not found" >&2

--- a/runtime-assets/build-scripts/bin/enclave-install-npm-tool
+++ b/runtime-assets/build-scripts/bin/enclave-install-npm-tool
@@ -29,7 +29,8 @@ package="$1"
 binary="$2"
 label="${3:-$binary}"
 
-enclave-agent-npm-install "${npm_flags[@]}" "$package"
+# `--` ends npm option parsing so the package spec can never be read as a flag.
+enclave-agent-npm-install "${npm_flags[@]}" -- "$package"
 
 if ! command -v "$binary" >/dev/null 2>&1; then
     echo "$label install failed: $binary binary not found" >&2

--- a/runtime-assets/build-scripts/bin/enclave-install-npm-tool
+++ b/runtime-assets/build-scripts/bin/enclave-install-npm-tool
@@ -13,12 +13,10 @@ usage() {
     exit 2
 }
 
+# Flags must be self-contained (`--flag` or `--flag=value`); a flag that takes a
+# separate value would consume the package argument.
 npm_flags=()
 while [ "$#" -gt 0 ] && [[ "$1" == -* ]]; do
-    if [ "$1" = "--" ]; then
-        shift
-        break
-    fi
     npm_flags+=("$1")
     shift
 done


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #72.

Dependency lifecycle scripts ran at image build time for no functional gain. enclave-install-npm-tool now forwards leading npm flags, and pi, codex, and claude's sandbox-runtime pass --ignore-scripts.

opencode is excluded: its postinstall is what places the platform binary, and the published bin stub fails with an explicit error without it.

#### How to test

Run enclave using this branch with tools installed via npm, i.e., pi, codex, and opencode. Verify that they still install and start.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
