### PR TITLE
fix: resolve host.docker.internal to IPv4 for bridge ports

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,7 +157,7 @@ The restricted network request flow has a separate
 - [`runtime-assets/gateway-allowlists/`](../runtime-assets/gateway-allowlists/) holds base DNS allowlists and domain fragments baked into the image.
 - [`runtime-assets/build-scripts/`](../runtime-assets/build-scripts/) holds Docker build composition scripts (feature selection/install, template aggregation, agent tool helper setup).
 - [`runtime-assets/auth-reconcile.sh`](../runtime-assets/auth-reconcile.sh) holds shared shell logic used by the entrypoint and helper containers to reconcile shared auth files.
-- [`runtime-assets/net.sh`](../runtime-assets/net.sh) holds shared entrypoint network helpers (local resolver and loopback proxy setup).
+- [`runtime-assets/net.sh`](../runtime-assets/net.sh) holds shared entrypoint network helpers (local resolver, Docker host gateway resolution, and loopback proxy setup).
 - [`runtime-assets/microvm/alpine/`](../runtime-assets/microvm/alpine/) holds the experimental QEMU Alpine bundle init and builder.
 - [`extensions/tools/<tool>/templates/`](../extensions/tools/) holds per-tool settings templates baked into the image during build.
 - [`docs/`](../docs/) is included in the runtime build context so the image can install agent-facing help under `/usr/share/doc/enclave/`. [`docs/assets/`](../docs/assets/) is excluded in [`.dockerignore`](../.dockerignore); it holds only `README.md` branding, and keeping it out spares users an image rebuild whenever the logo changes.

--- a/gateway-entrypoint.sh
+++ b/gateway-entrypoint.sh
@@ -326,7 +326,12 @@ setup_ide_bridge() {
         return
     fi
 
-    ide_host_ip=$(awk '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ && /host\.docker\.internal/ {print $1; exit}' /etc/hosts)
+    ide_host_ip=$(awk '{ sub(/#.*/, "") }
+        $1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ {
+            for (i = 2; i <= NF; i++) {
+                if ($i == "host.docker.internal") { print $1; exit }
+            }
+        }' /etc/hosts)
     if [ -z "$ide_host_ip" ]; then
         ide_host_ip=$(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1; exit}')
     fi

--- a/gateway-entrypoint.sh
+++ b/gateway-entrypoint.sh
@@ -326,15 +326,12 @@ setup_ide_bridge() {
         return
     fi
 
-    ide_host_ip=$(awk '{ sub(/#.*/, "") }
-        $1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ {
-            for (i = 2; i <= NF; i++) {
-                if ($i == "host.docker.internal") { print $1; exit }
-            }
-        }' /etc/hosts)
-    if [ -z "$ide_host_ip" ]; then
-        ide_host_ip=$(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1; exit}')
+    if ! command -v enclave_resolve_docker_host_ipv4 >/dev/null 2>&1; then
+        log "IDE bridge: network helper unavailable; disabled"
+        return
     fi
+
+    ide_host_ip=$(enclave_resolve_docker_host_ipv4 || true)
     if [ -z "$ide_host_ip" ]; then
         log "IDE bridge: cannot resolve host.docker.internal; disabled"
         return

--- a/gateway-entrypoint.sh
+++ b/gateway-entrypoint.sh
@@ -326,10 +326,6 @@ setup_ide_bridge() {
         return
     fi
 
-    # Only IPv4: these rules go into iptables (not ip6tables), and on Docker
-    # Desktop `getent hosts` returns the IPv6 entry for host.docker.internal,
-    # which iptables rejects as a bad address. Take the first address only --
-    # getent prints one line per address.
     ide_host_ip=$(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1; exit}')
     if [ -z "$ide_host_ip" ]; then
         ide_host_ip=$(awk '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ && /host\.docker\.internal/ {print $1; exit}' /etc/hosts)

--- a/gateway-entrypoint.sh
+++ b/gateway-entrypoint.sh
@@ -326,9 +326,13 @@ setup_ide_bridge() {
         return
     fi
 
-    ide_host_ip=$(getent hosts host.docker.internal 2>/dev/null | awk '{print $1}')
+    # Only IPv4: these rules go into iptables (not ip6tables), and on Docker
+    # Desktop `getent hosts` returns the IPv6 entry for host.docker.internal,
+    # which iptables rejects as a bad address. Take the first address only --
+    # getent prints one line per address.
+    ide_host_ip=$(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1; exit}')
     if [ -z "$ide_host_ip" ]; then
-        ide_host_ip=$(awk '/host\.docker\.internal/ {print $1; exit}' /etc/hosts)
+        ide_host_ip=$(awk '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ && /host\.docker\.internal/ {print $1; exit}' /etc/hosts)
     fi
     if [ -z "$ide_host_ip" ]; then
         log "IDE bridge: cannot resolve host.docker.internal; disabled"

--- a/gateway-entrypoint.sh
+++ b/gateway-entrypoint.sh
@@ -326,9 +326,9 @@ setup_ide_bridge() {
         return
     fi
 
-    ide_host_ip=$(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1; exit}')
+    ide_host_ip=$(awk '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ && /host\.docker\.internal/ {print $1; exit}' /etc/hosts)
     if [ -z "$ide_host_ip" ]; then
-        ide_host_ip=$(awk '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ && /host\.docker\.internal/ {print $1; exit}' /etc/hosts)
+        ide_host_ip=$(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1; exit}')
     fi
     if [ -z "$ide_host_ip" ]; then
         log "IDE bridge: cannot resolve host.docker.internal; disabled"

--- a/internal/gateway/net_asset_test.go
+++ b/internal/gateway/net_asset_test.go
@@ -1,0 +1,121 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package gateway
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolveDockerHostIPv4 sources the shipped net.sh and runs the helper against
+// a fixture hosts file. getent is stubbed so the DNS fallback is deterministic.
+func resolveDockerHostIPv4(t *testing.T, hostsContent, getentOutput string) (string, bool) {
+	t.Helper()
+
+	dir := t.TempDir()
+	hostsFile := filepath.Join(dir, "hosts")
+	if err := os.WriteFile(hostsFile, []byte(hostsContent), 0o644); err != nil {
+		t.Fatalf("write hosts fixture: %v", err)
+	}
+
+	stubDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(stubDir, 0o755); err != nil {
+		t.Fatalf("create stub dir: %v", err)
+	}
+	stub := "#!/bin/sh\nexit 1\n"
+	if getentOutput != "" {
+		stub = "#!/bin/sh\ncat <<'STUB_EOF'\n" + getentOutput + "STUB_EOF\n"
+	}
+	if err := os.WriteFile(filepath.Join(stubDir, "getent"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("write getent stub: %v", err)
+	}
+
+	netLib, err := filepath.Abs(filepath.Join("..", "..", "runtime-assets", "net.sh"))
+	if err != nil {
+		t.Fatalf("resolve net.sh: %v", err)
+	}
+
+	cmd := exec.Command("sh", "-c", ". \"$0\"; enclave_resolve_docker_host_ipv4", netLib)
+	cmd.Env = append(os.Environ(),
+		"ENCLAVE_HOSTS_FILE="+hostsFile,
+		"PATH="+stubDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err == nil
+}
+
+func TestResolveDockerHostIPv4FromHosts(t *testing.T) {
+	tests := []struct {
+		name  string
+		hosts string
+		want  string
+	}{
+		{
+			name:  "plain entry",
+			hosts: "127.0.0.1\tlocalhost\n192.168.65.254\thost.docker.internal\n",
+			want:  "192.168.65.254",
+		},
+		{
+			name:  "skips ipv6 entry",
+			hosts: "::1\thost.docker.internal\n192.168.65.254\thost.docker.internal\n",
+			want:  "192.168.65.254",
+		},
+		{
+			name:  "ignores suffix lookalike hostname",
+			hosts: "10.1.2.3\tbuild.host.docker.internal.example\n192.168.65.254\thost.docker.internal\n",
+			want:  "192.168.65.254",
+		},
+		{
+			name:  "ignores commented entry",
+			hosts: "#192.0.2.9 host.docker.internal\n192.168.65.254\thost.docker.internal\n",
+			want:  "192.168.65.254",
+		},
+		{
+			name:  "matches alias beyond the first hostname",
+			hosts: "192.168.65.254\tgateway.docker.internal host.docker.internal\n",
+			want:  "192.168.65.254",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := resolveDockerHostIPv4(t, tc.hosts, "")
+			if !ok {
+				t.Fatalf("helper failed, output %q", got)
+			}
+			if got != tc.want {
+				t.Errorf("resolved %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveDockerHostIPv4FallsBackToGetent(t *testing.T) {
+	hosts := "127.0.0.1\tlocalhost\n"
+
+	got, ok := resolveDockerHostIPv4(t, hosts, "192.168.65.254 STREAM host.docker.internal\n192.168.65.254 DGRAM\n")
+	if !ok {
+		t.Fatalf("helper failed, output %q", got)
+	}
+	if got != "192.168.65.254" {
+		t.Errorf("resolved %q, want 192.168.65.254", got)
+	}
+}
+
+func TestResolveDockerHostIPv4FailsWhenUnresolvable(t *testing.T) {
+	got, ok := resolveDockerHostIPv4(t, "127.0.0.1\tlocalhost\n", "")
+	if ok {
+		t.Fatalf("expected failure, got %q", got)
+	}
+	if got != "" {
+		t.Errorf("expected no output, got %q", got)
+	}
+}

--- a/runtime-assets/net.sh
+++ b/runtime-assets/net.sh
@@ -42,6 +42,26 @@ enclave_resolve_bind_ip() {
     return 1
 }
 
+enclave_resolve_docker_host_ipv4() {
+    _enclave_hosts="${ENCLAVE_HOSTS_FILE:-/etc/hosts}"
+    _enclave_ip="$(awk '{ sub(/#.*/, "") }
+        $1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ {
+            for (i = 2; i <= NF; i++) {
+                if ($i == "host.docker.internal") { print $1; exit }
+            }
+        }' "$_enclave_hosts" 2>/dev/null)"
+    if [ -n "$_enclave_ip" ]; then
+        printf '%s\n' "$_enclave_ip"
+        return 0
+    fi
+    _enclave_ip="$(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1; exit}')"
+    if [ -n "$_enclave_ip" ]; then
+        printf '%s\n' "$_enclave_ip"
+        return 0
+    fi
+    return 1
+}
+
 enclave_start_socat_loopback_proxy() {
     _enclave_port="$1"
     _enclave_bind_ip="$2"


### PR DESCRIPTION
#### What it does

Fixes `--bridge-port` (and the automatic IDE bridge) on macOS with Docker Desktop, where forwarding silently failed and host services stayed unreachable from inside the container.

Reported in [discussion #40](https://github.com/eclipse-enclave/enclave/discussions/40#discussion-10589406).

`setup_ide_bridge` in `gateway-entrypoint.sh` resolved `host.docker.internal` with `getent hosts`. On Docker Desktop that returns the IPv6 entry (and may return multiple lines). The address was then passed to `iptables` DNAT/MASQUERADE/ACCEPT rules, which only accept IPv4, so every rule was rejected as a bad address: the DNAT for `localhost:<port>` was never installed (connection refused) and the egress ACCEPT for the host address was missing (`host.docker.internal:<port>` hangs) — which also explains why `--allow-all-network` made it work.

Resolution is now restricted to IPv4 and to a single address:

- `getent ahostsv4` instead of `getent hosts`, taking the first line only.
- The `/etc/hosts` fallback matches only IPv4 addresses.

No flags, options, or output contracts change.

#### How to test

Reproduces the setup from [discussion #40](https://github.com/eclipse-enclave/enclave/discussions/40#discussion-10589406) on macOS with Docker Desktop:

1. Serve something on the host on `0.0.0.0:8000` (the report used oMLX; `python3 -m http.server 8000 --bind 0.0.0.0` works as well).
2. Confirm the host side: `curl http://localhost:8000/health`.
3. Confirm plain Docker reaches it: `docker run --rm curlimages/curl http://host.docker.internal:8000/health`.
4. Run `enclave shell --bridge-port 8000` and inside the container:
   - `curl http://localhost:8000/health` — on `main` this fails immediately with connection refused; with the fix it answers.
   - `curl http://host.docker.internal:8000/health` — on `main` this hangs; with the fix it answers.
5. Neither call should need `--allow-all-network` anymore.
6. Gateway log check: `docker logs <container>-gateway | grep "IDE bridge"` should show `IDE bridge: port 8000 -> <IPv4>:8000` instead of `IDE bridge: failed DNAT for port 8000`.

Same for the automatic IDE bridge: with VS Code attached (a `~/.claude/ide/<port>.lock` file present), the discovered port should now be forwarded successfully.

Linux is unaffected — `getent ahostsv4` returns the same IPv4 address that `getent hosts` returned there.

#### Follow-ups

- The gateway entrypoint has no automated test coverage; this path is verified manually only. A shell-level test for the host resolution in `gateway-entrypoint.sh` would be worth adding.
- Host resolution is Docker-specific (`host.docker.internal`). Other backends (microVMs/QEMU) will need a transparent way to resolve the host address, as noted in the discussion.
- If IPv6-only hosts ever need support, the rules would need an `ip6tables` counterpart. Not required for any currently supported setup.

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
