### PR TITLE
Allow extensions to declare project-scoped cache mounts

### DIFF
--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -107,6 +107,7 @@ environment: {...}
 credentials: {...}
 providers: [...]          # enclave-native, see "Tool Extensions" below
 ports: [...]              # enclave-native; honored for tools and enabled features
+caches: [...]             # enclave-native; persistent per-project cache mounts, see below
 
 # mixin-only fields (kind: mixin)
 priority: <int, default 100>
@@ -183,6 +184,42 @@ Honored for both sandbox and mixin extensions:
   entry must match a declared `credentials.sources.<id>.env` alias; a typo is
   a load error. Entries are unioned across the tool spec and all enabled
   mixins.
+
+### Project caches (`caches`)
+
+Honored for both sandbox and mixin extensions (enclave-native, not part of the
+sbx format). Each entry asks the runtime to persist one directory of the
+container home across sessions of the same project — a `java-dev` feature can
+keep the Maven local repository, for example:
+
+```yaml
+caches:
+  - name: m2               # subdirectory under the enclave-managed project cache dir
+    target: .m2/repository # container path inside $HOME
+```
+
+At session start the declared entries join the built-in package caches (npm,
+pip, go, go-build, cargo, pnpm, uv, yarn, bun, nvm):
+`~/.cache/enclave/<tool>/<project-hash>/<name>` on the host is bind-mounted at
+`$HOME/<target>` in the container. `--no-cache` disables extension caches along
+with the built-in ones, and `enclave cleanup` removes the whole cache dir
+unless `--keep cache` is set.
+
+The host side is always enclave-managed: a spec names a cache subdirectory and
+a container target, never a host path. Load-time validation rejects a `name`
+outside the extension-name charset, a `target` that is absolute, contains
+traversal, or resolves outside the container home, and any collision with the
+built-in cache names/targets or the runtime's reserved mounts (auth stores,
+shell history). Across the tool spec and all enabled features, an identical
+`name` + `target` pair declared twice dedupes; the same name with a different
+target — or the same target under a different name — fails session start with
+an error naming both claimants.
+
+A cache mount starts empty and **shadows image-baked content** at its target:
+anything the image installed there is invisible until the cache is seeded.
+Seed it from a `feature-entrypoint.d/` script on first start, the way
+`node-dev` copies the image's default Node version into the persistent `nvm`
+cache.
 
 ### Examples
 
@@ -631,6 +668,12 @@ the same container port. `hostAllocation` selects the host port: `fixed` (the
 default) mirrors the container port, while `auto` publishes with an OS-assigned
 host port (the `-p 0:<port>` form) so concurrent sessions do not contend — the
 resolved port appears in the printed `openUrl` and in `enclave ps`.
+
+### Declared caches
+
+A feature can declare top-level `caches` exactly like a tool (see
+[Project caches](#project-caches-caches)). Entries apply only to sessions that
+enable the feature.
 
 ### Available Features
 

--- a/docs/extensions/adding-a-tool.md
+++ b/docs/extensions/adding-a-tool.md
@@ -134,6 +134,10 @@ as `host:port`). Notes:
 - `providers[].oauthPorts` is a separate mechanism for OAuth loopback callbacks
   and is unaffected.
 
+A tool can also declare top-level `caches` to persist directories of the
+container home (package caches, model downloads, ...) per project; see
+[Project caches](README.md#project-caches-caches).
+
 ## 5) Add a settings template
 - Create `extensions/tools/<tool>/templates/<filename>`.
 - It is copied into the image as `/usr/local/share/enclave/templates/<tool>-<filename>`.

--- a/docs/extensions/installing.md
+++ b/docs/extensions/installing.md
@@ -88,8 +88,9 @@ this is a capability summary, not a code audit), how many `commands.install`
 steps run as root (a step with no `user` field defaults to root, independently
 of the top-level `needsRoot`), whether it ships a `check-update.sh` that enclave
 runs in a container on each automatic update check, widens the network allowlist
-or denies domains, publishes a container port on the host, declares credentials
-and where they're released as HTTP headers, whether it flips on the
+or denies domains, publishes a container port on the host, declares persistent
+per-project cache directories mounted into the container home, declares
+credentials and where they're released as HTTP headers, whether it flips on the
 approval-bypass flag (`sandbox.yoloFlag`, active by default once declared) or
 appends its own argv to the agent for `--continue`/`--resume`
 (`sandbox.continueArgs`/`resumeArgs`, which can carry the same flag), launches

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -45,7 +45,7 @@ Per-project data is stored on the host and reused across sessions:
 
 | Data | Location |
 |------|----------|
-| Package caches | `~/.cache/enclave/<tool>/<project-hash>/` |
+| Package caches | `~/.cache/enclave/<tool>/<project-hash>/` (built-in package caches plus [extension-declared caches](extensions/README.md#project-caches-caches)) |
 | Shell history | `~/.local/state/enclave/projects/<project-hash>/<tool>/history/` |
 | Agent memory | `~/.local/state/enclave/projects/<project-hash>/<tool>/memory/` (Claude) |
 | Config/env/auth stores | Host directories under `~/.local/state/enclave/` (bind-mounted; no Docker volumes) |

--- a/internal/config/caches.go
+++ b/internal/config/caches.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"fmt"
+
+	"enclave/internal/model"
+)
+
+// reservedCacheTargets maps each container-home-relative path the runtime
+// already claims to a label naming its owner, so a cache colliding with one is
+// rejected with a message that says what it collides with. Besides the
+// built-in caches these are the auth-store mounts and the shell-history mount
+// (see runtime.addHistoryMounts).
+func reservedCacheTargets() map[string]string {
+	reserved := map[string]string{
+		model.ContainerAuthDir:        "the auth store",
+		model.ContainerFeatureAuthDir: "the feature auth store",
+		model.ContainerHistoryDir:     "the shell history store",
+	}
+	for _, cache := range model.BuiltinProjectCaches {
+		reserved[cache.Target] = fmt.Sprintf("the built-in %q cache", cache.Name)
+	}
+	return reserved
+}
+
+// validateAndNormalizeCaches checks a spec's declared cache mounts. Each name
+// becomes a host directory under the enclave-managed project cache dir, so it
+// is held to the extension-name charset; each target is a container path that
+// must stay inside the container home. Collisions with built-in cache names
+// and reserved targets are load errors. Within the list, a repeated name with
+// the same target dedupes, while a name or target redeclared with a different
+// counterpart is an error. Cross-extension collisions can only be checked at
+// session start, where the tool spec and the enabled features meet.
+func validateAndNormalizeCaches(caches []model.CacheConfig) ([]model.CacheConfig, error) {
+	if len(caches) == 0 {
+		return nil, nil
+	}
+	builtinNames := map[string]struct{}{}
+	for _, cache := range model.BuiltinProjectCaches {
+		builtinNames[cache.Name] = struct{}{}
+	}
+	reservedTargets := reservedCacheTargets()
+
+	targetByName := map[string]string{}
+	nameByTarget := map[string]string{}
+	out := make([]model.CacheConfig, 0, len(caches))
+	for i, cache := range caches {
+		if cache.Name == "" {
+			return nil, fmt.Errorf("caches[%d]: name must not be empty", i)
+		}
+		if !extensionNamePattern.MatchString(cache.Name) {
+			return nil, fmt.Errorf("caches[%d]: invalid name %q: %s", i, cache.Name, ExtensionNameCharset)
+		}
+		target, err := cleanHomeRelativePath(cache.Target)
+		if err != nil {
+			return nil, fmt.Errorf("caches[%d] (%q): target: %w", i, cache.Name, err)
+		}
+		if _, ok := builtinNames[cache.Name]; ok {
+			return nil, fmt.Errorf("caches[%d]: name %q is reserved by a built-in cache", i, cache.Name)
+		}
+		if owner, ok := reservedTargets[target]; ok {
+			return nil, fmt.Errorf("caches[%d] (%q): target %q is reserved by %s", i, cache.Name, target, owner)
+		}
+		if seen, ok := targetByName[cache.Name]; ok {
+			if seen == target {
+				continue
+			}
+			return nil, fmt.Errorf("caches[%d]: name %q declared twice with different targets (%q and %q)", i, cache.Name, seen, target)
+		}
+		if seen, ok := nameByTarget[target]; ok {
+			return nil, fmt.Errorf("caches[%d]: target %q declared twice (as %q and %q)", i, target, seen, cache.Name)
+		}
+		targetByName[cache.Name] = target
+		nameByTarget[target] = cache.Name
+		out = append(out, model.CacheConfig{Name: cache.Name, Target: target})
+	}
+	return out, nil
+}

--- a/internal/config/caches_test.go
+++ b/internal/config/caches_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/model"
+)
+
+// loadFeatureWithCaches writes a mixin spec declaring cachesYAML (the caches:
+// block body) and loads it as a feature extension.
+func loadFeatureWithCaches(t *testing.T, cachesYAML string) (model.Extension, error) {
+	t.Helper()
+	root := t.TempDir()
+	spec := "schemaVersion: \"1\"\nkind: mixin\nname: java-dev\ncaches:\n" + cachesYAML
+	writeTestFile(t, filepath.Join(root, "features", "java-dev", SpecFilename), spec)
+	return LoadFeatureExtension(model.Paths{FeaturesDir: filepath.Join(root, "features")}, "java-dev")
+}
+
+func TestSpecCachesLoadIntoExtension(t *testing.T) {
+	ext, err := loadFeatureWithCaches(t, "  - name: m2\n    target: .m2//repository/\n")
+	if err != nil {
+		t.Fatalf("LoadFeatureExtension: %v", err)
+	}
+	want := []model.CacheConfig{{Name: "m2", Target: ".m2/repository"}}
+	if len(ext.Caches) != 1 || ext.Caches[0] != want[0] {
+		t.Fatalf("Caches = %v, want %v (target cleaned)", ext.Caches, want)
+	}
+}
+
+func TestSpecCachesLoadIntoProfile(t *testing.T) {
+	root := t.TempDir()
+	spec := "schemaVersion: \"1\"\nkind: sandbox\nname: demo\ncaches:\n  - name: demo-cache\n    target: .cache/demo\n"
+	writeTestFile(t, filepath.Join(root, "tools", "demo", SpecFilename), spec)
+
+	profile, err := LoadProfile(model.Paths{ToolsDir: filepath.Join(root, "tools")}, "demo")
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
+	want := model.CacheConfig{Name: "demo-cache", Target: ".cache/demo"}
+	if len(profile.Caches) != 1 || profile.Caches[0] != want {
+		t.Fatalf("Caches = %v, want %v", profile.Caches, want)
+	}
+}
+
+func TestSpecCachesDedupeIdenticalEntries(t *testing.T) {
+	ext, err := loadFeatureWithCaches(t,
+		"  - name: m2\n    target: .m2/repository\n  - name: m2\n    target: .m2/repository\n")
+	if err != nil {
+		t.Fatalf("LoadFeatureExtension: %v", err)
+	}
+	if len(ext.Caches) != 1 {
+		t.Fatalf("Caches = %v, want the identical entries deduped", ext.Caches)
+	}
+}
+
+func TestSpecCachesRejectInvalidEntries(t *testing.T) {
+	cases := []struct {
+		name    string
+		caches  string
+		wantErr string
+	}{
+		{"empty name", "  - target: .m2\n", "name must not be empty"},
+		{"invalid name charset", "  - name: ../m2\n    target: .m2\n", "invalid name"},
+		{"absolute target", "  - name: m2\n    target: /opt/m2\n", "must be relative"},
+		{"traversal target", "  - name: m2\n    target: ../outside\n", "traversal"},
+		{"empty target", "  - name: m2\n    target: \"\"\n", "path is empty"},
+		{"dot target", "  - name: m2\n    target: .\n", "current directory"},
+		{"reserved built-in name", "  - name: npm\n    target: .m2\n", "reserved by a built-in cache"},
+		{"reserved built-in target", "  - name: m2\n    target: .cache/pip\n", "reserved by the built-in"},
+		{"reserved auth target", "  - name: m2\n    target: " + model.ContainerAuthDir + "\n", "reserved by the auth store"},
+		{"reserved history target", "  - name: m2\n    target: " + model.ContainerHistoryDir + "\n", "reserved by the shell history store"},
+		{"same name different target", "  - name: m2\n    target: .m2\n  - name: m2\n    target: .m2/repository\n", "declared twice with different targets"},
+		{"same target different name", "  - name: m2\n    target: .m2\n  - name: maven\n    target: .m2\n", "declared twice"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadFeatureWithCaches(t, tc.caches)
+			if err == nil {
+				t.Fatalf("caches %q loaded, want error containing %q", tc.caches, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/extension.go
+++ b/internal/config/extension.go
@@ -418,5 +418,10 @@ func validateAndNormalizeExtension(ext *model.Extension, manifestPath string) er
 	if err := normalizePortConfigs(ext.Ports, ext.Name); err != nil {
 		return fmt.Errorf("%s: %w", manifestPath, err)
 	}
+	caches, err := validateAndNormalizeCaches(ext.Caches)
+	if err != nil {
+		return fmt.Errorf("%s: %w", manifestPath, err)
+	}
+	ext.Caches = caches
 	return nil
 }

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -76,6 +76,11 @@ func validateAndNormalizeProfile(profile *model.Profile) error {
 	if err := validateAndNormalizeMemoryDir(profile); err != nil {
 		return err
 	}
+	caches, err := validateAndNormalizeCaches(profile.Caches)
+	if err != nil {
+		return err
+	}
+	profile.Caches = caches
 	return validateAndNormalizeProviderSecurestorage(profile.Providers)
 }
 
@@ -84,7 +89,7 @@ func validateAndNormalizeProfile(profile *model.Profile) error {
 // concrete location (not "."). The cleaned value is written back to the profile.
 func validateAndNormalizeMemoryDir(profile *model.Profile) error {
 	if profile.MemoryDir != "" {
-		cleaned, err := cleanMemoryPath(profile.MemoryDir)
+		cleaned, err := cleanHomeRelativePath(profile.MemoryDir)
 		if err != nil {
 			return fmt.Errorf("memory_dir: %w", err)
 		}
@@ -138,7 +143,10 @@ func containerProfilePath(value string) string {
 	return path.Join(model.ContainerHome, value)
 }
 
-func cleanMemoryPath(path string) (string, error) {
+// cleanHomeRelativePath validates a container path that must stay inside the
+// container home: relative, traversal-free, and resolving to a concrete
+// location (not "."). It returns the cleaned value.
+func cleanHomeRelativePath(path string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("path is empty")
 	}

--- a/internal/config/spec.go
+++ b/internal/config/spec.go
@@ -42,6 +42,7 @@ type specDocument struct {
 	Credentials  *specCredentials `json:"credentials,omitempty"`
 	Providers    []specProvider   `json:"providers,omitempty"`
 	Ports        []specPort       `json:"ports,omitempty"`
+	Caches       []specCache      `json:"caches,omitempty"`
 
 	// Build-selection metadata. Priority/aptPackages/needsRoot/failOnInstallError
 	// and defaultEnabled are mixin-only (kind: mixin); defaultIncluded is
@@ -181,6 +182,15 @@ type specOAuthPort struct {
 	Port                            string `json:"port"`
 	AutoHintWhenNoSession           *bool  `json:"autoHintWhenNoSession,omitempty"`
 	RequireMappingWhenNoCredentials *bool  `json:"requireMappingWhenNoCredentials,omitempty"`
+}
+
+// specCache is enclave-native: it declares one persistent per-project cache
+// mount (see model.CacheConfig). Name selects the enclave-managed host cache
+// subdirectory; Target is the container path under the container home. A spec
+// can never name a host path.
+type specCache struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
 }
 
 type specPort struct {

--- a/internal/config/spec_map.go
+++ b/internal/config/spec_map.go
@@ -302,6 +302,18 @@ func buildPorts(doc specDocument) []model.PortConfig {
 	return out
 }
 
+// buildCaches maps specCache entries onto model.CacheConfig.
+func buildCaches(doc specDocument) []model.CacheConfig {
+	if len(doc.Caches) == 0 {
+		return nil
+	}
+	out := make([]model.CacheConfig, 0, len(doc.Caches))
+	for _, c := range doc.Caches {
+		out = append(out, model.CacheConfig{Name: c.Name, Target: c.Target})
+	}
+	return out
+}
+
 // specToProfile projects a sandbox (kind: sandbox) specDocument onto the
 // runtime model.Profile used by the existing run path.
 func specToProfile(doc specDocument) model.Profile {
@@ -310,6 +322,7 @@ func specToProfile(doc specDocument) model.Profile {
 		Providers: buildProviders(doc),
 		Secrets:   buildSecrets(doc),
 		Ports:     buildPorts(doc),
+		Caches:    buildCaches(doc),
 	}
 	if doc.Network != nil {
 		p.AllowedDomains = doc.Network.AllowedDomains
@@ -370,6 +383,7 @@ func specToExtension(doc specDocument) (model.Extension, extensionManifestState)
 		AuthFiles:   doc.AuthFiles,
 		Secrets:     buildSecrets(doc),
 		Ports:       buildPorts(doc),
+		Caches:      buildCaches(doc),
 	}
 	if doc.Network != nil {
 		ext.AllowedDomains = doc.Network.AllowedDomains

--- a/internal/config/spec_summary.go
+++ b/internal/config/spec_summary.go
@@ -38,6 +38,13 @@ type SpecPortSummary struct {
 	Publish   bool
 }
 
+// SpecCacheSummary describes one caches[] entry: the enclave-managed host
+// cache subdirectory and the container-home-relative path it is mounted at.
+type SpecCacheSummary struct {
+	Name   string
+	Target string
+}
+
 // SpecCredentialSource describes one credentials.sources entry: which env
 // aliases it fills, which host file (if any) it can also be read from, and —
 // the most consequential grant in the schema — whether it is released as an
@@ -100,6 +107,7 @@ type SpecSummary struct {
 	AllowedDomains        []string
 	DeniedDomains         []string
 	Ports                 []SpecPortSummary
+	Caches                []SpecCacheSummary
 	CredentialEnv         []string
 	CredentialSources     []SpecCredentialSource
 	ProxyManaged          []string
@@ -204,6 +212,12 @@ func summarizeSpecDocument(doc specDocument) SpecSummary {
 	}
 	for _, port := range doc.Ports {
 		summary.Ports = append(summary.Ports, SpecPortSummary{Container: port.Container, Publish: port.Publish})
+	}
+	for _, cache := range doc.Caches {
+		summary.Caches = append(summary.Caches, SpecCacheSummary{
+			Name:   strings.TrimSpace(cache.Name),
+			Target: strings.TrimSpace(cache.Target),
+		})
 	}
 	for _, p := range doc.Providers {
 		ps := SpecProviderSummary{

--- a/internal/config/spec_summary_test.go
+++ b/internal/config/spec_summary_test.go
@@ -89,6 +89,9 @@ providers:
 ports:
   - container: 8080
     publish: true
+caches:
+  - name: m2
+    target: .m2/repository
 `
 
 func TestSummarizeSpecDir(t *testing.T) {
@@ -129,6 +132,9 @@ func TestSummarizeSpecDir(t *testing.T) {
 	}
 	if len(summary.CredentialEnv) != 1 || summary.CredentialEnv[0] != "ACME_TOKEN" {
 		t.Errorf("CredentialEnv = %v", summary.CredentialEnv)
+	}
+	if len(summary.Caches) != 1 || summary.Caches[0] != (SpecCacheSummary{Name: "m2", Target: ".m2/repository"}) {
+		t.Errorf("Caches = %v, want the enclave-managed name with its container target", summary.Caches)
 	}
 	if summary.DefaultEnabled == nil || *summary.DefaultEnabled {
 		t.Errorf("DefaultEnabled = %v, want explicit false", summary.DefaultEnabled)

--- a/internal/extinstall/capabilities.go
+++ b/internal/extinstall/capabilities.go
@@ -321,6 +321,13 @@ func describeProvider(p config.SpecProviderSummary) string {
 	return strings.Join(parts, " ")
 }
 
+// describeCache renders a caches[] entry as its host-managed name and the
+// container path it persists. The host side is always enclave-managed, so the
+// summary reports where in the container home the data survives sessions.
+func describeCache(c config.SpecCacheSummary) string {
+	return c.Name + " -> $HOME/" + c.Target
+}
+
 func describeCredentialSource(c config.SpecCredentialSource) string {
 	parts := []string{c.ID}
 	if len(c.Env) > 0 {

--- a/internal/extinstall/capabilities_diff.go
+++ b/internal/extinstall/capabilities_diff.go
@@ -49,6 +49,9 @@ func diffCapabilities(before capabilities, after capabilities) []string {
 	changes = append(changes, diffList("allowlist directive", before.AllowlistDirectives, after.AllowlistDirectives)...)
 	changes = append(changes, diffList("denied domain", before.Spec.DeniedDomains, after.Spec.DeniedDomains)...)
 	changes = append(changes, diffList("port", before.allPorts(), after.allPorts())...)
+	changes = append(changes, diffList("project cache",
+		mapDescribe(before.Spec.Caches, describeCache),
+		mapDescribe(after.Spec.Caches, describeCache))...)
 	changes = append(changes, diffList("credential", before.Spec.CredentialEnv, after.Spec.CredentialEnv)...)
 	changes = append(changes, diffList("credential grant",
 		mapDescribe(before.Spec.CredentialSources, describeCredentialSource),

--- a/internal/extinstall/capabilities_render.go
+++ b/internal/extinstall/capabilities_render.go
@@ -68,6 +68,11 @@ func (c capabilities) render(w io.Writer, style Style, source string) {
 	row("allowlist directives", strings.Join(c.AllowlistDirectives, ", "))
 	row("denied domains", strings.Join(c.Spec.DeniedDomains, ", "))
 	row("ports", strings.Join(c.allPorts(), ", "))
+	caches := strings.Join(mapDescribe(c.Spec.Caches, describeCache), ", ")
+	if caches != "" {
+		caches += " (persisted per project on the host)"
+	}
+	row("project caches", caches)
 	envAliases := strings.Join(c.Spec.CredentialEnv, ", ")
 	if envAliases != "" {
 		envAliases += " (env alias)"

--- a/internal/extinstall/capabilities_test.go
+++ b/internal/extinstall/capabilities_test.go
@@ -658,6 +658,9 @@ func capabilityFieldCases() map[string]capabilityFieldCase {
 		"Spec.DeniedDomains":      {func(c *capabilities) { c.Spec.DeniedDomains = []string{"deny.example"} }, "deny.example", "denied domain deny.example"},
 		"Spec.Ports": {func(c *capabilities) { c.Spec.Ports = []config.SpecPortSummary{{Container: 12345, Publish: true}} },
 			"12345 (published on the host)", "port 12345 (published on the host)"},
+		"Spec.Caches": {func(c *capabilities) {
+			c.Spec.Caches = []config.SpecCacheSummary{{Name: "m2", Target: ".m2/repository"}}
+		}, "m2 -> $HOME/.m2/repository", "project cache m2 -> $HOME/.m2/repository"},
 		"Spec.ContinueArgs": {func(c *capabilities) { c.Spec.ContinueArgs = "resume --last" }, "resume --last", "continue args"},
 		"Spec.ResumeArgs":   {func(c *capabilities) { c.Spec.ResumeArgs = "resume" }, "resume", "resume args"},
 		"Spec.PostStartOpenIDE": {func(c *capabilities) { c.Spec.PostStartOpenIDE = "theia" },

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -218,6 +218,7 @@ type Profile struct {
 	QEMUMinMemoryMiB    int                     `json:"qemu_min_memory_mib,omitempty"`
 	QEMUStoreCacheMmap  bool                    `json:"qemu_store_cache_mmap,omitempty"`
 	Ports               []PortConfig            `json:"ports,omitempty"`
+	Caches              []CacheConfig           `json:"caches,omitempty"`
 	Providers           []ProviderConfig        `json:"providers"`
 	Secrets             map[string]SecretConfig `json:"secrets,omitempty"`
 	HostConfigDir       string                  `json:"host_config_dir"`
@@ -240,6 +241,33 @@ type Profile struct {
 	// aliases listed here, only those aliases carry the placeholder; the rest
 	// receive the raw value. Internal-only, like AllowedDomains/EnvVariables.
 	ProxyManaged []string `json:"proxyManaged,omitempty"`
+}
+
+// CacheConfig declares one persistent per-project cache directory: Name is the
+// subdirectory under the enclave-managed host project cache dir, Target the
+// container path it is bind-mounted at, relative to the container home. The
+// host side is always enclave-managed — a spec names a cache subdirectory and
+// a container target, never a host path.
+type CacheConfig struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+}
+
+// BuiltinProjectCaches are the package caches every session bind-mounts from
+// the enclave-managed host project cache dir into the container home (unless
+// --no-cache). Extension-declared caches may not collide with them by name or
+// target.
+var BuiltinProjectCaches = []CacheConfig{
+	{Name: "npm", Target: ".npm"},
+	{Name: "pip", Target: ".cache/pip"},
+	{Name: "go", Target: "go/pkg/mod"},
+	{Name: "go-build", Target: ".cache/go-build"},
+	{Name: "cargo", Target: ".cargo"},
+	{Name: "pnpm", Target: ".local/share/pnpm"},
+	{Name: "uv", Target: ".cache/uv"},
+	{Name: "yarn", Target: ".cache/yarn"},
+	{Name: "bun", Target: ".bun"},
+	{Name: "nvm", Target: ".nvm/versions"},
 }
 
 // PostStartActions describes side effects to perform once the container is
@@ -412,6 +440,9 @@ type Extension struct {
 	// true are bound for sessions that enable the feature, flowing through the
 	// same resolution as a user-supplied -p.
 	Ports []PortConfig `json:"ports,omitempty"`
+	// Caches mirrors Profile.Caches for mixins: declared per-project cache
+	// mounts join the built-in list for sessions that enable the feature.
+	Caches []CacheConfig `json:"caches,omitempty"`
 }
 
 func (e Extension) IsMixin() bool   { return e.Type == ExtensionKindMixin }
@@ -471,6 +502,9 @@ const (
 	ContainerHome           = "/home/" + ContainerUser
 	ContainerAuthDir        = "." + AppName + "-auth"
 	ContainerFeatureAuthDir = "." + AppName + "-feature-auth"
+	// ContainerHistoryDir is the home-relative mount point of the persistent
+	// shell-history store (see runtime.addHistoryMounts).
+	ContainerHistoryDir = ".shell_history"
 	// UserCommandsContainerDir is the fixed, home-layout-neutral path where the
 	// host session command tree is mounted read-only inside the container.
 	UserCommandsContainerDir = "/opt/" + AppName + "/commands"

--- a/internal/runtime/cache_mounts_test.go
+++ b/internal/runtime/cache_mounts_test.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the MIT License, which is available in the project root.
+//
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"enclave/internal/backend"
+	"enclave/internal/config"
+	"enclave/internal/model"
+)
+
+func cacheTestRuntime(home string) *Runtime {
+	return &Runtime{
+		host:          model.Host{Home: home},
+		project:       model.Project{Hash: "project-hash"},
+		profile:       model.Profile{Name: "demo"},
+		containerHome: "/home/agent",
+	}
+}
+
+func findMountByTarget(mounts []backend.Mount, target string) (backend.Mount, bool) {
+	for _, m := range mounts {
+		if m.ContainerPath == target {
+			return m, true
+		}
+	}
+	return backend.Mount{}, false
+}
+
+// TestAddCacheMountsIncludesExtensionCaches covers spec-declared caches (tool
+// and mixin) joining the built-in list: each is bind-mounted from the
+// enclave-managed project cache dir to its container-home target.
+func TestAddCacheMountsIncludesExtensionCaches(t *testing.T) {
+	r := cacheTestRuntime(t.TempDir())
+	r.profile.Caches = []model.CacheConfig{{Name: "demo-cache", Target: ".cache/demo"}}
+	r.features = []model.Extension{
+		{
+			Name:   "java-dev",
+			Type:   model.ExtensionKindMixin,
+			Caches: []model.CacheConfig{{Name: "m2", Target: ".m2/repository"}},
+		},
+	}
+
+	mounts := newMountAccumulator(nil, nil)
+	if err := r.addCacheMounts(mounts); err != nil {
+		t.Fatalf("addCacheMounts: %v", err)
+	}
+
+	cacheDir := config.HostCacheToolProjectDir(r.host.Home, "demo", "project-hash")
+	for target, name := range map[string]string{
+		"/home/agent/.npm":           "npm", // built-in entries stay mounted
+		"/home/agent/.cache/demo":    "demo-cache",
+		"/home/agent/.m2/repository": "m2",
+	} {
+		mount, ok := findMountByTarget(mounts.Mounts(), target)
+		if !ok {
+			t.Fatalf("expected a cache mount at %s, got %v", target, mounts.Mounts())
+		}
+		if want := filepath.Join(cacheDir, name); mount.Source != want {
+			t.Errorf("cache %q source = %q, want %q", name, mount.Source, want)
+		}
+		if mount.ReadOnly {
+			t.Errorf("cache %q mounted read-only", name)
+		}
+	}
+}
+
+// TestAddCacheMountsSkipsExtensionCachesWithoutCache covers --no-cache
+// disabling extension-declared caches alongside the built-in ones.
+func TestAddCacheMountsSkipsExtensionCachesWithoutCache(t *testing.T) {
+	r := cacheTestRuntime(t.TempDir())
+	r.run.NoCache = true
+	r.features = []model.Extension{
+		{Name: "java-dev", Caches: []model.CacheConfig{{Name: "m2", Target: ".m2/repository"}}},
+	}
+
+	mounts := newMountAccumulator(nil, nil)
+	if err := r.addCacheMounts(mounts); err != nil {
+		t.Fatalf("addCacheMounts: %v", err)
+	}
+	if len(mounts.Mounts()) != 0 {
+		t.Fatalf("did not expect cache mounts with cache disabled, got %v", mounts.Mounts())
+	}
+}
+
+// TestProjectCachesDedupesIdenticalDeclarations covers the same name+target
+// pair declared by two features collapsing into one mount.
+func TestProjectCachesDedupesIdenticalDeclarations(t *testing.T) {
+	r := cacheTestRuntime(t.TempDir())
+	cache := model.CacheConfig{Name: "m2", Target: ".m2/repository"}
+	r.features = []model.Extension{
+		{Name: "java-dev", Caches: []model.CacheConfig{cache}},
+		{Name: "maven-tools", Caches: []model.CacheConfig{cache}},
+	}
+
+	caches, err := r.projectCaches()
+	if err != nil {
+		t.Fatalf("projectCaches: %v", err)
+	}
+	if want := len(model.BuiltinProjectCaches) + 1; len(caches) != want {
+		t.Fatalf("len(caches) = %d, want %d (identical declarations dedupe): %v", len(caches), want, caches)
+	}
+}
+
+// TestProjectCachesRejectsNameConflict covers the same cache name declared
+// with different targets by two features: the error names both claimants.
+func TestProjectCachesRejectsNameConflict(t *testing.T) {
+	r := cacheTestRuntime(t.TempDir())
+	r.features = []model.Extension{
+		{Name: "java-dev", Caches: []model.CacheConfig{{Name: "m2", Target: ".m2/repository"}}},
+		{Name: "maven-tools", Caches: []model.CacheConfig{{Name: "m2", Target: ".m2"}}},
+	}
+
+	_, err := r.projectCaches()
+	if err == nil {
+		t.Fatal("expected a name-conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "java-dev") || !strings.Contains(err.Error(), "maven-tools") {
+		t.Fatalf("err = %v, want it to name both claimants", err)
+	}
+}
+
+// TestProjectCachesRejectsTargetConflict covers two different cache names
+// claiming the same container target, which would silently shadow one mount.
+func TestProjectCachesRejectsTargetConflict(t *testing.T) {
+	r := cacheTestRuntime(t.TempDir())
+	r.profile.Caches = []model.CacheConfig{{Name: "tool-cache", Target: ".m2/repository"}}
+	r.features = []model.Extension{
+		{Name: "java-dev", Caches: []model.CacheConfig{{Name: "m2", Target: ".m2/repository"}}},
+	}
+
+	_, err := r.projectCaches()
+	if err == nil {
+		t.Fatal("expected a target-conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), ".m2/repository") {
+		t.Fatalf("err = %v, want it to name the contested target", err)
+	}
+}

--- a/internal/runtime/env_variables_test.go
+++ b/internal/runtime/env_variables_test.go
@@ -89,7 +89,9 @@ func TestAddCacheMountsConfiguresPnpmStore(t *testing.T) {
 	}
 
 	mounts := newMountAccumulator(nil, nil)
-	r.addCacheMounts(mounts)
+	if err := r.addCacheMounts(mounts); err != nil {
+		t.Fatalf("addCacheMounts: %v", err)
+	}
 
 	want := "/home/agent/.local/share/pnpm/store"
 	if !envSliceContainsKV(mounts.Env(), "PNPM_CONFIG_STORE_DIR", want) {
@@ -104,7 +106,9 @@ func TestAddCacheMountsUsesEphemeralPnpmStoreWithoutCache(t *testing.T) {
 	}
 
 	mounts := newMountAccumulator(nil, nil)
-	r.addCacheMounts(mounts)
+	if err := r.addCacheMounts(mounts); err != nil {
+		t.Fatalf("addCacheMounts: %v", err)
+	}
 
 	want := "/home/agent/.local/share/pnpm/store"
 	if !envSliceContainsKV(mounts.Env(), "PNPM_CONFIG_STORE_DIR", want) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -348,7 +348,9 @@ func (r *Runtime) prepareMounts() (*mountAccumulator, error) {
 	r.addSSHMount(mountArgs)
 	r.addImageInboxMount(mountArgs)
 	r.addSessionMonitorEnv(mountArgs)
-	r.addCacheMounts(mountArgs)
+	if err := r.addCacheMounts(mountArgs); err != nil {
+		return nil, err
+	}
 	r.addHistoryMounts(mountArgs)
 	r.addMemoryMounts(mountArgs)
 	r.addToolConfigMounts(mountArgs)
@@ -1200,42 +1202,74 @@ func (r *Runtime) addSessionMonitorEnv(mounts *mountAccumulator) {
 	mounts.AddEnv(model.EnvSessionMonitorUser, r.containerUser)
 }
 
-func (r *Runtime) addCacheMounts(mounts *mountAccumulator) {
+func (r *Runtime) addCacheMounts(mounts *mountAccumulator) error {
 	pnpmStoreDir := r.containerHome + "/.local/share/pnpm/store"
 	mounts.AddEnv("PNPM_CONFIG_STORE_DIR", pnpmStoreDir)
 
 	if r.run.NoCache {
-		return
+		return nil
+	}
+	caches, err := r.projectCaches()
+	if err != nil {
+		return err
 	}
 	cacheDir := config.HostCacheToolProjectDir(r.host.Home, r.profile.Name, r.project.Hash)
-
-	// Create all cache directories
-	cacheDirs := []string{
-		"npm", "pip",
-		"go", "go-build", "cargo", "pnpm", "uv", "yarn", "bun",
-		"nvm",
+	for _, cache := range caches {
+		hostDir := filepath.Join(cacheDir, cache.Name)
+		_ = os.MkdirAll(hostDir, 0o700)
+		mounts.AddMount(bindMount(hostDir, r.containerHome+"/"+cache.Target, false))
 	}
-	for _, dir := range cacheDirs {
-		_ = os.MkdirAll(filepath.Join(cacheDir, dir), 0o700)
-	}
+	return nil
+}
 
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "npm"), r.containerHome+"/.npm", false))
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "pip"), r.containerHome+"/.cache/pip", false))
-	// Go caches
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "go"), r.containerHome+"/go/pkg/mod", false))
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "go-build"), r.containerHome+"/.cache/go-build", false))
-	// Rust/Cargo cache
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "cargo"), r.containerHome+"/.cargo", false))
-	// pnpm store
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "pnpm"), r.containerHome+"/.local/share/pnpm", false))
-	// uv (Python) cache
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "uv"), r.containerHome+"/.cache/uv", false))
-	// Yarn cache
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "yarn"), r.containerHome+"/.cache/yarn", false))
-	// Bun cache
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "bun"), r.containerHome+"/.bun", false))
-	// nvm installed Node.js versions
-	mounts.AddMount(bindMount(filepath.Join(cacheDir, "nvm"), r.containerHome+"/.nvm/versions", false))
+// projectCaches returns the built-in package caches followed by the caches the
+// tool spec and the enabled features declare. Spec loading already validates
+// each spec in isolation (name charset, target containment, reserved
+// collisions); the cross-extension rules can only be applied here, where the
+// profile and the features meet: the same name+target pair declared twice
+// dedupes, while a name or target re-declared with a different counterpart is
+// an error naming both claimants.
+func (r *Runtime) projectCaches() ([]model.CacheConfig, error) {
+	caches := append([]model.CacheConfig(nil), model.BuiltinProjectCaches...)
+	ownerByName := map[string]string{}
+	targetByName := map[string]string{}
+	ownerByTarget := map[string]string{}
+	claim := func(owner string, cache model.CacheConfig) error {
+		if seenTarget, ok := targetByName[cache.Name]; ok {
+			if seenTarget == cache.Target {
+				return nil
+			}
+			return fmt.Errorf("cache %q: %s declares target %q but %s declares target %q",
+				cache.Name, owner, cache.Target, ownerByName[cache.Name], seenTarget)
+		}
+		if seenOwner, ok := ownerByTarget[cache.Target]; ok {
+			return fmt.Errorf("cache target %q: declared by both %s (cache %q) and %s",
+				cache.Target, owner, cache.Name, seenOwner)
+		}
+		ownerByName[cache.Name] = owner
+		targetByName[cache.Name] = cache.Target
+		ownerByTarget[cache.Target] = owner
+		caches = append(caches, cache)
+		return nil
+	}
+	for _, cache := range model.BuiltinProjectCaches {
+		ownerByName[cache.Name] = "the built-in cache list"
+		targetByName[cache.Name] = cache.Target
+		ownerByTarget[cache.Target] = "the built-in cache list"
+	}
+	for _, cache := range r.profile.Caches {
+		if err := claim(fmt.Sprintf("tool %q", r.profile.Name), cache); err != nil {
+			return nil, err
+		}
+	}
+	for _, feature := range r.features {
+		for _, cache := range feature.Caches {
+			if err := claim(fmt.Sprintf("feature %q", feature.Name), cache); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return caches, nil
 }
 
 func (r *Runtime) addHistoryMounts(mounts *mountAccumulator) {
@@ -1244,8 +1278,9 @@ func (r *Runtime) addHistoryMounts(mounts *mountAccumulator) {
 	}
 	projectDataDir := config.HostProjectHistoryDir(r.host.Home, r.project.Hash, r.profile.Name)
 	_ = os.MkdirAll(projectDataDir, 0o700)
-	mounts.AddMount(bindMount(projectDataDir, r.containerHome+"/.shell_history", false))
-	mounts.AddEnv("HISTFILE", r.containerHome+"/.shell_history/bash_history")
+	historyDir := r.containerHome + "/" + model.ContainerHistoryDir
+	mounts.AddMount(bindMount(projectDataDir, historyDir, false))
+	mounts.AddEnv("HISTFILE", historyDir+"/bash_history")
 }
 
 func (r *Runtime) addMemoryMounts(mounts *mountAccumulator) {


### PR DESCRIPTION
#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The persistent per-project package caches were hard-coded in `addCacheMounts`, so extensions had no way to persist their own directories — a `java-dev` feature, for example, re-downloads the whole Maven repository in every fresh container.

- Add a declarative `caches` field to extension specs (`kind: sandbox` and `kind: mixin`): each entry names a subdirectory under the enclave-managed project cache dir and a container target inside `$HOME` — a spec can never name a host path
- At session start, entries from the tool spec and the enabled features join the built-in list in `addCacheMounts`, respecting `--no-cache`
- Validate at load time: targets are cleaned, traversal-free, inside the container home, and must not collide with built-in cache names/targets or reserved mounts (auth stores, shell history)
- Validate across extensions at session start: identical `name`+`target` declarations dedupe; the same name with a different target — or the same target under a different name — fails with an error naming both claimants
- Surface declared caches in the capability summary and update diff shown by `enclave features|tools add`
- Document the `caches` field, including that an empty cache mount shadows image-baked content at the target (seed from `feature-entrypoint.d`, as node-dev does for nvm)

Fixes #82

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

```bash
make build && make test && make lint
```

- Declare a cache in a feature spec, e.g. in `extensions/features/devtools/spec.yaml`:
  ```yaml
  caches:
    - name: m2
      target: .m2/repository
  ```
- Start a session and verify `~/.cache/enclave/<tool>/<project-hash>/m2` exists on the host and is mounted at `~/.m2/repository` in the container; files written there survive a fresh container
- `--no-cache` starts the session without the mount
- Two features declaring the same name with different targets fail session start with an error naming both features
- `enclave features add` against an extension repo with a `caches` entry lists it in the capability summary

- [x] Verified locally: `make build`, `make test`, `make lint`, `make check-license-headers`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

Migrate the feature-specific built-in entries (nvm, uv, pip, pnpm, yarn) into their features' specs, keeping the same `name` values so existing host cache directories stay valid.

#### Breaking changes

- [ ] This PR introduces breaking changes and has been coordinated with maintainers.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the [contribution guidelines](https://github.com/eclipse-enclave/enclave/blob/main/CONTRIBUTING.md).
