### PR TITLE
fix: make qemu guest sessions usable for all bundled tools

### DIFF
--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -328,8 +328,10 @@ listed paths are eligible for copy, and a hard-coded deny backstop still
 blocks auth/history/session/runtime-state paths.
 
 Generated QEMU microVM bundles use max(default 4096 MiB,
-`sandbox.qemuMinMemoryMiB`). Use it for tools that need more memory than the
-default to start reliably. Set `sandbox.qemuStoreCacheMmap` when the tool's
+`sandbox.qemuMinMemoryMiB`, what the built initramfs needs). Use it for tools
+that need more memory than the default to start reliably; it never has to
+account for the bundle's own size, because the guest rootfs is the unpacked
+initramfs and the builder already sizes memory to it. Set `sandbox.qemuStoreCacheMmap` when the tool's
 config store needs 9p `cache=mmap` (for example SQLite WAL shared-memory files).
 
 `check-update.sh` runs in a controlled containerized probe environment, never directly on the host. Contract:

--- a/docs/extensions/adding-a-tool.md
+++ b/docs/extensions/adding-a-tool.md
@@ -76,7 +76,8 @@ the complete set and semantics):
 - `passthroughPaths`: (optional) narrow, reviewed allow-list for
   `host_config=passthrough` — keep it config-only.
 - `qemuMinMemoryMiB`: (optional) minimum memory for generated QEMU microVM
-  bundles; the effective size is max(default 4096 MiB, this value).
+  bundles; the effective size is max(default 4096 MiB, this value, what the
+  built initramfs needs to unpack and stay resident).
 - `qemuStoreCacheMmap`: (optional) mount the tool's config store with 9p
   `cache=mmap`; required when the store holds SQLite databases in WAL mode.
 - `hostConfigDir` / `hostCredentialsFile` / `hostOauthJson`: (optional) host-side

--- a/extensions/tools/opencode/spec.yaml
+++ b/extensions/tools/opencode/spec.yaml
@@ -14,6 +14,9 @@ description: OpenCode terminal IDE
 sandbox:
   entrypoint: { run: [opencode] }
   configDir: .config/opencode
+  # opencode keeps its state in opencode.db (SQLite, WAL) inside the config
+  # store, and WAL shared-memory files need mmap semantics on 9p.
+  qemuStoreCacheMmap: true
   skillsDir: .config/opencode/skills
   settingsFile: opencode-settings.json
   settingsTarget: .config/opencode/opencode.json

--- a/internal/app/build_microvm.go
+++ b/internal/app/build_microvm.go
@@ -8,9 +8,9 @@
 package app
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -67,8 +67,8 @@ func ensureQEMUBundle(input *CommandInput, opts model.Options, buildCfg buildCon
 		logx.Errorf("%v", err)
 		return buildConfig{}, 1
 	}
-	bundleConfig := qemuBundleConfigForProfile(profile)
-	configHash, err := qemuBundleConfigHash(bundleConfig)
+	declaredConfig := qemuBundleConfigForProfile(profile)
+	configHash, err := qemuBundleConfigHash(declaredConfig)
 	if err != nil {
 		logx.Errorf("%v", err)
 		return buildConfig{}, 1
@@ -76,6 +76,7 @@ func ensureQEMUBundle(input *CommandInput, opts model.Options, buildCfg buildCon
 	bundleHash := plan.CombinedHash + "-" + assetHash + "-" + configHash
 	bundleDir := qemuBundleDir(host.Home, opts.Tool, bundleHash)
 	buildCfg.ImageName = bundleDir
+	logx.Debugf("qemu bundle hash: %s", bundleHash)
 	logx.Infof("Using qemu bundle: %s", bundleDir)
 	if opts.NoRebuild {
 		logx.Warnf("Skipping qemu bundle build due to --no-rebuild.")
@@ -85,7 +86,7 @@ func ensureQEMUBundle(input *CommandInput, opts model.Options, buildCfg buildCon
 		}
 		return buildCfg, 0
 	}
-	current, err := qemuBundleCurrent(bundleDir, opts.Tool, bundleHash, bundleConfig)
+	current, err := qemuBundleCurrent(bundleDir, opts.Tool, bundleHash)
 	if err != nil {
 		logx.Debugf("qemu bundle stamp check failed: %v", err)
 	}
@@ -97,7 +98,7 @@ func ensureQEMUBundle(input *CommandInput, opts model.Options, buildCfg buildCon
 		} else {
 			logx.Infof("Agent update interval elapsed, rebuilding qemu bundle automatically.")
 		}
-		if err := buildQEMUBundle(context.Background(), input.Ctx.Paths, host, bundleDir, opts.Tool, bundleHash, bundleConfig); err != nil {
+		if err := buildQEMUBundle(context.Background(), input.Ctx.Paths, host, bundleDir, opts.Tool, bundleHash, declaredConfig.MemoryMiB); err != nil {
 			logx.Errorf("%v", err)
 			return buildConfig{}, 1
 		}
@@ -141,28 +142,51 @@ func sanitizeBundlePart(value string) string {
 }
 
 func ensureExistingQEMUBundle(dir string) error {
-	for _, name := range []string{"vmlinuz", "initramfs.cpio"} {
-		path := filepath.Join(dir, name)
-		info, err := os.Stat(path)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("qemu bundle %q is missing %s; rerun without --no-rebuild or pass --rebuild", dir, name)
-			}
-			return err
+	path := filepath.Join(dir, "vmlinuz")
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("qemu bundle %q is missing vmlinuz; rerun without --no-rebuild or pass --rebuild", dir)
 		}
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("qemu bundle %q has non-file %s", dir, name)
-		}
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("qemu bundle %q has non-file vmlinuz", dir)
+	}
+	if _, err := backendqemu.InitramfsPath(dir); err != nil {
+		return fmt.Errorf("%w; rerun without --no-rebuild or pass --rebuild", err)
 	}
 	return nil
 }
 
+// qemuBundleConfigForProfile is the memory floor a profile declares. It feeds
+// the bundle hash; the effective launch size is computed from the built
+// initramfs in buildQEMUBundle and can only be larger.
 func qemuBundleConfigForProfile(profile model.Profile) backendqemu.BundleConfig {
 	memoryMiB := backendqemu.DefaultMemoryMiB
 	if profile.QEMUMinMemoryMiB > memoryMiB {
 		memoryMiB = profile.QEMUMinMemoryMiB
 	}
 	return backendqemu.BundleConfig{MemoryMiB: memoryMiB}
+}
+
+// qemuBundleMemoryMiB raises the declared memory floor to what the built
+// initramfs needs. The kernel unpacks the image into a ramfs that stays
+// resident as the guest rootfs, so a large bundle needs proportionally more
+// memory; too little and the guest dies in the unpacker with no usable init.
+func qemuBundleMemoryMiB(bundleDir string, minMemoryMiB int) (int, error) {
+	meta, err := backendqemu.ReadInitramfsMeta(bundleDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return minMemoryMiB, nil
+		}
+		return 0, err
+	}
+	required := backendqemu.RequiredMemoryMiB(meta.UncompressedBytes, meta.CompressedBytes)
+	if required > minMemoryMiB {
+		return required, nil
+	}
+	return minMemoryMiB, nil
 }
 
 func qemuBundleConfigHash(cfg backendqemu.BundleConfig) (string, error) {
@@ -195,23 +219,19 @@ func writeQEMUBundleConfig(dir string, cfg backendqemu.BundleConfig) error {
 	return nil
 }
 
-func qemuBundleCurrent(dir string, tool string, hash string, cfg backendqemu.BundleConfig) (bool, error) {
+// qemuBundleCurrent reports whether the cached bundle was built from the same
+// inputs. The stamped hash covers the declared memory floor, so the stored
+// config itself only has to be readable: its memory value is a build output
+// derived from the initramfs, not an input to compare against.
+func qemuBundleCurrent(dir string, tool string, hash string) (bool, error) {
 	if err := ensureExistingQEMUBundle(dir); err != nil {
 		return false, nil
 	}
-	expectedConfig, err := qemuBundleConfigJSON(cfg)
-	if err != nil {
-		return false, err
-	}
-	currentConfig, err := os.ReadFile(filepath.Join(dir, backendqemu.BundleConfigFile)) // #nosec G304 -- dir is enclave-managed cache path.
-	if err != nil {
-		if os.IsNotExist(err) {
+	if _, err := backendqemu.ReadBundleConfig(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}
 		return false, err
-	}
-	if !bytes.Equal(currentConfig, expectedConfig) {
-		return false, nil
 	}
 	data, err := os.ReadFile(filepath.Join(dir, qemuBundleBuildStampFile)) // #nosec G304 -- dir is enclave-managed cache path.
 	if err != nil {
@@ -224,10 +244,14 @@ func qemuBundleCurrent(dir string, tool string, hash string, cfg backendqemu.Bun
 	if err := json.Unmarshal(data, &stamp); err != nil {
 		return false, err
 	}
-	return stamp.Hash == hash && stamp.Tool == tool, nil
+	if stamp.Tool != tool || stamp.Hash != hash {
+		logx.Debugf("qemu bundle stamp mismatch: stamped tool=%s hash=%s", stamp.Tool, stamp.Hash)
+		return false, nil
+	}
+	return true, nil
 }
 
-func buildQEMUBundle(ctx context.Context, paths model.Paths, host model.Host, bundleDir string, tool string, hash string, cfg backendqemu.BundleConfig) error {
+func buildQEMUBundle(ctx context.Context, paths model.Paths, host model.Host, bundleDir string, tool string, hash string, minMemoryMiB int) error {
 	selection := runtimeImageSelection{Tools: []string{tool}}
 	contextDir, cleanup, err := prepareBuildContext(paths, selection)
 	if err != nil {
@@ -259,7 +283,14 @@ func buildQEMUBundle(ctx context.Context, paths model.Paths, host model.Host, bu
 	if err := ensureExistingQEMUBundle(bundleDir); err != nil {
 		return err
 	}
-	if err := writeQEMUBundleConfig(bundleDir, cfg); err != nil {
+	memoryMiB, err := qemuBundleMemoryMiB(bundleDir, minMemoryMiB)
+	if err != nil {
+		return err
+	}
+	if memoryMiB > minMemoryMiB {
+		logx.Infof("Sizing qemu guest memory to %d MiB for the built initramfs.", memoryMiB)
+	}
+	if err := writeQEMUBundleConfig(bundleDir, backendqemu.BundleConfig{MemoryMiB: memoryMiB}); err != nil {
 		return err
 	}
 	stamp := qemuBundleBuildStamp{Hash: hash, Tool: tool}

--- a/internal/app/build_microvm_test.go
+++ b/internal/app/build_microvm_test.go
@@ -102,9 +102,9 @@ func TestWriteQEMUBundleConfig(t *testing.T) {
 	}
 }
 
-func TestQEMUBundleCurrentRequiresExpectedConfig(t *testing.T) {
+func TestQEMUBundleCurrentRequiresReadableConfig(t *testing.T) {
 	dir := t.TempDir()
-	for _, name := range []string{"vmlinuz", "initramfs.cpio"} {
+	for _, name := range []string{"vmlinuz", backendqemu.InitramfsFile} {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -114,23 +114,63 @@ func TestQEMUBundleCurrentRequiresExpectedConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := backendqemu.BundleConfig{MemoryMiB: backendqemu.DefaultMemoryMiB}
-	current, err := qemuBundleCurrent(dir, "codex", "h", cfg)
+	current, err := qemuBundleCurrent(dir, "codex", "h")
 	if err != nil {
 		t.Fatalf("qemuBundleCurrent without config: %v", err)
 	}
 	if current {
-		t.Fatal("bundle without expected config should not be current")
+		t.Fatal("bundle without config should not be current")
 	}
-	if err := writeQEMUBundleConfig(dir, cfg); err != nil {
+	if err := writeQEMUBundleConfig(dir, backendqemu.BundleConfig{MemoryMiB: backendqemu.DefaultMemoryMiB}); err != nil {
 		t.Fatal(err)
 	}
-	current, err = qemuBundleCurrent(dir, "codex", "h", cfg)
+	current, err = qemuBundleCurrent(dir, "codex", "h")
 	if err != nil {
 		t.Fatalf("qemuBundleCurrent with config: %v", err)
 	}
 	if !current {
-		t.Fatal("bundle with matching stamp and config should be current")
+		t.Fatal("bundle with matching stamp and readable config should be current")
+	}
+}
+
+func TestQEMUBundleMemoryMiBRaisesFloorForLargeInitramfs(t *testing.T) {
+	dir := t.TempDir()
+	meta := []byte(`{"uncompressedBytes":3221225472,"compressedBytes":1073741824,"compression":"zstd"}`)
+	if err := os.WriteFile(filepath.Join(dir, backendqemu.InitramfsMetaFile), meta, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := qemuBundleMemoryMiB(dir, backendqemu.DefaultMemoryMiB)
+	if err != nil {
+		t.Fatalf("qemuBundleMemoryMiB: %v", err)
+	}
+	// 3072 MiB rootfs + 2048 MiB workload headroom, rounded up to 512 MiB.
+	if got != 5120 {
+		t.Fatalf("memoryMiB = %d, want 5120", got)
+	}
+}
+
+func TestQEMUBundleMemoryMiBKeepsFloorForSmallInitramfs(t *testing.T) {
+	dir := t.TempDir()
+	meta := []byte(`{"uncompressedBytes":545259520,"compressedBytes":209715200,"compression":"zstd"}`)
+	if err := os.WriteFile(filepath.Join(dir, backendqemu.InitramfsMetaFile), meta, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := qemuBundleMemoryMiB(dir, backendqemu.DefaultMemoryMiB)
+	if err != nil {
+		t.Fatalf("qemuBundleMemoryMiB: %v", err)
+	}
+	if got != backendqemu.DefaultMemoryMiB {
+		t.Fatalf("memoryMiB = %d, want %d", got, backendqemu.DefaultMemoryMiB)
+	}
+}
+
+func TestQEMUBundleMemoryMiBWithoutMetadata(t *testing.T) {
+	got, err := qemuBundleMemoryMiB(t.TempDir(), backendqemu.DefaultMemoryMiB)
+	if err != nil {
+		t.Fatalf("qemuBundleMemoryMiB: %v", err)
+	}
+	if got != backendqemu.DefaultMemoryMiB {
+		t.Fatalf("memoryMiB = %d, want %d", got, backendqemu.DefaultMemoryMiB)
 	}
 }
 

--- a/internal/backend/qemu/bundle.go
+++ b/internal/backend/qemu/bundle.go
@@ -10,6 +10,7 @@ package qemu
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,9 +27,34 @@ const (
 	// BundleConfigFile is the metadata file next to vmlinuz/initramfs that
 	// declares host-side QEMU launch settings for a bundle.
 	BundleConfigFile = "enclave-vm-bundle.json"
+	// InitramfsFile is the guest initramfs of a generated bundle. It is a
+	// zstd-compressed newc cpio archive, padded to a 4-byte boundary so the
+	// per-run overlay archive can be appended to it.
+	InitramfsFile = "initramfs.cpio.zst"
+	// LegacyInitramfsFile is the uncompressed initramfs name, still accepted for
+	// hand-assembled bundles passed via --image-name.
+	LegacyInitramfsFile = "initramfs.cpio"
+	// InitramfsMetaFile records the built initramfs sizes. The host needs the
+	// unpacked size to size guest memory and cannot derive it from the
+	// compressed image.
+	InitramfsMetaFile = "enclave-vm-initramfs.json"
 	// DefaultMemoryMiB is the generated-bundle memory default and the fallback
 	// for minimal/prebuilt bundles without BundleConfigFile.
 	DefaultMemoryMiB = 4096
+
+	// Guest memory has to cover the unpacked initramfs for the whole session:
+	// it becomes the rootfs, a ramfs the guest can never reclaim. During boot
+	// the still-compressed image is resident on top of it, and the boot slack
+	// covers the kernel plus early allocations; once unpacking is done that
+	// memory is freed and the workload budget is what the agent tool gets.
+	initramfsBootSlackMiB = 256
+	initramfsWorkloadMiB  = 2048
+	memoryGranularityMiB  = 512
+
+	bytesPerMiB = 1 << 20
+	// initramfsSegmentAlignment is the boundary an appended plain cpio segment
+	// must start on for the kernel's unpack_to_rootfs() to recognize it.
+	initramfsSegmentAlignment = 4
 
 	guestControlPath       = "/run/enclave/control"
 	guestFilesPath         = "/run/enclave/files"
@@ -39,9 +65,18 @@ const (
 )
 
 // BundleConfig is the host-side metadata stored next to a generated or
-// prebuilt QEMU bundle.
+// prebuilt QEMU bundle. MemoryMiB is the effective launch size: the bundle
+// builder raises the profile minimum to whatever the built initramfs needs.
 type BundleConfig struct {
 	MemoryMiB int `json:"memoryMiB"`
+}
+
+// InitramfsMeta is the size metadata the bundle builder writes next to the
+// compressed initramfs.
+type InitramfsMeta struct {
+	UncompressedBytes int64  `json:"uncompressedBytes"`
+	CompressedBytes   int64  `json:"compressedBytes"`
+	Compression       string `json:"compression"`
 }
 
 type bundle struct {
@@ -94,13 +129,13 @@ func resolveBundle(image string) (bundle, error) {
 		return bundle{}, fmt.Errorf("qemu backend: inspect bundle path %q: %w", resolved, err)
 	}
 	if !info.IsDir() {
-		return bundle{}, fmt.Errorf("qemu backend: bundle path %q must be a directory containing vmlinuz and initramfs.cpio", resolved)
+		return bundle{}, fmt.Errorf("qemu backend: bundle path %q must be a directory containing vmlinuz and %s", resolved, InitramfsFile)
 	}
 	kernel, err := requireRegularFile(filepath.Join(resolved, "vmlinuz"), "kernel")
 	if err != nil {
 		return bundle{}, err
 	}
-	initramfs, err := requireRegularFile(filepath.Join(resolved, "initramfs.cpio"), "initramfs")
+	initramfs, err := InitramfsPath(resolved)
 	if err != nil {
 		return bundle{}, err
 	}
@@ -108,7 +143,97 @@ func resolveBundle(image string) (bundle, error) {
 	if err != nil {
 		return bundle{}, err
 	}
+	if err := checkBundleMemory(resolved, memoryMiB); err != nil {
+		return bundle{}, err
+	}
 	return bundle{Root: resolved, Kernel: kernel, Initramfs: initramfs, MemoryMiB: memoryMiB}, nil
+}
+
+// InitramfsPath resolves a bundle's initramfs, preferring the compressed image
+// over the uncompressed legacy name.
+func InitramfsPath(root string) (string, error) {
+	compressed := filepath.Join(root, InitramfsFile)
+	if info, err := os.Stat(compressed); err == nil {
+		if !info.Mode().IsRegular() {
+			return "", fmt.Errorf("qemu backend: initramfs %s is not a regular file", compressed)
+		}
+		return compressed, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("qemu backend: inspect initramfs %s: %w", compressed, err)
+	}
+	legacy := filepath.Join(root, LegacyInitramfsFile)
+	if _, err := os.Stat(legacy); err != nil && os.IsNotExist(err) {
+		return "", fmt.Errorf("qemu backend: missing initramfs %s", compressed)
+	}
+	return requireRegularFile(legacy, "initramfs")
+}
+
+// RequiredMemoryMiB is the guest memory a bundle with the given initramfs sizes
+// needs: enough to unpack the image at boot, and enough to keep the unpacked
+// rootfs resident next to the running agent tool afterwards.
+func RequiredMemoryMiB(uncompressedBytes int64, compressedBytes int64) int {
+	unpacked := bytesToMiB(uncompressedBytes)
+	boot := unpacked + bytesToMiB(compressedBytes) + initramfsBootSlackMiB
+	workload := unpacked + initramfsWorkloadMiB
+	required := boot
+	if workload > required {
+		required = workload
+	}
+	return roundUpMiB(required, memoryGranularityMiB)
+}
+
+func bytesToMiB(size int64) int {
+	if size <= 0 {
+		return 0
+	}
+	return int((size + bytesPerMiB - 1) / bytesPerMiB)
+}
+
+func roundUpMiB(value int, granularity int) int {
+	if value <= 0 {
+		return granularity
+	}
+	return ((value + granularity - 1) / granularity) * granularity
+}
+
+// ReadInitramfsMeta reads the size metadata the bundle builder wrote. It
+// reports os.ErrNotExist for bundles built without it.
+func ReadInitramfsMeta(root string) (InitramfsMeta, error) {
+	path := filepath.Join(root, InitramfsMetaFile)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is inside a validated bundle directory.
+	if err != nil {
+		return InitramfsMeta{}, err
+	}
+	var meta InitramfsMeta
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&meta); err != nil {
+		return InitramfsMeta{}, fmt.Errorf("qemu backend: parse initramfs metadata %s: %w", path, err)
+	}
+	if meta.UncompressedBytes <= 0 {
+		return InitramfsMeta{}, fmt.Errorf("qemu backend: initramfs metadata %s has invalid uncompressedBytes %d", path, meta.UncompressedBytes)
+	}
+	return meta, nil
+}
+
+// checkBundleMemory rejects a bundle whose initramfs cannot be unpacked in the
+// memory its config declares. Without it the guest fails deep inside the kernel
+// ("Initramfs unpacking failed: write error", then a no-init panic), which says
+// nothing about the actual cause.
+func checkBundleMemory(root string, memoryMiB int) error {
+	meta, err := ReadInitramfsMeta(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	required := RequiredMemoryMiB(meta.UncompressedBytes, meta.CompressedBytes)
+	if memoryMiB >= required {
+		return nil
+	}
+	return fmt.Errorf("qemu backend: bundle %s needs at least %d MiB to unpack its %d MiB initramfs but %s declares %d MiB; rebuild the bundle with --rebuild",
+		root, required, bytesToMiB(meta.UncompressedBytes), BundleConfigFile, memoryMiB)
 }
 
 func requireRegularFile(path string, label string) (string, error) {
@@ -125,23 +250,36 @@ func requireRegularFile(path string, label string) (string, error) {
 	return path, nil
 }
 
-func resolveBundleMemoryMiB(root string) (int, error) {
+// ReadBundleConfig reads a bundle's host-side launch metadata. It reports
+// os.ErrNotExist for minimal or prebuilt bundles that ship without it.
+func ReadBundleConfig(root string) (BundleConfig, error) {
 	path := filepath.Join(root, BundleConfigFile)
 	data, err := os.ReadFile(path) // #nosec G304 -- path is inside a validated bundle directory.
 	if err != nil {
 		if os.IsNotExist(err) {
-			return DefaultMemoryMiB, nil
+			return BundleConfig{}, err
 		}
-		return 0, fmt.Errorf("qemu backend: read bundle config %s: %w", path, err)
+		return BundleConfig{}, fmt.Errorf("qemu backend: read bundle config %s: %w", path, err)
 	}
 	var cfg BundleConfig
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&cfg); err != nil {
-		return 0, fmt.Errorf("qemu backend: parse bundle config %s: %w", path, err)
+		return BundleConfig{}, fmt.Errorf("qemu backend: parse bundle config %s: %w", path, err)
 	}
 	if cfg.MemoryMiB <= 0 {
-		return 0, fmt.Errorf("qemu backend: bundle config %s has invalid memoryMiB %d", path, cfg.MemoryMiB)
+		return BundleConfig{}, fmt.Errorf("qemu backend: bundle config %s has invalid memoryMiB %d", path, cfg.MemoryMiB)
+	}
+	return cfg, nil
+}
+
+func resolveBundleMemoryMiB(root string) (int, error) {
+	cfg, err := ReadBundleConfig(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return DefaultMemoryMiB, nil
+		}
+		return 0, err
 	}
 	return cfg.MemoryMiB, nil
 }
@@ -189,7 +327,7 @@ func (b *Backend) prepareGuestRuntime(bundle bundle, req backend.Request) (guest
 		cleanupOnErr()
 		return guestRuntime{}, err
 	}
-	runtimeInitramfs := filepath.Join(tempDir, "initramfs.cpio")
+	runtimeInitramfs := filepath.Join(tempDir, "initramfs.img")
 	if err := concatenateFiles(runtimeInitramfs, bundle.Initramfs, overlayInitramfs); err != nil {
 		cleanupOnErr()
 		return guestRuntime{}, err
@@ -345,18 +483,32 @@ func createCPIOArchive(sourceDir string, output string) error {
 	return nil
 }
 
+// concatenateFiles builds the initrd the guest boots from: the bundle image
+// followed by the per-run overlay archive. Every segment starts on a 4-byte
+// boundary because the kernel's unpack_to_rootfs() only detects a plain cpio
+// segment there; it skips the padding bytes in between.
 func concatenateFiles(output string, inputs ...string) error {
 	out, err := os.Create(output) // #nosec G304 -- output is under a generated runtime directory.
 	if err != nil {
 		return fmt.Errorf("qemu backend: create runtime initramfs: %w", err)
 	}
 	defer func() { _ = out.Close() }()
+	written := int64(0)
 	for _, input := range inputs {
+		if pad := segmentPadding(written); pad > 0 {
+			padded, err := out.Write(make([]byte, pad))
+			if err != nil {
+				return fmt.Errorf("qemu backend: pad runtime initramfs: %w", err)
+			}
+			written += int64(padded)
+		}
 		file, err := os.Open(input) // #nosec G304 -- inputs are validated bundle/generated files.
 		if err != nil {
 			return fmt.Errorf("qemu backend: open initramfs part %s: %w", input, err)
 		}
-		if _, err := io.Copy(out, file); err != nil {
+		copied, err := io.Copy(out, file)
+		written += copied
+		if err != nil {
 			_ = file.Close()
 			return fmt.Errorf("qemu backend: append initramfs part %s: %w", input, err)
 		}
@@ -368,6 +520,14 @@ func concatenateFiles(output string, inputs ...string) error {
 		return fmt.Errorf("qemu backend: close runtime initramfs: %w", err)
 	}
 	return nil
+}
+
+func segmentPadding(offset int64) int {
+	remainder := offset % initramfsSegmentAlignment
+	if remainder == 0 {
+		return 0
+	}
+	return initramfsSegmentAlignment - int(remainder)
 }
 
 func persistFileMounts(files []runtimeFileMount) []error {

--- a/internal/backend/qemu/bundle.go
+++ b/internal/backend/qemu/bundle.go
@@ -284,7 +284,7 @@ func resolveBundleMemoryMiB(root string) (int, error) {
 	return cfg.MemoryMiB, nil
 }
 
-func (b *Backend) prepareGuestRuntime(bundle bundle, req backend.Request) (guestRuntime, error) {
+func (b *Backend) prepareGuestRuntime(bundle bundle, req backend.Request, console consoleSize) (guestRuntime, error) {
 	tempDir, err := os.MkdirTemp("", "enclave-qemu-*")
 	if err != nil {
 		return guestRuntime{}, fmt.Errorf("qemu backend: create runtime directory: %w", err)
@@ -313,7 +313,7 @@ func (b *Backend) prepareGuestRuntime(bundle bundle, req backend.Request) (guest
 		cleanupOnErr()
 		return guestRuntime{}, fmt.Errorf("qemu backend: create overlay directory: %w", err)
 	}
-	content, err := b.renderRunScript(req, mounts, fileMounts)
+	content, err := b.renderRunScript(req, mounts, fileMounts, console)
 	if err != nil {
 		cleanupOnErr()
 		return guestRuntime{}, err

--- a/internal/backend/qemu/bundle_test.go
+++ b/internal/backend/qemu/bundle_test.go
@@ -8,7 +8,10 @@
 package qemu
 
 import (
+	"bytes"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"enclave/internal/backend"
@@ -70,6 +73,114 @@ func TestBuildRuntimeMountsPropagatesStoreCacheMmap(t *testing.T) {
 	}
 	if got := findRuntimeMount(t, mounts, guestControlPath).CacheMmap; got {
 		t.Fatal("control mount unexpectedly uses cache=mmap")
+	}
+}
+
+func TestRequiredMemoryMiBCoversUnpackAndWorkload(t *testing.T) {
+	cases := []struct {
+		name         string
+		uncompressed int64
+		compressed   int64
+		want         int
+	}{
+		// Boot needs 1024 + 384 + 256 MiB, the session 1024 + 2048 MiB.
+		{name: "workload dominates", uncompressed: 1024 << 20, compressed: 384 << 20, want: 3072},
+		// Boot needs 4096 + 1536 + 256 MiB, the session 4096 + 2048 MiB.
+		{name: "unpacking dominates", uncompressed: 4096 << 20, compressed: 1536 << 20, want: 6144},
+		{name: "unknown sizes", uncompressed: 0, compressed: 0, want: 2048},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RequiredMemoryMiB(tc.uncompressed, tc.compressed); got != tc.want {
+				t.Fatalf("RequiredMemoryMiB(%d, %d) = %d, want %d", tc.uncompressed, tc.compressed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInitramfsPathPrefersCompressedImage(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, LegacyInitramfsFile)
+	if err := os.WriteFile(legacy, []byte("legacy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := InitramfsPath(dir)
+	if err != nil {
+		t.Fatalf("InitramfsPath with legacy image: %v", err)
+	}
+	if got != legacy {
+		t.Fatalf("InitramfsPath = %s, want %s", got, legacy)
+	}
+	compressed := filepath.Join(dir, InitramfsFile)
+	if err := os.WriteFile(compressed, []byte("zstd"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = InitramfsPath(dir)
+	if err != nil {
+		t.Fatalf("InitramfsPath with compressed image: %v", err)
+	}
+	if got != compressed {
+		t.Fatalf("InitramfsPath = %s, want %s", got, compressed)
+	}
+}
+
+func TestInitramfsPathReportsMissingImage(t *testing.T) {
+	if _, err := InitramfsPath(t.TempDir()); err == nil {
+		t.Fatal("expected an error for a bundle without an initramfs")
+	}
+}
+
+// A bundle whose initramfs cannot be unpacked in its declared memory must be
+// rejected on the host; the guest failure mode is an unrelated-looking kernel
+// panic about a missing init.
+func TestCheckBundleMemoryRejectsUndersizedGuest(t *testing.T) {
+	dir := t.TempDir()
+	meta := []byte(`{"uncompressedBytes":3221225472,"compressedBytes":1073741824,"compression":"zstd"}`)
+	if err := os.WriteFile(filepath.Join(dir, InitramfsMetaFile), meta, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := checkBundleMemory(dir, DefaultMemoryMiB)
+	if err == nil {
+		t.Fatal("expected undersized guest memory to be rejected")
+	}
+	if !strings.Contains(err.Error(), "needs at least 5120 MiB") {
+		t.Fatalf("error does not name the required memory: %v", err)
+	}
+	if err := checkBundleMemory(dir, 5120); err != nil {
+		t.Fatalf("checkBundleMemory with sufficient memory: %v", err)
+	}
+	if err := checkBundleMemory(t.TempDir(), DefaultMemoryMiB); err != nil {
+		t.Fatalf("checkBundleMemory without metadata: %v", err)
+	}
+}
+
+// The kernel's unpack_to_rootfs() only detects the appended plain cpio overlay
+// when it starts on a 4-byte boundary.
+func TestConcatenateFilesAlignsSegments(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base")
+	overlay := filepath.Join(dir, "overlay")
+	if err := os.WriteFile(base, []byte("compressed"), 0o600); err != nil { // 10 bytes
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(overlay, []byte("070701overlay"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(dir, "initramfs.img")
+	if err := concatenateFiles(output, base, overlay); err != nil {
+		t.Fatalf("concatenateFiles: %v", err)
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := append([]byte("compressed"), 0, 0)
+	want = append(want, []byte("070701overlay")...)
+	if !bytes.Equal(data, want) {
+		t.Fatalf("runtime initramfs = %q, want %q", data, want)
+	}
+	if got := bytes.Index(data, []byte("070701overlay")) % initramfsSegmentAlignment; got != 0 {
+		t.Fatalf("overlay segment starts at offset %% %d = %d, want 0", initramfsSegmentAlignment, got)
 	}
 }
 

--- a/internal/backend/qemu/console.go
+++ b/internal/backend/qemu/console.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package qemu
+
+import (
+	"os"
+
+	"golang.org/x/term"
+
+	"enclave/internal/backend"
+)
+
+// consoleSize is the window size the guest console is initialized to.
+type consoleSize struct {
+	Rows int
+	Cols int
+}
+
+// defaultConsoleSize is the conventional terminal size, used when the host
+// stdio carries no window size (output piped to a file, CI).
+var defaultConsoleSize = consoleSize{Rows: 24, Cols: 80}
+
+// resolveConsoleSize reads the window size of the host terminal driving the
+// session. The emulated serial console has no window size of its own, so
+// unless the guest is told, its console stays 0x0: tools that trust the
+// terminal render one column wide, and those that do not fall back to 80x24
+// regardless of the real terminal.
+func resolveConsoleSize(attach backend.AttachIO) consoleSize {
+	var candidates []*os.File
+	appendFile := func(value any) {
+		if file, ok := value.(*os.File); ok && file != nil {
+			candidates = append(candidates, file)
+		}
+	}
+	// The session's own stdio first, then the process stdio the backend falls
+	// back to when the caller leaves AttachIO empty.
+	appendFile(attach.Out)
+	appendFile(attach.Err)
+	appendFile(attach.In)
+	candidates = append(candidates, os.Stdout, os.Stderr, os.Stdin)
+	for _, file := range candidates {
+		cols, rows, err := term.GetSize(int(file.Fd())) // #nosec G115 -- file descriptor from Fd() fits in int on all supported platforms.
+		if err != nil || cols <= 0 || rows <= 0 {
+			continue
+		}
+		return consoleSize{Rows: rows, Cols: cols}
+	}
+	return defaultConsoleSize
+}

--- a/internal/backend/qemu/qemu.go
+++ b/internal/backend/qemu/qemu.go
@@ -74,7 +74,7 @@ func (b *Backend) Run(ctx context.Context, req backend.Request, attach backend.A
 	if err != nil {
 		return backend.ExitStatus{}, err
 	}
-	runtime, err := b.prepareGuestRuntime(vmBundle, req)
+	runtime, err := b.prepareGuestRuntime(vmBundle, req, resolveConsoleSize(attach))
 	if err != nil {
 		return backend.ExitStatus{}, err
 	}

--- a/internal/backend/qemu/script.go
+++ b/internal/backend/qemu/script.go
@@ -129,7 +129,7 @@ func rejectQEMUOptionComma(label string, value string) error {
 	return nil
 }
 
-func (b *Backend) renderRunScript(req backend.Request, mounts []runtimeMount, files []runtimeFileMount) (string, error) {
+func (b *Backend) renderRunScript(req backend.Request, mounts []runtimeMount, files []runtimeFileMount, console consoleSize) (string, error) {
 	if len(req.Argv) == 0 {
 		return "", fmt.Errorf("qemu backend: command argv is empty")
 	}
@@ -140,6 +140,11 @@ func (b *Backend) renderRunScript(req backend.Request, mounts []runtimeMount, fi
 	out.WriteString("#!/bin/sh\n")
 	out.WriteString("set -eu\n")
 	out.WriteString("export PATH=/home/" + model.ContainerUser + "/.local/bin:/opt/enclave/node/bin:/sbin:/bin:/usr/sbin:/usr/bin\n")
+	// The console inherited from init reports 0x0 until it is told otherwise,
+	// which leaves terminal UIs either one column wide or stuck on their 80x24
+	// fallback. stty works on the inherited descriptor even though the agent
+	// user cannot open /dev/console itself.
+	fmt.Fprintf(&out, "stty rows %d cols %d 2>/dev/null || true\n", console.Rows, console.Cols)
 	out.WriteString("modprobe 9p 2>/dev/null || true\n")
 	out.WriteString("modprobe 9pnet 2>/dev/null || true\n")
 	out.WriteString("modprobe 9pnet_virtio 2>/dev/null || true\n")

--- a/internal/backend/qemu/script_test.go
+++ b/internal/backend/qemu/script_test.go
@@ -8,6 +8,7 @@
 package qemu
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestRenderPayloadCommandSetsAgentHomeAndUser(t *testing.T) {
 func TestRenderRunScriptMountsWithMmapCacheWhenRequested(t *testing.T) {
 	be := New(Options{})
 
-	script, err := be.renderRunScript(backend.Request{Argv: []string{"true"}}, []runtimeMount{{Tag: "tag-0", Target: "/home/agent/.codex", CacheMmap: true}}, nil)
+	script, err := be.renderRunScript(backend.Request{Argv: []string{"true"}}, []runtimeMount{{Tag: "tag-0", Target: "/home/agent/.codex", CacheMmap: true}}, nil, defaultConsoleSize)
 	if err != nil {
 		t.Fatalf("renderRunScript: %v", err)
 	}
@@ -39,12 +40,40 @@ func TestRenderRunScriptMountsWithMmapCacheWhenRequested(t *testing.T) {
 func TestRenderRunScriptDoesNotMountWithMmapCacheByDefault(t *testing.T) {
 	be := New(Options{})
 
-	script, err := be.renderRunScript(backend.Request{Argv: []string{"true"}}, []runtimeMount{{Tag: "tag-0", Target: "/home/agent/.claude"}}, nil)
+	script, err := be.renderRunScript(backend.Request{Argv: []string{"true"}}, []runtimeMount{{Tag: "tag-0", Target: "/home/agent/.claude"}}, nil, defaultConsoleSize)
 	if err != nil {
 		t.Fatalf("renderRunScript: %v", err)
 	}
 
 	assertNotContains(t, script, "cache=mmap")
+}
+
+// The serial console starts out 0x0, which leaves terminal UIs unrenderable.
+func TestRenderRunScriptSeedsConsoleSize(t *testing.T) {
+	be := New(Options{})
+
+	script, err := be.renderRunScript(backend.Request{Argv: []string{"true"}}, nil, nil, consoleSize{Rows: 47, Cols: 173})
+	if err != nil {
+		t.Fatalf("renderRunScript: %v", err)
+	}
+
+	assertContains(t, script, "stty rows 47 cols 173")
+}
+
+func TestResolveConsoleSizeFallsBackToDefault(t *testing.T) {
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = read.Close()
+		_ = write.Close()
+	}()
+
+	got := resolveConsoleSize(backend.AttachIO{In: read, Out: write, Err: write})
+	if got != defaultConsoleSize {
+		t.Fatalf("consoleSize = %+v, want %+v", got, defaultConsoleSize)
+	}
 }
 
 func TestRenderPayloadCommandPreservesExplicitHomeAndUser(t *testing.T) {

--- a/internal/config/testdata/golden/tool-opencode.json
+++ b/internal/config/testdata/golden/tool-opencode.json
@@ -28,6 +28,7 @@
     "tui.json",
     "tui.jsonc"
   ],
+  "qemu_store_cache_mmap": true,
   "providers": [
     {
       "name": "openai",

--- a/runtime-assets/microvm/alpine/README.md
+++ b/runtime-assets/microvm/alpine/README.md
@@ -29,6 +29,17 @@ appended plain cpio segment that starts on such a boundary.
 Bundles passed via `--image-name` may also ship an uncompressed `initramfs.cpio`
 and no metadata; those fall back to the default memory size.
 
+## Console size
+
+The guest runs on the emulated serial console, which carries no window size:
+left alone it reports 0x0, and terminal UIs then either render one column wide
+or fall back to 80x24 no matter how large the host terminal is. The generated
+run script therefore seeds the console with the host terminal's size
+(`stty rows … cols …`, from `resolveConsoleSize`). The size is applied once at
+startup; resizing the host terminal mid-session does not reach the guest,
+because the console is not a controlling terminal there and no `SIGWINCH` is
+delivered.
+
 The builder is invoked by `enclave --backend qemu --allow-all-network --slim ...` and uses Docker only as a host-side packaging helper. The resulting session runs under `qemu-system-x86_64`, not Docker.
 
 Sessions mount the same persistent store directories as the Docker backend (XDG state, via `internal/backend/hoststore`), so auth credentials, tool config, and persisted env are shared with Docker sessions of the same tool/project.

--- a/runtime-assets/microvm/alpine/README.md
+++ b/runtime-assets/microvm/alpine/README.md
@@ -5,8 +5,29 @@ This directory contains the experimental builder for the `qemu` backend's minima
 The generated bundle contains:
 
 - `vmlinuz` from Alpine `linux-virt`
-- `initramfs.cpio` with Alpine userland, the selected agent tool, and enclave runtime assets
+- `initramfs.cpio.zst` with Alpine userland, the selected agent tool, and enclave runtime assets
+- `enclave-vm-initramfs.json` with the packed and unpacked initramfs sizes
 - `enclave-vm-bundle.json` with guest sizing metadata
+
+## Initramfs sizing
+
+The guest has no disk: the initramfs is unpacked into a ramfs that becomes the
+rootfs and is never reclaimed, and while unpacking the kernel holds the image
+and its unpacked contents at the same time. Guest memory therefore scales with
+the bundle, and the host derives it from `enclave-vm-initramfs.json`
+(`backendqemu.RequiredMemoryMiB`), never below the profile's
+`qemuMinMemoryMiB`. Two consequences for the builder:
+
+- The image is zstd-compressed, which roughly halves the boot-time peak.
+- Build-time caches (npm, pip, uv) and `/boot` are stripped from the rootfs.
+  Anything left in it costs guest RAM byte for byte for the whole session.
+
+The image is padded to a 4-byte boundary because the host appends a per-run
+overlay archive to it, and the kernel's `unpack_to_rootfs()` only recognizes an
+appended plain cpio segment that starts on such a boundary.
+
+Bundles passed via `--image-name` may also ship an uncompressed `initramfs.cpio`
+and no metadata; those fall back to the default memory size.
 
 The builder is invoked by `enclave --backend qemu --allow-all-network --slim ...` and uses Docker only as a host-side packaging helper. The resulting session runs under `qemu-system-x86_64`, not Docker.
 

--- a/runtime-assets/microvm/alpine/build-bundle.sh
+++ b/runtime-assets/microvm/alpine/build-bundle.sh
@@ -195,6 +195,16 @@ mkdir -p "$root"
 tar -C "$root" -xf -
 rm -f "$root/.dockerenv"
 
+# Docker bind-mounts /etc/hosts into the provisioning container, so the export
+# carries an empty placeholder and the guest ends up with no loopback entry at
+# all: resolving "localhost" falls through to musl built-ins, which answer ::1
+# first. /etc/resolv.conf is a placeholder for the same reason but udhcpc
+# rewrites it during startup.
+cat > "$root/etc/hosts" <<HOSTS
+127.0.0.1	localhost localhost.localdomain
+::1	localhost ip6-localhost ip6-loopback
+HOSTS
+
 # docker export leaves runtime placeholders in /dev (a regular-file console
 # would swallow all guest output) and node/npm scratch in /tmp (init mounts a
 # tmpfs over it, so the content is pure initramfs bloat). Rebuild both fresh.

--- a/runtime-assets/microvm/alpine/build-bundle.sh
+++ b/runtime-assets/microvm/alpine/build-bundle.sh
@@ -158,6 +158,18 @@ set -eu
 
 echo 'eval "$(direnv hook bash)"' >> /home/agent/.bashrc
 
+# Package-manager download caches are build-time only. The Docker image keeps
+# them out of its layers with BuildKit cache mounts; here they would be baked
+# into the rootfs, and every rootfs byte costs a guest RAM byte because the
+# initramfs is unpacked into a ramfs that is never reclaimed.
+rm -rf \
+    /home/agent/.npm \
+    /home/agent/.cache/pip \
+    /home/agent/.cache/uv \
+    /home/agent/.cache/go-build \
+    /root/.npm \
+    /root/.cache
+
 rm -f /tmp/enclave-install-tool.sh /tmp/enclave-provision-rootfs.sh
 PHASE2
 chmod 0755 "$root/tmp/enclave-provision-rootfs.sh"
@@ -176,7 +188,7 @@ fi
 # shellcheck disable=SC2016 # expanded by the child shell, not while assigning here.
 phase3_script='
 set -eu
-apk add --no-cache cpio kmod tar >/dev/null
+apk add --no-cache cpio kmod tar zstd >/dev/null
 
 root=/tmp/rootfs
 mkdir -p "$root"
@@ -210,9 +222,38 @@ kernel_version=$(find "$root/lib/modules" -mindepth 1 -maxdepth 1 -type d | sed 
 if [ -n "$kernel_version" ]; then
     depmod -a -b "$root" "$kernel_version"
 fi
-rm -f "$root"/boot/vmlinuz-*
+# Nothing in the guest reads /boot: it boots the kernel the host hands to QEMU,
+# so the Alpine kernel image, its initramfs, System.map and config would only
+# occupy guest RAM.
+rm -rf "$root/boot"
+mkdir -m 755 "$root/boot"
 
-( cd "$root" && find . -print | cpio -o -H newc --quiet ) > /out/initramfs.cpio
+# Compress the image: the kernel holds the initrd and the fully unpacked ramfs
+# in memory at the same time, so an uncompressed archive costs its own size
+# twice at boot. zstd is both smaller and faster to unpack than gzip here.
+initramfs=/out/initramfs.cpio.zst
+( cd "$root" && find . -print | cpio -o -H newc --quiet ) | zstd -q -f -T0 -9 -o "$initramfs"
+zstd -q -t "$initramfs"
+uncompressed=$(zstd -q -d -c "$initramfs" | wc -c)
+if [ "$uncompressed" -le 0 ]; then
+    echo "empty guest initramfs" >&2
+    exit 1
+fi
+
+# unpack_to_rootfs() only takes an appended plain cpio segment - the host-side
+# run overlay - when it starts on a 4-byte boundary, so pad the compressed
+# image out to one. The kernel skips the padding bytes before the segment.
+compressed=$(wc -c < "$initramfs")
+pad=$(( (4 - compressed % 4) % 4 ))
+if [ "$pad" -gt 0 ]; then
+    dd if=/dev/zero bs=1 count="$pad" >> "$initramfs" 2>/dev/null
+    compressed=$(wc -c < "$initramfs")
+fi
+
+# The host sizes guest memory from the unpacked size: the initramfs becomes the
+# rootfs, a ramfs the guest can never reclaim.
+printf "{\n  \"uncompressedBytes\": %s,\n  \"compressedBytes\": %s,\n  \"compression\": \"zstd\"\n}\n" \
+    "$uncompressed" "$compressed" > /out/enclave-vm-initramfs.json
 '
 docker export "$build_cid" | docker run --rm -i --platform linux/amd64 \
     -v "$output_dir:/out" \


### PR DESCRIPTION

#### What it does

Fixes #75.

Three defects kept `--backend qemu` sessions from working with the bundled tools.

- **Bundles too large to boot.** The guest has no disk: the initramfs is unpacked
  into a ramfs that becomes the rootfs, and during unpacking the kernel holds both
  the image and its contents. opencode's 1.4 GB image did not fit the fixed
  4096 MiB guest and panicked without an init. The builder now strips build-time
  caches (npm, pip, uv) and `/boot`, compresses the image with zstd, and records
  packed/unpacked sizes so the host derives guest memory from the actual bundle
  (never below `qemuMinMemoryMiB`). An undersized bundle is rejected on the host
  instead of dying inside the kernel. The compressed image is padded to a 4-byte
  boundary so the kernel still recognizes the per-run overlay archive appended to it.
- **Console reported 0x0.** The emulated serial console carries no window size, so
  codex and opencode rendered one column wide and claude and pi fell back to a fixed
  80x24 box. The generated run script now seeds the console from the host terminal.
- **opencode's SQLite store failed on 9p.** `opencode.db` runs in WAL mode inside the
  config store, and WAL shared-memory files need mmap semantics there; every query
  failed and the TUI painted an empty frame. opencode now declares
  `qemuStoreCacheMmap`, as codex already did. The bundle also gets a populated
  `/etc/hosts` — Docker bind-mounts it into the provisioning container, so the export
  left an empty placeholder and the guest answered `::1` for `localhost` first.

#### How to test

Requires Docker (bundle build) and `qemu-system-x86_64`. Resize your terminal to
something clearly wider than 80 columns first.

1. `enclave --backend qemu --tool opencode` — the bundle builds, the guest boots, and
   the TUI comes up filling the terminal with no `Failed query: PRAGMA wal_checkpoint`
   errors. Send a prompt, exit, restart: the session history is still there.
2. Same for `--tool codex`, `--tool claude`, `--tool pi` — each TUI uses the full
   terminal width, not one column and not 80x24.
3. In a guest shell: `stty size` matches your host terminal, and
   `getent hosts localhost` answers `127.0.0.1`.

#### Follow-ups

The console size is applied once at startup. Resizing the host terminal mid-session
does not reach the guest, because the console is not a controlling terminal there and
no `SIGWINCH` is delivered.

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).